### PR TITLE
Add const and non-const block modes to detect changes to blocks

### DIFF
--- a/include/wfslib/device.h
+++ b/include/wfslib/device.h
@@ -16,7 +16,7 @@ class Device {
   virtual ~Device() {}
   virtual void ReadSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) = 0;
   virtual void WriteSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) = 0;
-  virtual uint32_t SectorsCount() = 0;
-  virtual uint32_t Log2SectorSize() = 0;
-  uint32_t SectorSize() { return 1 << Log2SectorSize(); }
+  virtual uint32_t SectorsCount() const = 0;
+  virtual uint32_t Log2SectorSize() const = 0;
+  uint32_t SectorSize() const { return 1 << Log2SectorSize(); }
 };

--- a/include/wfslib/device.h
+++ b/include/wfslib/device.h
@@ -18,5 +18,6 @@ class Device {
   virtual void WriteSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) = 0;
   virtual uint32_t SectorsCount() const = 0;
   virtual uint32_t Log2SectorSize() const = 0;
+  virtual bool IsReadOnly() const = 0;
   uint32_t SectorSize() const { return 1 << Log2SectorSize(); }
 };

--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -26,13 +26,13 @@ class Directory : public WfsItem, public std::enable_shared_from_this<Directory>
             const std::shared_ptr<MetadataBlock>& block)
       : WfsItem(name, attributes), area_(area), block_(block) {}
 
-  std::shared_ptr<WfsItem> GetObject(const std::string& name);
-  std::shared_ptr<Directory> GetDirectory(const std::string& name);
-  std::shared_ptr<File> GetFile(const std::string& name);
+  std::shared_ptr<WfsItem> GetObject(const std::string& name) const;
+  std::shared_ptr<Directory> GetDirectory(const std::string& name) const;
+  std::shared_ptr<File> GetFile(const std::string& name) const;
 
-  size_t Size();
-  DirectoryItemsIterator begin();
-  DirectoryItemsIterator end();
+  size_t Size() const;
+  DirectoryItemsIterator begin() const;
+  DirectoryItemsIterator end() const;
 
   const std::shared_ptr<Area>& area() const { return area_; }
 
@@ -44,6 +44,6 @@ class Directory : public WfsItem, public std::enable_shared_from_this<Directory>
 
   std::shared_ptr<MetadataBlock> block_;
 
-  std::shared_ptr<WfsItem> Create(const std::string& name, const AttributesBlock& attributes);
-  AttributesBlock GetObjectAttributes(const std::shared_ptr<MetadataBlock>& block, const std::string& name);
+  std::shared_ptr<WfsItem> Create(const std::string& name, const AttributesBlock& attributes) const;
+  AttributesBlock GetObjectAttributes(const std::shared_ptr<MetadataBlock>& block, const std::string& name) const;
 };

