### PR TITLE
Fix compilation on gcc 9 and improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ WFS_FUSE_DIR=wfs-fuse
 WFS_FILE_INJECTOR_DIR=wfs-file-injector
 SUBDIRS=$(WFSLIB_DIR) $(WFS_EXTRACT_DIR) $(WFS_FUSE_DIR) $(WFS_FILE_INJECTOR_DIR)
 CLEAN_SUBDIRS=$(addsuffix clean,$(SUBDIRS))
+PREFIX ?= /usr/local
+DESTDIR ?= /
 
 .PHONY: all clean $(SUBDIRS) $(CLEAN_SUBDIRS)
 
@@ -20,3 +22,9 @@ $(SUBDIRS):
 
 $(CLEAN_SUBDIRS):
 	$(MAKE) -C $(@:%clean=%) clean
+
+install: all
+	install -dm755 $(DESTDIR)/$(PREFIX)/lib
+	install -dm755 $(DESTDIR)/$(PREFIX)/bin
+	install -Dm644 libwfs.a $(DESTDIR)/$(PREFIX)/lib
+	install -Dm755 $(WFS_EXTRACT_DIR)/wfs-extract $(WFS_FUSE_DIR)/wfs-fuse $(WFS_FILE_INJECTOR_DIR)/wfs-file-injector $(DESTDIR)/$(PREFIX)/bin

--- a/wfs-extract/Makefile
+++ b/wfs-extract/Makefile
@@ -1,7 +1,7 @@
 LIB=-L../
 INC=-I../
-CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14
-LDFLAGS=$(LIB) -lwfs -lboost_system -lboost_filesystem -lboost_program_options -lcryptopp -lstdc++
+CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14 $(shell pkg-config --cflags libcrypto++)
+LDFLAGS=$(LIB) -lwfs -lboost_system -lboost_filesystem -lboost_program_options $(shell pkg-config --libs libcrypto++) -lstdc++
 SOURCES=main.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=wfs-extract

--- a/wfs-file-injector/Makefile
+++ b/wfs-file-injector/Makefile
@@ -1,7 +1,7 @@
 LIB=-L../
 INC=-I../
-CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14
-LDFLAGS=$(LIB) -lwfs -lboost_system -lboost_filesystem -lboost_program_options -lcryptopp -lstdc++
+CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14 $(shell pkg-config --cflags libcrypto++)
+LDFLAGS=$(LIB) -lwfs -lboost_system -lboost_filesystem -lboost_program_options $(shell pkg-config --libs libcrypto++) -lstdc++
 SOURCES=main.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=wfs-file-injector

--- a/wfs-fuse/Makefile
+++ b/wfs-fuse/Makefile
@@ -1,7 +1,7 @@
 LIB=-L../
 INC=-I../
-CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14 -D_FILE_OFFSET_BITS=64
-LDFLAGS=$(LIB) -lfuse -lwfs -lboost_system -lboost_filesystem -lboost_program_options -lcryptopp -lstdc++
+CXXFLAGS=$(INC) -c -Wall -Werror -std=c++14 -D_FILE_OFFSET_BITS=64 $(shell pkg-config --cflags fuse libcrypto++)
+LDFLAGS=$(LIB) -lwfs -lboost_system -lboost_filesystem -lboost_program_options $(shell pkg-config --libs fuse libcrypto++) -lstdc++
 SOURCES=wfs-fuse.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=wfs-fuse

--- a/wfslib/Area.cpp
+++ b/wfslib/Area.cpp
@@ -42,7 +42,7 @@ std::shared_ptr<Area> Area::LoadRootArea(const std::shared_ptr<DeviceEncryption>
 	try {
 		block = MetadataBlock::LoadBlock(device, 0, Block::BlockSize::Basic, 0);
 	}
-	catch (Block::BadHash) {
+	catch (const Block::BadHash &) {
 		block = MetadataBlock::LoadBlock(device, 0, Block::BlockSize::Regular, 0);
 	}
 	return std::make_shared<Area>(device, std::shared_ptr<Area>(), block, "", AttributesBlock {block, sizeof(MetadataBlockHeader) + offsetof(WfsHeader, root_area_attributes)});

--- a/wfslib/Wfs.cpp
+++ b/wfslib/Wfs.cpp
@@ -99,7 +99,7 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
 	try {
 		block = MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, true);
 	}
-	catch (Block::BadHash) {
+	catch (const Block::BadHash &) {
 		throw std::runtime_error("Wfs: Failed to detect sector size and sectors count");
 	}
 }


### PR DESCRIPTION
Exceptions shouldn’t be taken by value.

This also adds an `install` target so that distributions can ship it much more easily. Also uses `pkg-config` to know where to find dependencies.

Fixes #11.