### PR TITLE
Refactor error handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ jobs:
             compiler: llvm
           - platform: ubuntu-latest
             compiler: msvc
+          # llvm doesn't work with libstd++ until P2493R0 is done
+          - platform: ubuntu-latest
+            compiler: llvm
           - platform: macos-latest
             compiler: msvc
           - platform: macos-latest
@@ -33,8 +36,6 @@ jobs:
 
       - name: Set gcc
         run: |
-          sudo apt update
-          sudo apt install gcc-13 g++-13
           echo "CC=gcc-13" >> $GITHUB_ENV
           echo "CXX=g++-13" >> $GITHUB_ENV
         shell: bash
@@ -48,8 +49,6 @@ jobs:
           sudo apt install libc++-17-dev
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
-          clang-17 -v
-          clang++-17 -v
         shell: bash
         if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'llvm'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,15 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v10
 
+      - name: Update gcc
+        run: |
+          sudo apt update
+          sudo apt install gcc-12 g++-12
+          echo "CC=gcc-12" >> $GITHUB_ENV
+          echo "CXX=g++-12" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.platform == 'ubuntu-latest'
+
       - name: Set llvm (Ubuntu)
         run: |
           wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, windows-latest, macos-13]
         compiler: [msvc, gcc, llvm]
         exclude:
           - platform: windows-latest
@@ -18,9 +18,9 @@ jobs:
           # llvm doesn't work with libstd++ until P2493R0 is done
           - platform: ubuntu-latest
             compiler: llvm
-          - platform: macos-latest
+          - platform: macos-13
             compiler: msvc
-          - platform: macos-latest
+          - platform: macos-13
             compiler: gcc
     runs-on: ${{matrix.platform}}
 
@@ -67,7 +67,7 @@ jobs:
           echo "LDFLAGS=-L/usr/local/opt/llvm/lib" >> $GITHUB_ENV
           echo "CXXFLAGS=-isystem /usr/local/opt/llvm/include" >> $GITHUB_ENV
         shell: bash
-        if: matrix.platform == 'macos-latest'
+        if: matrix.platform == 'macos-13'
 
       - name: Run cmake
         uses: lukka/run-cmake@v10

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,44 +22,45 @@ jobs:
     runs-on: ${{matrix.platform}}
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: 'true'
+      - uses: actions/checkout@v2
+        with:
+          submodules: "true"
 
-    - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@latest
 
-    - name: Run vcpkg
-      uses: lukka/run-vcpkg@v10
+      - name: Run vcpkg
+        uses: lukka/run-vcpkg@v10
 
-    - name: Set llvm (Ubuntu)
-      run: |
+      - name: Set llvm (Ubuntu)
+        run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16
+          sudo apt install libc++-16-dev
           echo "CC=clang-16" >> $GITHUB_ENV
           echo "CXX=clang++-16" >> $GITHUB_ENV
-      shell: bash
-      if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'llvm'
+        shell: bash
+        if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'llvm'
 
-    - name: Set llvm (MacOS)
-      run: |
-           brew update
-           # Temporary fix, see https://github.com/actions/setup-python/issues/577
-           rm /usr/local/bin/2to3 || true
-           rm /usr/local/bin/idle3 || true
-           rm /usr/local/bin/pydoc3 || true
-           rm /usr/local/bin/python3 || true
-           rm /usr/local/bin/python3-config || true
-           brew install llvm
-           echo "CC=/usr/local/opt/llvm/bin/clang" >> $GITHUB_ENV
-           echo "CXX=/usr/local/opt/llvm/bin/clang++" >> $GITHUB_ENV
-           echo "LDFLAGS=-L/usr/local/opt/llvm/lib" >> $GITHUB_ENV
-           echo "CXXFLAGS=-isystem /usr/local/opt/llvm/include" >> $GITHUB_ENV
-      shell: bash
-      if: matrix.platform == 'macos-latest'
+      - name: Set llvm (MacOS)
+        run: |
+          brew update
+          # Temporary fix, see https://github.com/actions/setup-python/issues/577
+          rm /usr/local/bin/2to3 || true
+          rm /usr/local/bin/idle3 || true
+          rm /usr/local/bin/pydoc3 || true
+          rm /usr/local/bin/python3 || true
+          rm /usr/local/bin/python3-config || true
+          brew install llvm
+          echo "CC=/usr/local/opt/llvm/bin/clang" >> $GITHUB_ENV
+          echo "CXX=/usr/local/opt/llvm/bin/clang++" >> $GITHUB_ENV
+          echo "LDFLAGS=-L/usr/local/opt/llvm/lib" >> $GITHUB_ENV
+          echo "CXXFLAGS=-isystem /usr/local/opt/llvm/include" >> $GITHUB_ENV
+        shell: bash
+        if: matrix.platform == 'macos-latest'
 