--- a/include/wfslib/directory_items_iterator.h
+++ b/include/wfslib/directory_items_iterator.h
@@ -25,13 +25,14 @@ class DirectoryItemsIterator {
 
   struct NodeState {
     std::shared_ptr<MetadataBlock> block;
-    DirectoryTreeNode* node;
+    const DirectoryTreeNode* node;
     std::shared_ptr<NodeState> parent;
     size_t current_index;
     std::string path;
   };
 
-  DirectoryItemsIterator(const std::shared_ptr<Directory>& directory, const std::shared_ptr<NodeState>& node_state);
+  DirectoryItemsIterator(const std::shared_ptr<const Directory>& directory,
+                         const std::shared_ptr<NodeState>& node_state);
   DirectoryItemsIterator(const DirectoryItemsIterator& mit);
 
   DirectoryItemsIterator& operator++();
@@ -41,6 +42,6 @@ class DirectoryItemsIterator {
   std::shared_ptr<WfsItem> operator*();
 
  private:
-  std::shared_ptr<Directory> directory_;
+  std::shared_ptr<const Directory> directory_;
   std::shared_ptr<NodeState> node_state_;
 };

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -29,8 +29,8 @@ class File : public WfsItem, public std::enable_shared_from_this<File> {
   File(const std::string& name, const AttributesBlock& attributes, const std::shared_ptr<Area>& area)
       : WfsItem(name, attributes), area_(area) {}
 
-  uint32_t Size();
-  uint32_t SizeOnDisk();
+  uint32_t Size() const;
+  uint32_t SizeOnDisk() const;
   void Resize(size_t new_size);
 
   class file_device {
@@ -45,7 +45,7 @@ class File : public WfsItem, public std::enable_shared_from_this<File> {
     std::streamsize optimal_buffer_size() const;
 
    private:
-    size_t size();
+    size_t size() const;
     std::shared_ptr<File> file_;
     std::shared_ptr<DataCategoryReader> reader_;
     boost::iostreams::stream_offset pos_;

--- a/include/wfslib/file_device.h
+++ b/include/wfslib/file_device.h
@@ -21,6 +21,7 @@ class FileDevice : public Device {
   void WriteSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) override;
   uint32_t SectorsCount() const override { return sectors_count_; }
   uint32_t Log2SectorSize() const override { return log2_sector_size_; }
+  bool IsReadOnly() const override { return read_only_: }
 
  private:
   friend Wfs;

--- a/include/wfslib/file_device.h
+++ b/include/wfslib/file_device.h
@@ -21,7 +21,7 @@ class FileDevice : public Device {
   void WriteSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) override;
   uint32_t SectorsCount() const override { return sectors_count_; }
   uint32_t Log2SectorSize() const override { return log2_sector_size_; }
-  bool IsReadOnly() const override { return read_only_: }
+  bool IsReadOnly() const override { return read_only_; }
 
  private:
   friend Wfs;

--- a/include/wfslib/file_device.h
+++ b/include/wfslib/file_device.h
@@ -19,8 +19,8 @@ class FileDevice : public Device {
   FileDevice(const std::string& path, uint32_t log2_sector_size = 9 /* 512 */, bool read_only = true);
   void ReadSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) override;
   void WriteSectors(const std::span<std::byte>& data, uint32_t sector_address, uint32_t sectors_count) override;
-  uint32_t SectorsCount() override { return sectors_count_; }
-  uint32_t Log2SectorSize() override { return log2_sector_size_; }
+  uint32_t SectorsCount() const override { return sectors_count_; }
+  uint32_t Log2SectorSize() const override { return log2_sector_size_; }
 
  private:
   friend Wfs;

--- a/include/wfslib/wfs_item.h
+++ b/include/wfslib/wfs_item.h
@@ -17,20 +17,25 @@ class MetadataBlock;
 struct AttributesBlock {
   std::shared_ptr<MetadataBlock> block;
   size_t attributes_offset;
-  ::Attributes* Attributes() const;
+
+  operator bool() const { return !!block; }
+
+  ::Attributes* Attributes();
+  const ::Attributes* Attributes() const;
 };
 
 class WfsItem {
  public:
   WfsItem(const std::string& name, const AttributesBlock& block);
   virtual ~WfsItem() {}
-  const std::string& GetName() { return name_; }
-  std::string GetRealName();
-  virtual bool IsDirectory();
-  virtual bool IsFile();
-  virtual bool IsLink();
+  const std::string& GetName() const { return name_; }
+  std::string GetRealName() const;
+  virtual bool IsDirectory() const;
+  virtual bool IsFile() const;
+  virtual bool IsLink() const;
 
  protected:
+  AttributesBlock& attributes_data() { return attributes_; }
   const AttributesBlock& attributes_data() const { return attributes_; }
 
   std::string name_;

--- a/src/area.cpp
+++ b/src/area.cpp
@@ -12,23 +12,8 @@
 #include "directory.h"
 #include "metadata_block.h"
 #include "structs.h"
+#include "utils.h"
 #include "wfs.h"
-
-WfsAreaHeader* Area::Data() const {
-  if (header_block_->BlockNumber() == 0) {
-    return reinterpret_cast<WfsAreaHeader*>(&header_block_->Data()[sizeof(MetadataBlockHeader) + sizeof(WfsHeader)]);
-  } else {
-    return reinterpret_cast<WfsAreaHeader*>(&header_block_->Data()[sizeof(MetadataBlockHeader)]);
-  }
-}
-
-WfsHeader* Area::WfsData() const {
-  if (header_block_->BlockNumber() == 0) {
-    return reinterpret_cast<WfsHeader*>(&header_block_->Data()[sizeof(MetadataBlockHeader)]);
-  } else {
-    return NULL;
-  }
-}
 
 Area::Area(const std::shared_ptr<DeviceEncryption>& device,
            const std::shared_ptr<Area>& root_area,
@@ -61,7 +46,8 @@ std::shared_ptr<Directory> Area::GetDirectory(uint32_t block_number,
 }
 
 std::shared_ptr<Directory> Area::GetRootDirectory() {
-  return GetDirectory(Data()->root_directory_block_number.value(), root_directory_name_, root_directory_attributes_);
+  return GetDirectory(as_const(this)->header()->root_directory_block_number.value(), root_directory_name_,
+                      root_directory_attributes_);
 }
 
 std::shared_ptr<Area> Area::GetArea(uint32_t block_number,
@@ -73,11 +59,11 @@ std::shared_ptr<Area> Area::GetArea(uint32_t block_number,
 }
 
 std::shared_ptr<MetadataBlock> Area::GetMetadataBlock(uint32_t block_number) const {
-  return GetMetadataBlock(block_number, static_cast<Block::BlockSize>(Data()->log2_block_size.value()));
+  return GetMetadataBlock(block_number, static_cast<Block::BlockSize>(header()->log2_block_size.value()));
 }
 
 uint32_t Area::IV(uint32_t block_number) const {
-  return (Data()->iv.value() ^ (root_area_ ? root_area_.get() : this)->WfsData()->iv.value()) +
+  return (header()->iv.value() ^ (root_area_ ? as_const(root_area_.get()) : this)->wfs_header()->iv.value()) +
          (ToBasicBlockNumber(block_number) << (Block::BlockSize::Basic - device_->device()->Log2SectorSize()));
 }
 
@@ -96,19 +82,19 @@ std::shared_ptr<DataBlock> Area::GetDataBlock(uint32_t block_number,
 }
 
 uint32_t Area::ToBasicBlockNumber(uint32_t block_number) const {
-  return block_number << (Data()->log2_block_size.value() - Block::BlockSize::Basic);
+  return block_number << (header()->log2_block_size.value() - Block::BlockSize::Basic);
 }
 
 size_t Area::GetDataBlockLog2Size() const {
-  return Data()->log2_block_size.value();
+  return header()->log2_block_size.value();
 }
 
 uint32_t Area::RelativeBlockNumber(uint32_t block_number) const {
-  return (block_number - header_block_->BlockNumber()) >> (Data()->log2_block_size.value() - Block::BlockSize::Basic);
+  return (block_number - header_block_->BlockNumber()) >> (header()->log2_block_size.value() - Block::BlockSize::Basic);
 }
 
 uint32_t Area::AbsoluteBlockNumber(uint32_t block_number) const {
-  return (block_number << (Data()->log2_block_size.value() - Block::BlockSize::Basic)) + header_block_->BlockNumber();
+  return (block_number << (header()->log2_block_size.value() - Block::BlockSize::Basic)) + header_block_->BlockNumber();
 }
 
 uint32_t Area::BlockNumber() const {

--- a/src/area.cpp
+++ b/src/area.cpp
@@ -78,7 +78,7 @@ std::shared_ptr<MetadataBlock> Area::GetMetadataBlock(uint32_t block_number) con
 
 uint32_t Area::IV(uint32_t block_number) const {
   return (Data()->iv.value() ^ (root_area_ ? root_area_.get() : this)->WfsData()->iv.value()) +
-         (ToBasicBlockNumber(block_number) << (Block::BlockSize::Basic - device_->GetDevice()->Log2SectorSize()));
+         (ToBasicBlockNumber(block_number) << (Block::BlockSize::Basic - device_->device()->Log2SectorSize()));
 }
 
 std::shared_ptr<MetadataBlock> Area::GetMetadataBlock(uint32_t block_number, Block::BlockSize size) const {

--- a/src/area.h
+++ b/src/area.h
@@ -15,14 +15,11 @@
 #include "data_block.h"
 #include "free_blocks_allocator_tree.h"
 #include "metadata_block.h"
+#include "structs.h"
 #include "wfs_item.h"
 
-class MetadataBlock;
 class DeviceEncryption;
 class Directory;
-
-struct WfsAreaHeader;
-struct WfsHeader;
 
 class Area : public std::enable_shared_from_this<Area> {
  public:
@@ -78,8 +75,20 @@ class Area : public std::enable_shared_from_this<Area> {
  private:
   static constexpr uint32_t FreeBlocksAllocatorBlockNumber = 1;
 
-  WfsAreaHeader* Data() const;
-  WfsHeader* WfsData() const;
+  MetadataBlock* block() { return header_block_.get(); }
+  const MetadataBlock* block() const { return header_block_.get(); }
+
+  bool has_wfs_header() const { return BlockNumber() == 0; }
+  uint16_t wfs_header_offset() const { return sizeof(MetadataBlockHeader); }
+  uint16_t header_offset() const { return sizeof(MetadataBlockHeader) + (has_wfs_header() ? sizeof(WfsHeader) : 0); }
+
+  WfsAreaHeader* header() { return block()->GetStruct<WfsAreaHeader>(header_offset()); }
+  const WfsAreaHeader* header() const { return block()->GetStruct<WfsAreaHeader>(header_offset()); }
+
+  WfsHeader* wfs_header() { return has_wfs_header() ? block()->GetStruct<WfsHeader>(wfs_header_offset()) : NULL; }
+  const WfsHeader* wfs_header() const {
+    return has_wfs_header() ? block()->GetStruct<WfsHeader>(wfs_header_offset()) : NULL;
+  }
 
   uint32_t ToBasicBlockNumber(uint32_t block_number) const;
   uint32_t IV(uint32_t block_number) const;

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -57,3 +57,11 @@ void Block::Flush() {
 uint32_t Block::ToDeviceSector(uint32_t block_number) {
   return block_number << (BlockSize::Basic - device_->device()->Log2SectorSize());
 }
+
+std::span<std::byte> Block::GetData(bool read_only = false) {
+  if (!read_only) {
+    assert(!device_->device()->IsReadOnly());
+    dirty_ = true;
+  }
+  return data_;
+}

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -58,10 +58,8 @@ uint32_t Block::ToDeviceSector(uint32_t block_number) {
   return block_number << (BlockSize::Basic - device_->device()->Log2SectorSize());
 }
 
-std::span<std::byte> Block::GetData(bool read_only = false) {
-  if (!read_only) {
-    assert(!device_->device()->IsReadOnly());
-    dirty_ = true;
-  }
+std::span<std::byte> Block::GetDataForWriting() {
+  assert(!device_->device()->IsReadOnly());
+  dirty_ = true;
   return data_;
 }

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -42,8 +42,7 @@ void Block::Resize(size_t new_size) {
 
 void Block::Fetch(bool check_hash) {
   device_->ReadBlock(ToDeviceSector(block_number_), data_, iv_, encrypted_);
-  const auto* const_this = this;
-  if (check_hash && !device_->CheckHash(data_, const_this->Hash()))
+  if (check_hash && !device_->CheckHash(data_, as_const(this)->Hash()))
     throw Block::BadHash(block_number_);
 }
 

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -33,10 +33,6 @@ Block::Block(const std::shared_ptr<DeviceEncryption>& device,
   Resize(data_.size());
 }
 
-Block::~Block() {
-  Flush();
-}
-
 void Block::Resize(size_t new_size) {
   // Ensure that block data is aligned to device sectors
   new_size = div_ceil(new_size, device_->device()->SectorSize()) * device_->device()->SectorSize();

--- a/src/block.h
+++ b/src/block.h
@@ -30,9 +30,9 @@ class Block {
   // The actual size of the data, may be smaller than the allocated size.
   size_t data_size() const { return data_.size(); }
 
-  std::span<const std::byte> Data() const { return GetData(true); }
+  std::span<const std::byte> Data() const { return data_; }
   // Accessing the non-const variant of data will mark the block as dirty.
-  std::span<std::byte> Data() { return GetData(); }
+  std::span<std::byte> Data() { return GetDataForWriting(); }
 
   template <typename T>
   const T* GetStruct(size_t offset) const {
@@ -61,7 +61,7 @@ class Block {
  private:
   uint32_t ToDeviceSector(uint32_t block_number);
 
-  std::span<std::byte> GetData(bool read_only = false);
+  std::span<std::byte> GetDataForWriting();
 
  protected:
   Block(const std::shared_ptr<DeviceEncryption>& device,

--- a/src/block.h
+++ b/src/block.h
@@ -30,12 +30,9 @@ class Block {
   // The actual size of the data, may be smaller than the allocated size.
   size_t data_size() const { return data_.size(); }
 
-  std::span<const std::byte> Data() const { return data_; }
+  std::span<const std::byte> Data() const { return GetData(true); }
   // Accessing the non-const variant of data will mark the block as dirty.
-  std::span<std::byte> Data() {
-    dirty_ = true;
-    return data_;
-  }
+  std::span<std::byte> Data() { return GetData(); }
 
   template <typename T>
   const T* GetStruct(size_t offset) const {
@@ -63,6 +60,8 @@ class Block {
 
  private:
   uint32_t ToDeviceSector(uint32_t block_number);
+
+  std::span<std::byte> GetData(bool read_only = false);
 
  protected:
   Block(const std::shared_ptr<DeviceEncryption>& device,

--- a/src/block.h
+++ b/src/block.h
@@ -27,6 +27,9 @@ class Block {
   void Fetch(bool check_hash = true);
   void Flush();
 
+  // The actual size of the data, may be smaller than the allocated size.
+  size_t data_size() const { return data_.size(); }
+
   std::span<const std::byte> Data() const { return data_; }
   // Accessing the non-const variant of data will mark the block as dirty.
   std::span<std::byte> Data() {
@@ -34,9 +37,19 @@ class Block {
     return data_;
   }
 
+  template <typename T>
+  const T* GetStruct(size_t offset) const {
+    return reinterpret_cast<const T*>(Data().data() + offset);
+  }
+
+  template <typename T>
+  T* GetStruct(size_t offset) {
+    return reinterpret_cast<T*>(Data().data() + offset);
+  }
+
   void Resize(size_t new_size);
-  uint32_t BlockNumber() { return block_number_; }
-  Block::BlockSize Size() { return size_category_; }
+  uint32_t BlockNumber() const { return block_number_; }
+  Block::BlockSize log2_size() const { return size_category_; }
 
   class BadHash : public std::exception {
    public:
@@ -58,7 +71,7 @@ class Block {
         uint32_t iv,
         bool encrypted,
         std::vector<std::byte>&& data);
-  virtual ~Block();
+  virtual ~Block() = default;
 
   virtual std::span<std::byte> Hash() = 0;
   virtual std::span<const std::byte> Hash() const = 0;

--- a/src/data_block.cpp
+++ b/src/data_block.cpp
@@ -20,6 +20,10 @@ DataBlock::DataBlock(const std::shared_ptr<DeviceEncryption>& device,
                      bool encrypted)
     : Block(device, block_number, size_category, iv, encrypted, {data_size, std::byte{0}}), data_hash_(data_hash) {}
 
+DataBlock::~DataBlock() {
+  Flush();
+}
+
 std::shared_ptr<DataBlock> DataBlock::LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                                 uint32_t block_number,
                                                 Block::BlockSize size_category,

--- a/src/data_block.cpp
+++ b/src/data_block.cpp
@@ -20,12 +20,6 @@ DataBlock::DataBlock(const std::shared_ptr<DeviceEncryption>& device,
                      bool encrypted)
     : Block(device, block_number, size_category, iv, encrypted, {data_size, std::byte{0}}), data_hash_(data_hash) {}
 
-void DataBlock::Flush() {
-  Block::Flush();
-  // TODO: Write now we write two blocks for each block written, we need some caching with option to commit changes
-  data_hash_.block->Flush();
-}
-
 std::shared_ptr<DataBlock> DataBlock::LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                                 uint32_t block_number,
                                                 Block::BlockSize size_category,
@@ -42,5 +36,9 @@ std::shared_ptr<DataBlock> DataBlock::LoadBlock(const std::shared_ptr<DeviceEncr
 }
 
 std::span<std::byte> DataBlock::Hash() {
-  return {&data_hash_.block->Data()[data_hash_.hash_offset], device_->DIGEST_SIZE};
+  return {hash_metadata_block()->Data().data() + hash_offset(), device_->DIGEST_SIZE};
+}
+
+std::span<const std::byte> DataBlock::Hash() const {
+  return {hash_metadata_block()->Data().data() + hash_offset(), device_->DIGEST_SIZE};
 }

--- a/src/data_block.h
+++ b/src/data_block.h
@@ -26,6 +26,7 @@ class DataBlock : public Block {
             uint32_t iv,
             const DataBlockHash& data_hash,
             bool encrypted);
+  ~DataBlock() override;
 
   static std::shared_ptr<DataBlock> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                               uint32_t block_number,

--- a/src/data_block.h
+++ b/src/data_block.h
@@ -27,8 +27,6 @@ class DataBlock : public Block {
             const DataBlockHash& data_hash,
             bool encrypted);
 
-  void Flush() override;
-
   static std::shared_ptr<DataBlock> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                               uint32_t block_number,
                                               Block::BlockSize size_category,
@@ -39,7 +37,12 @@ class DataBlock : public Block {
 
  protected:
   std::span<std::byte> Hash() override;
+  std::span<const std::byte> Hash() const override;
 
  private:
+  std::shared_ptr<MetadataBlock> hash_metadata_block() { return data_hash_.block; }
+  std::shared_ptr<const MetadataBlock> hash_metadata_block() const { return data_hash_.block; }
+  size_t hash_offset() const { return data_hash_.hash_offset; }
+
   DataBlockHash data_hash_;
 };

--- a/src/device_encryption.cpp
+++ b/src/device_encryption.cpp
@@ -26,7 +26,6 @@ DeviceEncryption::DeviceEncryption(const std::shared_ptr<Device>& device, const 
 
 void DeviceEncryption::HashData(const std::list<std::span<const std::byte>>& data,
                                 const std::span<std::byte>& hash) const {
-  assert(data.size() % device_->SectorSize() == 0);
   // Pad and hash
   CryptoPP::SHA1 sha1;
   for (auto& data_part : data) {

--- a/src/device_encryption.cpp
+++ b/src/device_encryption.cpp
@@ -24,21 +24,25 @@ struct WfsBlockIV {
 DeviceEncryption::DeviceEncryption(const std::shared_ptr<Device>& device, const std::span<std::byte>& key)
     : device_(device), key_(key.begin(), key.end()) {}
 
-void DeviceEncryption::HashData(const std::span<std::byte>& data, const std::span<std::byte>& hash) {
+void DeviceEncryption::HashData(const std::list<std::span<const std::byte>>& data,
+                                const std::span<std::byte>& hash) const {
   assert(data.size() % device_->SectorSize() == 0);
   // Pad and hash
-  CryptoPP::SHA1().CalculateDigest(reinterpret_cast<uint8_t*>(hash.data()), reinterpret_cast<uint8_t*>(data.data()),
-                                   data.size());
+  CryptoPP::SHA1 sha1;
+  for (auto& data_part : data) {
+    sha1.Update(reinterpret_cast<const uint8_t*>(data_part.data()), data_part.size());
+  }
+  sha1.Final(reinterpret_cast<uint8_t*>(hash.data()));
 }
 
-void DeviceEncryption::CalculateHash(const std::span<std::byte>& data, const std::span<std::byte>& hash) {
+void DeviceEncryption::CalculateHash(const std::span<const std::byte>& data, const std::span<std::byte>& hash) const {
   bool hash_in_block = data.size() >= hash.size() && data.data() <= hash.data() &&
                        hash.data() + hash.size() <= data.data() + data.size();
   // Fill hash space with 0xFF
   if (hash_in_block)
     std::ranges::fill(hash, std::byte{0xFF});
 
-  HashData(data, hash);
+  HashData({data}, hash);
 }
 
 void DeviceEncryption::WriteBlock(uint32_t sector_address,
@@ -62,7 +66,10 @@ void DeviceEncryption::WriteBlock(uint32_t sector_address,
   device_->WriteSectors(enc_data, sector_address, sectors_count);
 }
 
-void DeviceEncryption::ReadBlock(uint32_t sector_address, const std::span<std::byte>& data, uint32_t iv, bool encrypt) {
+void DeviceEncryption::ReadBlock(uint32_t sector_address,
+                                 const std::span<std::byte>& data,
+                                 uint32_t iv,
+                                 bool encrypt) const {
   assert(data.size() % device_->SectorSize() == 0);
   auto const sectors_count = static_cast<uint32_t>(data.size() / device_->SectorSize());
 
@@ -77,27 +84,24 @@ void DeviceEncryption::ReadBlock(uint32_t sector_address, const std::span<std::b
   }
 }
 
-bool DeviceEncryption::CheckHash(const std::span<std::byte>& data, const std::span<std::byte>& hash) {
-  std::array<std::byte, DIGEST_SIZE> placeholder_hash;
-
+bool DeviceEncryption::CheckHash(const std::span<const std::byte>& data, const std::span<const std::byte>& hash) const {
   bool hash_in_block = data.size() >= hash.size() && data.data() <= hash.data() &&
                        hash.data() + hash.size() <= data.data() + data.size();
 
-  if (hash_in_block) {
-    placeholder_hash.fill(std::byte{0xFF});
-    std::ranges::swap_ranges(placeholder_hash, hash);
-  }
-
   std::array<std::byte, DIGEST_SIZE> calculated_hash;
-  HashData(data, calculated_hash);
-
-  if (hash_in_block)
-    std::ranges::swap_ranges(placeholder_hash, hash);
+  if (hash_in_block) {
+    std::array<std::byte, DIGEST_SIZE> placeholder_hash;
+    placeholder_hash.fill(std::byte{0xFF});
+    HashData({{data.data(), hash.data()}, placeholder_hash, {hash.data() + hash.size(), data.data() + data.size()}},
+             calculated_hash);
+  } else {
+    HashData({data}, calculated_hash);
+  }
 
   return std::ranges::equal(calculated_hash, hash);
 }
 
-WfsBlockIV DeviceEncryption::GetIV(uint32_t sectors_count, uint32_t iv) {
+WfsBlockIV DeviceEncryption::GetIV(uint32_t sectors_count, uint32_t iv) const {
   WfsBlockIV aes_iv;
   aes_iv.iv[0] = sectors_count * device_->SectorSize();
   aes_iv.iv[1] = iv;

--- a/src/device_encryption.h
+++ b/src/device_encryption.h
@@ -20,18 +20,18 @@ class DeviceEncryption {
   DeviceEncryption(const std::shared_ptr<Device>& device, const std::span<std::byte>& key);
 
   void WriteBlock(uint32_t sector_address, const std::span<std::byte>& data, uint32_t iv, bool encrypt);
-  void ReadBlock(uint32_t sector_address, const std::span<std::byte>& data, uint32_t iv, bool encrypt);
+  void ReadBlock(uint32_t sector_address, const std::span<std::byte>& data, uint32_t iv, bool encrypt) const;
 
-  void CalculateHash(const std::span<std::byte>& data, const std::span<std::byte>& hash);
-  bool CheckHash(const std::span<std::byte>& data, const std::span<std::byte>& hash);
+  void CalculateHash(const std::span<const std::byte>& data, const std::span<std::byte>& hash) const;
+  bool CheckHash(const std::span<const std::byte>& data, const std::span<const std::byte>& hash) const;
 
-  const std::shared_ptr<Device>& GetDevice() { return device_; }
+  std::shared_ptr<const Device> device() { return device_; }
 
   static constexpr size_t DIGEST_SIZE = CryptoPP::SHA1::DIGESTSIZE;
 
  private:
-  void HashData(const std::span<std::byte>& data, const std::span<std::byte>& hash);
-  WfsBlockIV GetIV(uint32_t sectors_count, uint32_t iv);
+  void HashData(const std::list<std::span<const std::byte>>& data, const std::span<std::byte>& hash) const;
+  WfsBlockIV GetIV(uint32_t sectors_count, uint32_t iv) const;
 
   std::shared_ptr<Device> device_;
 

--- a/src/metadata_block.cpp
+++ b/src/metadata_block.cpp
@@ -15,6 +15,9 @@ MetadataBlock::MetadataBlock(const std::shared_ptr<DeviceEncryption>& device,
                              Block::BlockSize size_category,
                              uint32_t iv)
     : Block(device, block_number, size_category, iv, true, {1ULL << size_category, std::byte{0}}) {}
+MetadataBlock::~MetadataBlock() {
+  Flush();
+}
 
 std::shared_ptr<MetadataBlock> MetadataBlock::LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                                         uint32_t block_number,

--- a/src/metadata_block.cpp
+++ b/src/metadata_block.cpp
@@ -26,10 +26,26 @@ std::shared_ptr<MetadataBlock> MetadataBlock::LoadBlock(const std::shared_ptr<De
   return block;
 }
 
+std::shared_ptr<const MetadataBlock> MetadataBlock::LoadConstBlock(const std::shared_ptr<DeviceEncryption>& device,
+                                                                   uint32_t block_number,
+                                                                   Block::BlockSize size_category,
+                                                                   uint32_t iv,
+                                                                   bool check_hash) {
+  return LoadBlock(device, block_number, size_category, iv, check_hash);
+}
+
 MetadataBlockHeader* MetadataBlock::Header() {
   return reinterpret_cast<MetadataBlockHeader*>(data_.data());
 }
 
+const MetadataBlockHeader* MetadataBlock::Header() const {
+  return reinterpret_cast<const MetadataBlockHeader*>(data_.data());
+}
+
 std::span<std::byte> MetadataBlock::Hash() {
-  return {&data_[offsetof(MetadataBlockHeader, hash)], device_->DIGEST_SIZE};
+  return {Data().data() + offsetof(MetadataBlockHeader, hash), device_->DIGEST_SIZE};
+}
+
+std::span<const std::byte> MetadataBlock::Hash() const {
+  return {Data().data() + offsetof(MetadataBlockHeader, hash), device_->DIGEST_SIZE};
 }

--- a/src/metadata_block.h
+++ b/src/metadata_block.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include "block.h"
+#include "utils.h"
 
 struct MetadataBlockHeader;
 
@@ -18,6 +19,7 @@ class MetadataBlock : public Block {
    public:
     Adapter(std::shared_ptr<MetadataBlock> block) : block_(std::move(block)) {}
     std::span<std::byte> data() { return block_->Data(); }
+    std::span<const std::byte> data() const { return as_const(block_.get())->Data(); }
 
    private:
     std::shared_ptr<MetadataBlock> block_;
@@ -27,6 +29,7 @@ class MetadataBlock : public Block {
                 uint32_t block_number,
                 Block::BlockSize size_category,
                 uint32_t iv);
+  ~MetadataBlock() override;
 
   static std::shared_ptr<MetadataBlock> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
                                                   uint32_t block_number,

--- a/src/metadata_block.h
+++ b/src/metadata_block.h
@@ -33,9 +33,16 @@ class MetadataBlock : public Block {
                                                   Block::BlockSize size_category,
                                                   uint32_t iv,
                                                   bool check_hash = true);
+  static std::shared_ptr<const MetadataBlock> LoadConstBlock(const std::shared_ptr<DeviceEncryption>& device,
+                                                             uint32_t block_number,
+                                                             Block::BlockSize size_category,
+                                                             uint32_t iv,
+                                                             bool check_hash = true);
 
   MetadataBlockHeader* Header();
+  const MetadataBlockHeader* Header() const;
 
  protected:
   std::span<std::byte> Hash() override;
+  std::span<const std::byte> Hash() const override;
 };

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -8,17 +8,17 @@
 #include "structs.h"
 #include "utils.h"
 
-size_t Attributes::DataOffset() {
+size_t Attributes::DataOffset() const {
   return offsetof(Attributes, case_bitmap) + div_ceil(filename_length.value(), 8);
 }
 
-size_t ExternalDirectoryTreeNode::size() {
+size_t ExternalDirectoryTreeNode::size() const {
   size_t total_size = sizeof(DirectoryTreeNode) + prefix_length.value() + choices_count.value() +
                       choices_count.value() * sizeof(boost::endian::big_uint16_buf_t);
   return align_to_power_of_2(total_size);
 }
 
-size_t InternalDirectoryTreeNode::size() {
+size_t InternalDirectoryTreeNode::size() const {
   size_t total_size = sizeof(DirectoryTreeNode) + prefix_length.value() + choices_count.value() +
                       choices_count.value() * sizeof(boost::endian::big_uint16_buf_t);
   if (choices_count.value() > 0 && choices()[0] == std::byte{0})

--- a/src/sub_block_allocator.cpp
+++ b/src/sub_block_allocator.cpp
@@ -8,90 +8,87 @@
 #include "sub_block_allocator.h"
 #include <bit>
 #include <cassert>
+#include "utils.h"
 
 namespace {
 
 int GetSizeGroup(uint16_t size) {
   assert(size > 0);
   int size_log2 = std::bit_width(static_cast<uint16_t>(size - 1));
-  size_log2 = std::min(size_log2, SubBlockAllocator::MIN_BLOCK_SIZE);
-  assert(size_log2 <= MAX_BLOCK_SIZE);
+  size_log2 = std::min(size_log2, SubBlockAllocatorBase::BLOCK_SIZE_QUANTA);
+  assert(size_log2 <= SubBlockAllocatorBase::MAX_BLOCK_SIZE);
   return size_log2;
 }
 
 }  // namespace
 
-SubBlockAllocatorStruct* SubBlockAllocator::Header() {
-  return GetNode<SubBlockAllocatorStruct>(sizeof(MetadataBlockHeader));
-}
+void SubBlockAllocatorBase::Init(uint16_t extra_header_size) {
+  auto* header = this->header();
+  memset(header, 0, sizeof(*header) + extra_header_size);
 
-void SubBlockAllocator::Init() {
-  auto* header = Header();
-  memset(header, 0, sizeof(*header));
-
-  uint16_t free_entries = 1 << (block_->Size() - MAX_BLOCK_SIZE);
+  uint16_t free_entries = 1 << (block_->log2_size() - MAX_BLOCK_SIZE);
   for (uint16_t i = 0; i < free_entries; ++i) {
-    auto* entry = GetNode<SubBlockAllocatorFreeListEntry>(i << MAX_BLOCK_SIZE);
+    auto* entry = block()->GetStruct<SubBlockAllocatorFreeListEntry>(i << MAX_BLOCK_SIZE);
     entry->next = ((i + 1) & (free_entries - 1)) << MAX_BLOCK_SIZE;
     entry->prev = ((i - 1) & (free_entries - 1)) << MAX_BLOCK_SIZE;
     entry->log2_block_size = MAX_BLOCK_SIZE;
   }
-  header->free_list[MAX_BLOCK_SIZE - MIN_BLOCK_SIZE].free_blocks_count = free_entries;
+  header->free_list[MAX_BLOCK_SIZE - BLOCK_SIZE_QUANTA].free_blocks_count = free_entries;
 
   // Reserve header
-  Alloc(sizeof(MetadataBlockHeader) + sizeof(*header));
+  Alloc(sizeof(MetadataBlockHeader) + sizeof(*header) + extra_header_size);
 }
 
-uint16_t SubBlockAllocator::Alloc(uint16_t size) {
+uint16_t SubBlockAllocatorBase::Alloc(uint16_t size) {
   int size_log2 = GetSizeGroup(size);
-  uint16_t offset = PopFreeEntry(size_log2 - MIN_BLOCK_SIZE);
+  uint16_t offset = PopFreeEntry(size_log2 - BLOCK_SIZE_QUANTA);
   if (offset) {
     return offset;
   }
   int base_size_log2 = size_log2++;
-  for (; !offset; offset = PopFreeEntry(size_log2 - MIN_BLOCK_SIZE)) {
-    if (++size_log2 > MAX_BLOCK_SIZE - MIN_BLOCK_SIZE)
+  for (; !offset; offset = PopFreeEntry(size_log2 - BLOCK_SIZE_QUANTA)) {
+    if (++size_log2 > MAX_BLOCK_SIZE - BLOCK_SIZE_QUANTA)
       return 0;
   }
 
   // Split a bigger block
   for (uint16_t sub_block_offset = offset + (1 << base_size_log2); base_size_log2 < size_log2;
        sub_block_offset += (1 << (base_size_log2++))) {
-    auto* free_entry = GetNode<SubBlockAllocatorFreeListEntry>(sub_block_offset);
+    auto* free_entry = block()->GetStruct<SubBlockAllocatorFreeListEntry>(sub_block_offset);
     free_entry->free_mark = free_entry->FREE_MARK_CONST;
     free_entry->prev = sub_block_offset;
     free_entry->next = sub_block_offset;
     free_entry->log2_block_size = static_cast<uint16_t>(base_size_log2);
-    Header()->free_list[base_size_log2 - MIN_BLOCK_SIZE].head = sub_block_offset;
-    Header()->free_list[base_size_log2 - MIN_BLOCK_SIZE].free_blocks_count = 1;
+    header()->free_list[base_size_log2 - BLOCK_SIZE_QUANTA].head = sub_block_offset;
+    header()->free_list[base_size_log2 - BLOCK_SIZE_QUANTA].free_blocks_count = 1;
   }
 
   return offset;
 }
 
-void SubBlockAllocator::Free(uint16_t offset, uint16_t size) {
+void SubBlockAllocatorBase::Free(uint16_t offset, uint16_t size) {
   int size_log2 = GetSizeGroup(size);
   assert(!(offset & ((1 << size_log2) - 1)));
   for (; size_log2 < MAX_BLOCK_SIZE; size_log2++) {
     // Try to coalesce if block not max size
-    auto* other_free_block = GetNode<SubBlockAllocatorFreeListEntry>(offset ^ (1 << size_log2));
+    auto* other_free_block = block()->GetStruct<SubBlockAllocatorFreeListEntry>(offset ^ (1 << size_log2));
     if (other_free_block->free_mark.value() != other_free_block->FREE_MARK_CONST ||
         other_free_block->log2_block_size.value() != size_log2) {
       // Other half not free
       break;
     }
     // Coalesce with other free block
-    Unlink(other_free_block, size_log2 - MIN_BLOCK_SIZE);
+    Unlink(other_free_block, size_log2 - BLOCK_SIZE_QUANTA);
     offset = std::min(offset, (uint16_t)(offset ^ (1 << size_log2)));
   }
 
-  auto* free_entry = GetNode<SubBlockAllocatorFreeListEntry>(offset);
-  auto free_blocks_count = Header()->free_list[size_log2 - MIN_BLOCK_SIZE].free_blocks_count.value();
+  auto* free_entry = block()->GetStruct<SubBlockAllocatorFreeListEntry>(offset);
+  auto free_blocks_count = header()->free_list[size_log2 - BLOCK_SIZE_QUANTA].free_blocks_count.value();
   if (free_blocks_count) {
     // Insert at end of list
-    uint16_t head_offset = Header()->free_list[size_log2 - MIN_BLOCK_SIZE].head.value();
-    auto* next_free = GetNode<SubBlockAllocatorFreeListEntry>(head_offset);
-    auto* prev_free = GetNode<SubBlockAllocatorFreeListEntry>(next_free->prev.value());
+    uint16_t head_offset = header()->free_list[size_log2 - BLOCK_SIZE_QUANTA].head.value();
+    auto* next_free = block()->GetStruct<SubBlockAllocatorFreeListEntry>(head_offset);
+    auto* prev_free = block()->GetStruct<SubBlockAllocatorFreeListEntry>(next_free->prev.value());
     free_entry->next = head_offset;
     free_entry->prev = next_free->prev.value();
     next_free->prev = offset;
@@ -99,8 +96,8 @@ void SubBlockAllocator::Free(uint16_t offset, uint16_t size) {
 
   } else {
     // New list
-    Header()->free_list[size_log2 - MIN_BLOCK_SIZE].head = offset;
-    Header()->free_list[size_log2 - MIN_BLOCK_SIZE].free_blocks_count = 1;
+    header()->free_list[size_log2 - BLOCK_SIZE_QUANTA].head = offset;
+    header()->free_list[size_log2 - BLOCK_SIZE_QUANTA].free_blocks_count = 1;
     free_entry->next = offset;
     free_entry->prev = offset;
   }
@@ -108,21 +105,21 @@ void SubBlockAllocator::Free(uint16_t offset, uint16_t size) {
   free_entry->free_mark = free_entry->FREE_MARK_CONST;
 }
 
-void SubBlockAllocator::Unlink(SubBlockAllocatorFreeListEntry* entry, int size_index) {
-  auto* prev_free = GetNode<SubBlockAllocatorFreeListEntry>(entry->prev.value());
-  auto* next_free = GetNode<SubBlockAllocatorFreeListEntry>(entry->next.value());
+void SubBlockAllocatorBase::Unlink(SubBlockAllocatorFreeListEntry* entry, int size_index) {
+  auto* prev_free = block()->GetStruct<SubBlockAllocatorFreeListEntry>(entry->prev.value());
+  auto* next_free = block()->GetStruct<SubBlockAllocatorFreeListEntry>(entry->next.value());
   next_free->prev = entry->prev.value();
   prev_free->next = entry->next.value();
-  Header()->free_list[size_index].head = entry->next.value();
-  Header()->free_list[size_index].free_blocks_count = Header()->free_list[size_index].free_blocks_count.value() - 1;
+  header()->free_list[size_index].head = entry->next.value();
+  header()->free_list[size_index].free_blocks_count = header()->free_list[size_index].free_blocks_count.value() - 1;
 }
 
-uint16_t SubBlockAllocator::PopFreeEntry(int size_index) {
-  auto free_blocks_count = Header()->free_list[size_index].free_blocks_count.value();
+uint16_t SubBlockAllocatorBase::PopFreeEntry(int size_index) {
+  auto free_blocks_count = as_const(this)->header()->free_list[size_index].free_blocks_count.value();
   if (free_blocks_count == 0)
     return 0;
-  uint16_t entry_offset = Header()->free_list[size_index].head.value();
-  auto* free_entry = GetNode<SubBlockAllocatorFreeListEntry>(entry_offset);
+  uint16_t entry_offset = header()->free_list[size_index].head.value();
+  auto* free_entry = block()->GetStruct<SubBlockAllocatorFreeListEntry>(entry_offset);
   free_entry->free_mark = 0;
   Unlink(free_entry, size_index);
   return entry_offset;

--- a/src/sub_block_allocator.h
+++ b/src/sub_block_allocator.h
@@ -50,8 +50,10 @@ class SubBlockAllocator : SubBlockAllocatorBase {
 
   void Init() { Init(sizeof(ExtraHeaderType)); }
 
-  ExtraHeaderType* extra_header() { return block()->GetStruct<ExtraHeaderType>(header_offset()); }
-  const ExtraHeaderType* extra_header() const { return block()->GetStruct<ExtraHeaderType>(extra_header_offset()); }
+  ExtraHeaderType* extra_header() { return block()->template GetStruct<ExtraHeaderType>(header_offset()); }
+  const ExtraHeaderType* extra_header() const {
+    return block()->template GetStruct<ExtraHeaderType>(extra_header_offset());
+  }
 
  private:
   uint16_t extra_header_offset() const { return header_offset() + sizeof(SubBlockAllocatorStruct); }

--- a/src/sub_block_allocator.h
+++ b/src/sub_block_allocator.h
@@ -14,35 +14,45 @@
 class MetadataBlock;
 struct SubBlockAllocatorStruct;
 
-class SubBlockAllocator {
+class SubBlockAllocatorBase {
  public:
-  static const int MIN_BLOCK_SIZE = 3;  // 1 << 3
+  static const int BLOCK_SIZE_QUANTA = 3;  // 1 << 3
   static constexpr int MAX_BLOCK_SIZE =
-      MIN_BLOCK_SIZE + std::extent<decltype(SubBlockAllocatorStruct::free_list)>::value - 1;
+      BLOCK_SIZE_QUANTA + std::extent<decltype(SubBlockAllocatorStruct::free_list)>::value - 1;
 
-  SubBlockAllocator(const std::shared_ptr<MetadataBlock>& block) : block_(block) {}
-
-  template <typename T>
-  T* GetNode(uint16_t offset) {
-    return reinterpret_cast<T*>(&block_->Data()[offset]);
-  }
-
-  template <typename T>
-  T* GetRootNode() {
-    return GetNode<T>(Header()->root.value());
-  }
-
-  void Init();
+  SubBlockAllocatorBase(const std::shared_ptr<MetadataBlock>& block) : block_(block) {}
 
   uint16_t Alloc(uint16_t size);
   void Free(uint16_t offset, uint16_t size);
 
+ protected:
+  void Init(uint16_t extra_header_size);
+
+  uint16_t header_offset() const { return sizeof(MetadataBlockHeader); }
+
+  MetadataBlock* block() { return block_.get(); }
+  const MetadataBlock* block() const { return block_.get(); }
+
  private:
+  SubBlockAllocatorStruct* header() { return block()->GetStruct<SubBlockAllocatorStruct>(header_offset()); }
+  const SubBlockAllocatorStruct* header() const { return block()->GetStruct<SubBlockAllocatorStruct>(header_offset()); }
+
   std::shared_ptr<MetadataBlock> block_;
 
-  SubBlockAllocatorStruct* Header();
-
   uint16_t PopFreeEntry(int size_index);
-
   void Unlink(SubBlockAllocatorFreeListEntry* entry, int size_index);
+};
+
+template <typename ExtraHeaderType>
+class SubBlockAllocator : SubBlockAllocatorBase {
+ public:
+  SubBlockAllocator(const std::shared_ptr<MetadataBlock>& block) : SubBlockAllocatorBase(block) {}
+
+  void Init() { Init(sizeof(ExtraHeaderType)); }
+
+  ExtraHeaderType* extra_header() { return block()->GetStruct<ExtraHeaderType>(header_offset()); }
+  const ExtraHeaderType* extra_header() const { return block()->GetStruct<ExtraHeaderType>(extra_header_offset()); }
+
+ private:
+  uint16_t extra_header_offset() const { return header_offset() + sizeof(SubBlockAllocatorStruct); }
 };

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,3 +18,8 @@ inline size_t align_to_power_of_2(size_t size) {
 inline size_t div_ceil(size_t n, size_t div) {
   return (n + div - 1) / div;
 }
+
+template <typename T>
+constexpr const T* as_const(T* obj) {
+  return obj;
+}

--- a/src/wfs.cpp
+++ b/src/wfs.cpp
@@ -67,8 +67,8 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
   device->SetSectorsCount(0x10);
   device->SetLog2SectorSize(9);
   auto enc_device = std::make_shared<DeviceEncryption>(device, key);
-  auto block = MetadataBlock::LoadBlock(enc_device, 0, Block::BlockSize::Basic, 0, false);
-  auto wfs_header = reinterpret_cast<WfsHeader*>(&block->Data()[sizeof(MetadataBlockHeader)]);
+  auto block = MetadataBlock::LoadConstBlock(enc_device, 0, Block::BlockSize::Basic, 0, false);
+  auto wfs_header = reinterpret_cast<const WfsHeader*>(&block->Data()[sizeof(MetadataBlockHeader)]);
   if (wfs_header->version.value() != 0x01010800)
     throw std::runtime_error("Unexpected WFS version (bad key?)");
   auto block_size = Block::BlockSize::Basic;
@@ -76,16 +76,16 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
       (wfs_header->root_area_attributes.flags.value() & Attributes::Flags::AREA_SIZE_REGULAR))
     block_size = Block::BlockSize::Regular;
   // Now lets read it again, this time with the correct block size
-  block = MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, false);
+  block = MetadataBlock::LoadConstBlock(enc_device, 0, block_size, 0, false);
   uint32_t xored_sectors_count, xored_sector_size;
   // The two last dwords of the IV is the sectors count and sector size, right now it is xored with our fake sector size
   // and sector count, and with the hash
-  auto data = block->Data();
+  std::vector<std::byte> data{block->Data().begin(), block->Data().end()};
   auto first_4_dwords = reinterpret_cast<boost::endian::big_uint32_buf_t*>(data.data());
   xored_sectors_count = first_4_dwords[2].value();
   xored_sector_size = first_4_dwords[3].value();
   // Lets calculate the hash of the block
-  enc_device->CalculateHash(data, {&data[offsetof(MetadataBlockHeader, hash)], enc_device->DIGEST_SIZE});
+  enc_device->CalculateHash(data, {data.data() + offsetof(MetadataBlockHeader, hash), enc_device->DIGEST_SIZE});
   // Now xor it with the real hash
   xored_sectors_count ^= first_4_dwords[2].value();
   xored_sector_size ^= first_4_dwords[3].value();
@@ -100,7 +100,7 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
   device->SetSectorsCount(xored_sectors_count);
   // Now try to fetch block again, this time check the hash, it will raise exception
   try {
-    block = MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, true);
+    block = MetadataBlock::LoadConstBlock(enc_device, 0, block_size, 0, true);
   } catch (const Block::BadHash&) {
     throw std::runtime_error("Wfs: Failed to detect sector size and sectors count");
   }

--- a/src/wfs_item.cpp
+++ b/src/wfs_item.cpp
@@ -12,39 +12,42 @@
 #include <ranges>
 #include "metadata_block.h"
 #include "structs.h"
+#include "utils.h"
 
 WfsItem::WfsItem(const std::string& name, const AttributesBlock& attributes) : name_(name), attributes_(attributes) {}
 
-Attributes* AttributesBlock::Attributes() const {
-  if (!block)
-    return NULL;
-  return reinterpret_cast<::Attributes*>(&block->Data()[attributes_offset]);
+Attributes* AttributesBlock::Attributes() {
+  return block->GetStruct<::Attributes>(attributes_offset);
 }
 
-bool WfsItem::IsDirectory() {
-  auto attributes = attributes_.Attributes();
+const Attributes* AttributesBlock::Attributes() const {
+  return as_const(block.get())->GetStruct<::Attributes>(attributes_offset);
+}
+
+bool WfsItem::IsDirectory() const {
+  auto attributes = attributes_data().Attributes();
   return !attributes->IsLink() && attributes->IsDirectory();
 }
 
-bool WfsItem::IsFile() {
-  auto attributes = attributes_.Attributes();
+bool WfsItem::IsFile() const {
+  auto attributes = attributes_data().Attributes();
   return !attributes->IsLink() && !attributes->IsDirectory();
 }
 
-bool WfsItem::IsLink() {
-  auto attributes = attributes_.Attributes();
+bool WfsItem::IsLink() const {
+  auto attributes = attributes_data().Attributes();
   return attributes->IsLink();
 }
 
-std::string WfsItem::GetRealName() {
-  auto attributes = attributes_.Attributes();
+std::string WfsItem::GetRealName() const {
+  auto attributes = attributes_data().Attributes();
   std::string real_filename = "";
   if (attributes->filename_length.value() != name_.size()) {
     throw std::runtime_error("Unexepected filename length");
   }
   boost::dynamic_bitset<uint8_t> bits(name_.size());
-  boost::from_block_range(reinterpret_cast<uint8_t*>(&attributes->case_bitmap),
-                          reinterpret_cast<uint8_t*>(&attributes->case_bitmap) + (name_.size() / 8), bits);
+  boost::from_block_range(reinterpret_cast<const uint8_t*>(&attributes->case_bitmap),
+                          reinterpret_cast<const uint8_t*>(&attributes->case_bitmap) + (name_.size() / 8), bits);
   std::string real_name;
   std::ranges::transform(std::ranges::iota_view(0ull, name_.size()), std::back_inserter(real_name),
                          [&](auto i) { return bits[i] ? std::toupper(name_[i]) : name_[i]; });


### PR DESCRIPTION
Accessing the non-const variant of Block::Data() will mark the block as dirty.