-    - name: Run cmake
-      uses: lukka/run-cmake@v10
-      with:
-        configurePreset: 'default'
-        buildPreset: 'release'
+      - name: Run cmake
+        uses: lukka/run-cmake@v10
+        with:
+          configurePreset: "default"
+          buildPreset: "release"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
           sudo apt install libc++-17-dev
           echo "CC=clang-17" >> $GITHUB_ENV
           echo "CXX=clang++-17" >> $GITHUB_ENV
+          clang-17 -v
+          clang++-17 -v
         shell: bash
         if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'llvm'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,8 +33,10 @@ jobs:
 
       - name: Set gcc
         run: |
-          echo "CC=gcc-12" >> $GITHUB_ENV
-          echo "CXX=g++-12" >> $GITHUB_ENV
+          sudo apt update
+          sudo apt install gcc-13 g++-13
+          echo "CC=gcc-13" >> $GITHUB_ENV
+          echo "CXX=g++-13" >> $GITHUB_ENV
         shell: bash
         if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'gcc'
 
@@ -42,10 +44,10 @@ jobs:
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16
-          sudo apt install libc++-16-dev
-          echo "CC=clang-16" >> $GITHUB_ENV
-          echo "CXX=clang++-16" >> $GITHUB_ENV
+          sudo ./llvm.sh 17
+          sudo apt install libc++-17-dev
+          echo "CC=clang-17" >> $GITHUB_ENV
+          echo "CXX=clang++-17" >> $GITHUB_ENV
         shell: bash
         if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'llvm'
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,12 @@ jobs:
       - name: Run vcpkg
         uses: lukka/run-vcpkg@v10
 
-      - name: Update gcc
+      - name: Set gcc
         run: |
-          sudo apt update
-          sudo apt install gcc-12 g++-12
           echo "CC=gcc-12" >> $GITHUB_ENV
           echo "CXX=g++-12" >> $GITHUB_ENV
         shell: bash
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-latest' && matrix.compiler == 'gcc'
 
       - name: Set llvm (Ubuntu)
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PROJECT_NAME}
     src/device_encryption.cpp
     src/directory.cpp
     src/directory_items_iterator.cpp
+    src/errors.cpp
     src/file.cpp
     src/file_device.cpp
     src/free_blocks_allocator.cpp
@@ -44,7 +45,7 @@ if(BUILD_STATIC AND MSVC)
         MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 endif()
 
-target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_20)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+  $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>
 )
 
 target_include_directories(${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,10 +51,6 @@ target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
 )
 
-target_compile_options(${PROJECT_NAME} PUBLIC
-  $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>
-)
-
 target_include_directories(${PROJECT_NAME}
     PUBLIC 
         $<INSTALL_INTERFACE:include>    

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,9 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+)
+
+target_compile_options(${PROJECT_NAME} PUBLIC
   $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>
 )
 

--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
+#include <expected>
 #include <memory>
 #include <string>
+
 #include "directory_items_iterator.h"
+#include "errors.h"
 #include "wfs_item.h"
 
 class Area;
@@ -26,9 +29,9 @@ class Directory : public WfsItem, public std::enable_shared_from_this<Directory>
             const std::shared_ptr<MetadataBlock>& block)
       : WfsItem(name, attributes), area_(area), block_(block) {}
 
-  std::shared_ptr<WfsItem> GetObject(const std::string& name) const;
-  std::shared_ptr<Directory> GetDirectory(const std::string& name) const;
-  std::shared_ptr<File> GetFile(const std::string& name) const;
+  std::expected<std::shared_ptr<WfsItem>, WfsError> GetObject(const std::string& name) const;
+  std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(const std::string& name) const;
+  std::expected<std::shared_ptr<File>, WfsError> GetFile(const std::string& name) const;
 
   size_t Size() const;
   DirectoryItemsIterator begin() const;
@@ -44,6 +47,8 @@ class Directory : public WfsItem, public std::enable_shared_from_this<Directory>
 
   std::shared_ptr<MetadataBlock> block_;
 
-  std::shared_ptr<WfsItem> Create(const std::string& name, const AttributesBlock& attributes) const;
-  AttributesBlock GetObjectAttributes(const std::shared_ptr<MetadataBlock>& block, const std::string& name) const;
+  std::expected<std::shared_ptr<WfsItem>, WfsError> GetObjectInternal(const std::string& name,
+                                                                      const AttributesBlock& attributes) const;
+  std::expected<AttributesBlock, WfsError> GetObjectAttributes(const std::shared_ptr<MetadataBlock>& block,
+                                                               const std::string& name) const;
 };

--- a/include/wfslib/directory_items_iterator.h
+++ b/include/wfslib/directory_items_iterator.h
@@ -7,9 +7,12 @@
 
 #pragma once
 
+#include <expected>
 #include <iterator>
 #include <memory>
 #include <string>
+
+#include "errors.h"
 
 class Directory;
 class WfsItem;
@@ -21,7 +24,7 @@ class DirectoryItemsIterator {
  public:
   using iterator_category = std::input_iterator_tag;
   using difference_type = std::ptrdiff_t;
-  using value_type = std::shared_ptr<WfsItem>;
+  using value_type = std::tuple<std::string, std::expected<std::shared_ptr<WfsItem>, WfsError>>;
 
   struct NodeState {
     std::shared_ptr<MetadataBlock> block;
@@ -39,7 +42,7 @@ class DirectoryItemsIterator {
   DirectoryItemsIterator operator++(int);
   bool operator==(const DirectoryItemsIterator& rhs) const;
   bool operator!=(const DirectoryItemsIterator& rhs) const;
-  std::shared_ptr<WfsItem> operator*();
+  value_type operator*();
 
  private:
   std::shared_ptr<const Directory> directory_;

--- a/include/wfslib/errors.h
+++ b/include/wfslib/errors.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <exception>
+#include <expected>
+
+enum WfsError {
+  kItemNotFound,
+  kNotDirectory,
+  kNotFile,
+  kBlockBadHash,
+  kAreaHeaderCorrupted,
+  kDirectoryCorrupted,
+  kFreeBlocksAllocatorCorrupted,
+  kFileDataCorrupted,
+  kFileMetadataCorrupted,
+};
+
+class WfsException : public std::exception {
+ public:
+  WfsException(WfsError error) : error_(error) {}
+  virtual char const* what() const noexcept override;
+
+ private:
+  WfsError error_;
+};
+
+template <typename T>
+T throw_if_error(std::expected<T, WfsError> res) {
+  if (!res.has_value())
+    throw WfsException(res.error());
+  return *res;
+}

--- a/include/wfslib/wfs_item.h
+++ b/include/wfslib/wfs_item.h
@@ -18,8 +18,6 @@ struct AttributesBlock {
   std::shared_ptr<MetadataBlock> block;
   size_t attributes_offset;
 
-  operator bool() const { return !!block; }
-
   ::Attributes* Attributes();
   const ::Attributes* Attributes() const;
 };
@@ -29,7 +27,6 @@ class WfsItem {
   WfsItem(const std::string& name, const AttributesBlock& block);
   virtual ~WfsItem() {}
   const std::string& GetName() const { return name_; }
-  std::string GetRealName() const;
   virtual bool IsDirectory() const;
   virtual bool IsFile() const;
   virtual bool IsLink() const;

--- a/src/area.h
+++ b/src/area.h
@@ -29,27 +29,28 @@ class Area : public std::enable_shared_from_this<Area> {
        const std::string& root_directory_name,
        const AttributesBlock& root_directory_attributes);
 
-  static std::shared_ptr<Area> LoadRootArea(const std::shared_ptr<DeviceEncryption>& device);
+  static std::expected<std::shared_ptr<Area>, WfsError> LoadRootArea(const std::shared_ptr<DeviceEncryption>& device);
 
-  std::shared_ptr<Area> GetArea(uint32_t block_number,
-                                const std::string& root_directory_name,
-                                const AttributesBlock& root_directory_attributes,
-                                Block::BlockSize size);
+  std::expected<std::shared_ptr<Area>, WfsError> GetArea(uint32_t block_number,
+                                                         const std::string& root_directory_name,
+                                                         const AttributesBlock& root_directory_attributes,
+                                                         Block::BlockSize size);
 
-  std::shared_ptr<Directory> GetRootDirectory();
+  std::expected<std::shared_ptr<Directory>, WfsError> GetRootDirectory();
 
-  std::shared_ptr<Directory> GetDirectory(uint32_t block_number,
-                                          const std::string& name,
-                                          const AttributesBlock& attributes);
+  std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(uint32_t block_number,
+                                                                   const std::string& name,
+                                                                   const AttributesBlock& attributes);
 
-  std::shared_ptr<MetadataBlock> GetMetadataBlock(uint32_t block_number) const;
-  std::shared_ptr<MetadataBlock> GetMetadataBlock(uint32_t block_number, Block::BlockSize size) const;
+  std::expected<std::shared_ptr<MetadataBlock>, WfsError> GetMetadataBlock(uint32_t block_number) const;
+  std::expected<std::shared_ptr<MetadataBlock>, WfsError> GetMetadataBlock(uint32_t block_number,
+                                                                           Block::BlockSize size) const;
 
-  std::shared_ptr<DataBlock> GetDataBlock(uint32_t block_number,
-                                          Block::BlockSize size,
-                                          uint32_t data_size,
-                                          const DataBlock::DataBlockHash& data_hash,
-                                          bool encrypted) const;
+  std::expected<std::shared_ptr<DataBlock>, WfsError> GetDataBlock(uint32_t block_number,
+                                                                   Block::BlockSize size,
+                                                                   uint32_t data_size,
+                                                                   const DataBlock::DataBlockHash& data_hash,
+                                                                   bool encrypted) const;
 
   uint32_t RelativeBlockNumber(uint32_t block_number) const;
   uint32_t AbsoluteBlockNumber(uint32_t block_number) const;
@@ -59,8 +60,8 @@ class Area : public std::enable_shared_from_this<Area> {
   uint32_t BlockNumber() const;
   uint32_t BlocksCount() const;
 
-  std::shared_ptr<const FreeBlocksAllocator> GetFreeBlocksAllocator() const;
-  std::shared_ptr<FreeBlocksAllocator> GetFreeBlocksAllocator();
+  std::expected<std::shared_ptr<const FreeBlocksAllocator>, WfsError> GetFreeBlocksAllocator() const;
+  std::expected<std::shared_ptr<FreeBlocksAllocator>, WfsError> GetFreeBlocksAllocator();
 
  private:
   static constexpr uint32_t FreeBlocksAllocatorBlockNumber = 1;

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -49,10 +49,9 @@ void Block::Resize(uint32_t data_size) {
   }
 }
 
-void Block::Fetch(bool check_hash) {
+bool Block::Fetch(bool check_hash) {
   device_->ReadBlock(ToDeviceSector(block_number_), data_, iv_, encrypted_);
-  if (check_hash && !device_->CheckHash(data_, as_const(this)->Hash()))
-    throw Block::BadHash(block_number_);
+  return !check_hash || device_->CheckHash(data_, as_const(this)->Hash());
 }
 
 void Block::Flush() {

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -7,16 +7,9 @@
 
 #include "block.h"
 
-#include <boost/format.hpp>
 #include "device.h"
 #include "device_encryption.h"
 #include "utils.h"
-
-Block::BadHash::BadHash(uint32_t block_number)
-    : block_number_(block_number), msg_((boost::format("Bad hash for block 0x%08X") % block_number_).str()) {}
-char const* Block::BadHash::what() const noexcept {
-  return msg_.c_str();
-}
 
 Block::Block(const std::shared_ptr<DeviceEncryption>& device,
              uint32_t block_number,

--- a/src/block.h
+++ b/src/block.h
@@ -9,7 +9,6 @@
 
 #include <memory>
 #include <span>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -51,16 +50,6 @@ class Block {
   Block::BlockSize log2_size() const { return size_category_; }
 
   bool encrypted() const { return encrypted_; }
-
-  class BadHash : public std::exception {
-   public:
-    BadHash(uint32_t block_number);
-    virtual char const* what() const noexcept override;
-
-   private:
-    uint32_t block_number_;
-    std::string msg_;
-  };
 
   virtual void Resize(uint32_t data_size);
 

--- a/src/block.h
+++ b/src/block.h
@@ -24,7 +24,7 @@ class Block {
     MegaRegular = 16,
   };
 
-  void Fetch(bool check_hash = true);
+  bool Fetch(bool check_hash = true);
   void Flush();
 
   // Actual used size, always equal to capacity in metadata blocks.

--- a/src/data_block.h
+++ b/src/data_block.h
@@ -7,8 +7,11 @@
 
 #pragma once
 
+#include <expected>
 #include <memory>
+
 #include "block.h"
+#include "errors.h"
 
 class MetadataBlock;
 
@@ -28,13 +31,13 @@ class DataBlock : public Block {
             bool encrypted);
   ~DataBlock() override;
 
-  static std::shared_ptr<DataBlock> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
-                                              uint32_t block_number,
-                                              Block::BlockSize size_category,
-                                              uint32_t data_size,
-                                              uint32_t iv,
-                                              const DataBlockHash& data_hash,
-                                              bool encrypted);
+  static std::expected<std::shared_ptr<DataBlock>, WfsError> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
+                                                                       uint32_t block_number,
+                                                                       Block::BlockSize size_category,
+                                                                       uint32_t data_size,
+                                                                       uint32_t iv,
+                                                                       const DataBlockHash& data_hash,
+                                                                       bool encrypted);
 
  protected:
   std::span<std::byte> Hash() override;

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -7,6 +7,8 @@
 
 #include "directory.h"
 
+#include <utility>
+
 #include "area.h"
 #include "file.h"
 #include "link.h"

--- a/src/directory_items_iterator.cpp
+++ b/src/directory_items_iterator.cpp
@@ -8,6 +8,8 @@
 #include "directory_items_iterator.h"
 
 #include <stdexcept>
+#include <utility>
+
 #include "area.h"
 #include "directory.h"
 #include "metadata_block.h"

--- a/src/directory_items_iterator.cpp
+++ b/src/directory_items_iterator.cpp
@@ -55,11 +55,13 @@ DirectoryItemsIterator& DirectoryItemsIterator::operator++() {
     // This is just internal node (in the directories trees tree), it just point to another tree
     auto block = directory_->area()->GetMetadataBlock(
         static_cast<const InternalDirectoryTreeNode*>(node_state_->node)->get_next_allocator_block_number().value());
-    DirectoryTree dir_tree{block};
+    if (!block.has_value())
+      throw WfsException(WfsError::kDirectoryCorrupted);
+    DirectoryTree dir_tree{*block};
     auto current_node =
-        as_const(block.get())->get_object<DirectoryTreeNode>(std::as_const(dir_tree).extra_header()->root.value());
+        as_const(block->get())->get_object<DirectoryTreeNode>(std::as_const(dir_tree).extra_header()->root.value());
     node_state_ =
-        std::make_shared<NodeState>(NodeState{block, current_node, std::move(node_state_), 0, current_node->prefix()});
+        std::make_shared<NodeState>(NodeState{*block, current_node, std::move(node_state_), 0, current_node->prefix()});
     // -- because it will be advanced immedialty to 0 when we do ++
     --node_state_->current_index;
     // Go to the first node in this directory block
@@ -87,15 +89,16 @@ bool DirectoryItemsIterator::operator!=(const DirectoryItemsIterator& rhs) const
   return !operator==(rhs);
 }
 
-std::shared_ptr<WfsItem> DirectoryItemsIterator::operator*() {
+DirectoryItemsIterator::value_type DirectoryItemsIterator::operator*() {
   if (!node_state_)
-    return nullptr;
+    return {{}, nullptr};
   if (node_state_->block->Header()->block_flags.value() &
       node_state_->block->Header()->Flags::EXTERNAL_DIRECTORY_TREE) {
     auto block = node_state_->block;
     auto external_node = static_cast<const ExternalDirectoryTreeNode*>(node_state_->node);
-    return directory_->Create(node_state_->path,
-                              AttributesBlock{block, external_node->get_item(node_state_->current_index).value()});
+    const AttributesBlock attributes{block, external_node->get_item(node_state_->current_index).value()};
+    auto name = attributes.Attributes()->GetCaseSensitiveName(node_state_->path);
+    return {name, directory_->GetObjectInternal(name, attributes)};
   } else {
     // Should not happen (can't happen, the iterator should stop only at external trees)
     throw std::logic_error("Should not happen!");

--- a/src/directory_items_iterator.cpp
+++ b/src/directory_items_iterator.cpp
@@ -93,7 +93,7 @@ bool DirectoryItemsIterator::operator!=(const DirectoryItemsIterator& rhs) const
 
 DirectoryItemsIterator::value_type DirectoryItemsIterator::operator*() {
   if (!node_state_)
-    return {{}, nullptr};
+    throw std::runtime_error("Out of bounds");
   if (node_state_->block->Header()->block_flags.value() &
       node_state_->block->Header()->Flags::EXTERNAL_DIRECTORY_TREE) {
     auto block = node_state_->block;

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "errors.h"
+
+char const* WfsException::what() const noexcept {
+  switch (error_) {
+    case WfsError::kItemNotFound:
+      return "Item not found";
+    case WfsError::kNotDirectory:
+      return "Not a directory";
+    case WfsError::kNotFile:
+      return "Not a file";
+    case WfsError::kBlockBadHash:
+      return "Block bad hash";
+    case WfsError::kAreaHeaderCorrupted:
+      return "Area header corrupted";
+    case WfsError::kDirectoryCorrupted:
+      return "Directory corrupted";
+  }
+  return "";
+}

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -21,6 +21,12 @@ char const* WfsException::what() const noexcept {
       return "Area header corrupted";
     case WfsError::kDirectoryCorrupted:
       return "Directory corrupted";
+    case WfsError::kFreeBlocksAllocatorCorrupted:
+      return "Free blocks allocator corrupted";
+    case WfsError::kFileDataCorrupted:
+      return "File data corrupted";
+    case WfsError::kFileMetadataCorrupted:
+      return "File metadata corrupted";
   }
   return "";
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<File::DataCategoryReader> File::CreateReader(const std::shared_p
     case 4:
       return std::make_shared<DataCategory4Reader>(file);
     default:
-      throw std::runtime_error("Unexpected file category");
+      throw std::runtime_error("Unexpected file category");  // TODO: Change to WfsError
   }
 }
 

--- a/src/free_blocks_allocator.cpp
+++ b/src/free_blocks_allocator.cpp
@@ -7,7 +7,5 @@
 
 #include "free_blocks_allocator.h"
 
-FreeBlocksAllocator::FreeBlocksAllocator(std::shared_ptr<const Area> area, uint32_t block_number)
-    : area_(area), tree_{Adapter{area}, block_number} {
-  root_block_ = area_->GetMetadataBlock(block_number);
-}
+FreeBlocksAllocator::FreeBlocksAllocator(std::shared_ptr<const Area> area, std::shared_ptr<MetadataBlock> root_block)
+    : area_(area), tree_{Adapter{area}, root_block->BlockNumber()}, root_block_(std::move(root_block)) {}

--- a/src/free_blocks_allocator.h
+++ b/src/free_blocks_allocator.h
@@ -5,6 +5,8 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
+#pragma once
+
 #include "area.h"
 #include "free_blocks_allocator_tree.h"
 

--- a/src/metadata_block.h
+++ b/src/metadata_block.h
@@ -7,8 +7,11 @@
 
 #pragma once
 
+#include <expected>
 #include <memory>
+
 #include "block.h"
+#include "errors.h"
 #include "utils.h"
 
 struct MetadataBlockHeader;
@@ -31,11 +34,12 @@ class MetadataBlock : public Block {
                 uint32_t iv);
   ~MetadataBlock() override;
 
-  static std::shared_ptr<MetadataBlock> LoadBlock(const std::shared_ptr<DeviceEncryption>& device,
-                                                  uint32_t block_number,
-                                                  Block::BlockSize size_category,
-                                                  uint32_t iv,
-                                                  bool check_hash = true);
+  static std::expected<std::shared_ptr<MetadataBlock>, WfsError> LoadBlock(
+      const std::shared_ptr<DeviceEncryption>& device,
+      uint32_t block_number,
+      Block::BlockSize size_category,
+      uint32_t iv,
+      bool check_hash = true);
 
   MetadataBlockHeader* Header();
   const MetadataBlockHeader* Header() const;

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -18,6 +18,7 @@ size_t Attributes::DataOffset() const {
 std::string Attributes::GetCaseSensitiveName(const std::string& name) const {
   std::string real_filename = "";
   if (filename_length.value() != name.size()) {
+    // TODO: return WfsError
     throw std::runtime_error("Unexepected filename length");
   }
   boost::dynamic_bitset<uint8_t> bits(name.size());

--- a/src/structs.h
+++ b/src/structs.h
@@ -85,6 +85,8 @@ struct Attributes {
   bool IsLink() const { return !!(flags.value() & Flags::LINK); }
 
   size_t DataOffset() const;
+
+  std::string GetCaseSensitiveName(const std::string& name) const;
 };
 static_assert(sizeof(Attributes) == 0x2C, "Incorrect sizeof Attributes");
 

--- a/src/wfs.cpp
+++ b/src/wfs.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<WfsItem> Wfs::GetObject(const std::string& filename) {
   std::filesystem::path path(filename);
   auto dir = GetDirectory(path.parent_path().string());
   if (!dir)
-    throw nullptr;
+    return nullptr;
   auto obj = dir->GetObject(path.filename().string());
   if (!obj.has_value()) {
     if (obj.error() == WfsError::kItemNotFound)
@@ -47,7 +47,7 @@ std::shared_ptr<File> Wfs::GetFile(const std::string& filename) {
   std::filesystem::path path(filename);
   auto dir = GetDirectory(path.parent_path().string());
   if (!dir)
-    throw nullptr;
+    return nullptr;
   auto file = dir->GetFile(path.filename().string());
   if (!file.has_value()) {
     if (file.error() == WfsError::kItemNotFound)

--- a/src/wfs.cpp
+++ b/src/wfs.cpp
@@ -19,7 +19,7 @@
 Wfs::Wfs(const std::shared_ptr<Device>& device, const std::span<std::byte>& key)
     : device_(std::make_shared<DeviceEncryption>(device, key)) {
   // Read first area
-  root_area_ = Area::LoadRootArea(device_);
+  root_area_ = throw_if_error(Area::LoadRootArea(device_));
 }
 
 Wfs::~Wfs() {
@@ -32,31 +32,55 @@ std::shared_ptr<WfsItem> Wfs::GetObject(const std::string& filename) {
   std::filesystem::path path(filename);
   auto dir = GetDirectory(path.parent_path().string());
   if (!dir)
-    return nullptr;
-  return dir->GetObject(path.filename().string());
+    throw nullptr;
+  auto obj = dir->GetObject(path.filename().string());
+  if (!obj.has_value()) {
+    if (obj.error() == WfsError::kItemNotFound)
+      return nullptr;
+    else
+      throw WfsException(obj.error());
+  }
+  return *obj;
 }
 
 std::shared_ptr<File> Wfs::GetFile(const std::string& filename) {
   std::filesystem::path path(filename);
   auto dir = GetDirectory(path.parent_path().string());
   if (!dir)
-    return nullptr;
-  return dir->GetFile(path.filename().string());
+    throw nullptr;
+  auto file = dir->GetFile(path.filename().string());
+  if (!file.has_value()) {
+    if (file.error() == WfsError::kItemNotFound)
+      return nullptr;
+    else
+      throw WfsException(file.error());
+  }
+  return *file;
 }
 
 std::shared_ptr<Directory> Wfs::GetDirectory(const std::string& filename) {
   std::filesystem::path path(filename);
-  std::shared_ptr<Directory> current_directory = root_area_->GetRootDirectory();
+  auto current_directory = root_area_->GetRootDirectory();
+  if (!current_directory.has_value()) {
+    if (current_directory.error() == WfsError::kItemNotFound)
+      return nullptr;
+    else
+      throw WfsException(current_directory.error());
+  }
 
   for (const auto& part : path) {
     // the first part is "/"
     if (part == "/")
       continue;
-    current_directory = current_directory->GetDirectory(part.string());
-    if (!current_directory)
-      return current_directory;
+    current_directory = (*current_directory)->GetDirectory(part.string());
+    if (!current_directory.has_value()) {
+      if (current_directory.error() == WfsError::kItemNotFound)
+        return nullptr;
+      else
+        throw WfsException(current_directory.error());
+    }
   }
-  return current_directory;
+  return *current_directory;
 }
 
 void Wfs::Flush() {
@@ -76,7 +100,7 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
   device->SetLog2SectorSize(9);
   auto enc_device = std::make_shared<DeviceEncryption>(device, key);
   std::shared_ptr<const MetadataBlock> block =
-      MetadataBlock::LoadBlock(enc_device, 0, Block::BlockSize::Basic, 0, false);
+      *MetadataBlock::LoadBlock(enc_device, 0, Block::BlockSize::Basic, 0, false);
   auto wfs_header = reinterpret_cast<const WfsHeader*>(&block->data()[sizeof(MetadataBlockHeader)]);
   if (wfs_header->version.value() != 0x01010800)
     throw std::runtime_error("Unexpected WFS version (bad key?)");
@@ -86,7 +110,7 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
     block_size = Block::BlockSize::Regular;
   block.reset();
   // Now lets read it again, this time with the correct block size
-  block = MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, false);
+  block = *MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, false);
   uint32_t xored_sectors_count, xored_sector_size;
   // The two last dwords of the IV is the sectors count and sector size, right now it is xored with our fake sector size
   // and sector count, and with the hash
@@ -110,9 +134,6 @@ void Wfs::DetectDeviceSectorSizeAndCount(const std::shared_ptr<FileDevice>& devi
   device->SetSectorsCount(xored_sectors_count);
   block.reset();
   // Now try to fetch block again, this time check the hash, it will raise exception
-  try {
-    block = MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, true);
-  } catch (const Block::BadHash&) {
+  if (!MetadataBlock::LoadBlock(enc_device, 0, block_size, 0, true).has_value())
     throw std::runtime_error("Wfs: Failed to detect sector size and sectors count");
-  }
 }

--- a/src/wfs_item.cpp
+++ b/src/wfs_item.cpp
@@ -7,9 +7,7 @@
 
 #include "wfs_item.h"
 
-#include <boost/dynamic_bitset.hpp>
 #include <cctype>
-#include <ranges>
 #include "metadata_block.h"
 #include "structs.h"
 #include "utils.h"
@@ -37,19 +35,4 @@ bool WfsItem::IsFile() const {
 bool WfsItem::IsLink() const {
   auto attributes = attributes_data().Attributes();
   return attributes->IsLink();
-}
-
-std::string WfsItem::GetRealName() const {
-  auto attributes = attributes_data().Attributes();
-  std::string real_filename = "";
-  if (attributes->filename_length.value() != name_.size()) {
-    throw std::runtime_error("Unexepected filename length");
-  }
-  boost::dynamic_bitset<uint8_t> bits(name_.size());
-  boost::from_block_range(reinterpret_cast<const uint8_t*>(&attributes->case_bitmap),
-                          reinterpret_cast<const uint8_t*>(&attributes->case_bitmap) + (name_.size() / 8), bits);
-  std::string real_name;
-  std::ranges::transform(std::ranges::iota_view(0ull, name_.size()), std::back_inserter(real_name),
-                         [&](auto i) { return bits[i] ? std::toupper(name_[i]) : name_[i]; });
-  return real_name;
 }

--- a/src/wfs_item.cpp
+++ b/src/wfs_item.cpp
@@ -7,7 +7,6 @@
 
 #include "wfs_item.h"
 
-#include <cctype>
 #include "metadata_block.h"
 #include "structs.h"
 #include "utils.h"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -4,7 +4,6 @@
   "dependencies": [
     "boost-dynamic-bitset",
     "boost-endian",
-    "boost-format",
     "boost-iostreams",
     "cryptopp"
   ]


### PR DESCRIPTION
Use std::expected instead of throwing an exception , allows much better error handling in the tools.
Still throw an exception when no other option (like during iterator)

Also made the API for retrieving files case-insensitive.

And upgrade the project to C++23 for std::expected