### PR TITLE
Simplify and refactor free blocks tree iterator

### DIFF
--- a/src/eptree.h
+++ b/src/eptree.h
@@ -14,36 +14,29 @@
 #include "free_blocks_allocator.h"
 #include "rtree.h"
 
-class EPTreeConstIterator {
+class EPTreeIterator {
  public:
   using iterator_category = std::bidirectional_iterator_tag;
   using difference_type = int;
   using value_type = RTree::iterator::value_type;
 
-  using const_reference = RTree::iterator::const_reference;
-  using const_pointer = RTree::iterator::const_pointer;
-
-  using reference = RTree::const_iterator::reference;
-  using pointer = RTree::const_iterator::const_pointer;
+  using reference = RTree::iterator::reference;
 
   using node_info = node_iterator_info<RTree>;
 
-  EPTreeConstIterator() = default;
+  EPTreeIterator() = default;
 
-  EPTreeConstIterator(FreeBlocksAllocator* allocator, std::vector<node_info> nodes)
+  EPTreeIterator(FreeBlocksAllocator* allocator, std::vector<node_info> nodes)
       : allocator_(allocator), nodes_(std::move(nodes)) {}
 
   reference operator*() const { return *nodes_.back().iterator; }
-  pointer operator->() const& { return nodes_.back().iterator.operator->(); }
 
-  EPTreeConstIterator& operator++();
-  EPTreeConstIterator& operator--();
-  EPTreeConstIterator operator++(int);
-  EPTreeConstIterator operator--(int);
+  EPTreeIterator& operator++();
+  EPTreeIterator& operator--();
+  EPTreeIterator operator++(int);
+  EPTreeIterator operator--(int);
 
-  bool operator==(const EPTreeConstIterator& other) const {
-    return nodes_.back().iterator == other.nodes_.back().iterator;
-  }
+  bool operator==(const EPTreeIterator& other) const { return nodes_.back().iterator == other.nodes_.back().iterator; }
 
   std::vector<node_info>& nodes() { return nodes_; };
   const std::vector<node_info>& nodes() const { return nodes_; };
@@ -58,67 +51,24 @@ class EPTreeConstIterator {
 
   std::vector<node_info> nodes_;
 };
-static_assert(std::bidirectional_iterator<EPTreeConstIterator>);
-
-class EPTreeIterator : public EPTreeConstIterator {
- public:
-  using base = EPTreeConstIterator;
-
-  using iterator_category = std::bidirectional_iterator_tag;
-  using difference_type = base::difference_type;
-  using value_type = base::value_type;
-
-  using reference = RTree::iterator::reference;
-  using pointer = RTree::iterator::pointer;
-
-  using node_info = base::node_info;
-
-  EPTreeIterator() = default;
-
-  EPTreeIterator(FreeBlocksAllocator* allocator, std::vector<node_info> nodes) : base(allocator, std::move(nodes)) {}
-
-  reference operator*() const { return *nodes().back().iterator; }
-  pointer operator->() const& { return nodes().back().iterator.operator->(); }
-
-  EPTreeIterator& operator++();
-  EPTreeIterator& operator--();
-  EPTreeIterator operator++(int);
-  EPTreeIterator operator--(int);
-
-  bool operator==(const EPTreeIterator& other) const { return base::operator==(other); }
-};
 static_assert(std::bidirectional_iterator<EPTreeIterator>);
 
 class EPTree : public EPTreeBlock {
  public:
   using iterator = EPTreeIterator;
-  using const_iterator = EPTreeConstIterator;
-  using reverse_iterator = TreeReverseIterator<iterator>;
-  using const_reverse_iterator = TreeReverseIterator<const_iterator>;
 
   EPTree(FreeBlocksAllocator* allocator) : EPTreeBlock(allocator->root_block()), allocator_(allocator) {}
 
   void Init(uint32_t block_number);
 
-  iterator begin() { return begin_impl(); }
-  iterator end() { return end_impl(); }
-  const_iterator begin() const { return begin_impl(); }
-  const_iterator end() const { return end_impl(); }
+  iterator begin() const;
+  iterator end() const;
 
-  reverse_iterator rbegin() { return reverse_iterator{end()}; }
-  reverse_iterator rend() { return reverse_iterator{begin()}; }
-  const_reverse_iterator rbegin() const { return const_reverse_iterator{end()}; }
-  const_reverse_iterator rend() const { return const_reverse_iterator{begin()}; }
-
-  const_iterator cbegin() const { return begin(); }
-  const_iterator cend() const { return end(); }
-
-  iterator find(key_type key, bool exact_match = true) { return find_impl(key, exact_match); }
-  const_iterator find(key_type key, bool exact_match = true) const { return find_impl(key, exact_match); }
+  iterator find(key_type key, bool exact_match = true) const;
 
   bool insert(const iterator::value_type& key_value);
-  bool insert(const RTree::const_iterator& it_start, const RTree::const_iterator& it_end);
-  void erase(const const_iterator& pos, std::vector<FreeBlocksRangeInfo>& blocks_to_delete);
+  bool insert(const RTree::iterator& it_start, const RTree::iterator& it_end);
+  void erase(const iterator& pos, std::vector<FreeBlocksRangeInfo>& blocks_to_delete);
   bool erase(key_type key, std::vector<FreeBlocksRangeInfo>& blocks_to_delete);
 
  private:
@@ -130,3 +80,4 @@ class EPTree : public EPTreeBlock {
 
   FreeBlocksAllocator* allocator_;
 };
+static_assert(std::ranges::bidirectional_range<EPTree>);

--- a/src/free_blocks_tree.h
+++ b/src/free_blocks_tree.h
@@ -14,7 +14,7 @@
 #include "ftrees.h"
 #include "tree_utils.h"
 
-class FreeBlocksTreeConstIterator {
+class FreeBlocksTreeIterator {
  public:
   using iterator_category = std::bidirectional_iterator_tag;
   using difference_type = int;
@@ -22,29 +22,24 @@ class FreeBlocksTreeConstIterator {
   using value_type = typename FTrees::iterator::value_type;
   using ref_type = typename FTrees::iterator::ref_type;
 
-  using const_reference = value_type;
-  using const_pointer = ref_type*;
-
-  using reference = const_reference;
-  using pointer = const_pointer;
+  using reference = value_type;
 
   using eptree_node_info = node_iterator_info<EPTree>;
   using ftrees_node_info = node_iterator_info<FTrees>;
 
-  FreeBlocksTreeConstIterator() = default;
-  FreeBlocksTreeConstIterator(FreeBlocksAllocator* allocator, eptree_node_info eptree, ftrees_node_info ftrees)
+  FreeBlocksTreeIterator() = default;
+  FreeBlocksTreeIterator(FreeBlocksAllocator* allocator, eptree_node_info eptree, ftrees_node_info ftrees)
       : allocator_(allocator), eptree_(std::move(eptree)), ftrees_(std::move(ftrees)) {}
 
-  reference operator*() const { return *operator->(); }
-  pointer operator->() const& { return reinterpret_cast<pointer>(ftrees_.iterator.operator->()); }
+  reference operator*() const { return *ftrees_.iterator; }
 
-  FreeBlocksTreeConstIterator& operator++();
-  FreeBlocksTreeConstIterator& operator--();
+  FreeBlocksTreeIterator& operator++();
+  FreeBlocksTreeIterator& operator--();
 
-  FreeBlocksTreeConstIterator operator++(int);
-  FreeBlocksTreeConstIterator operator--(int);
+  FreeBlocksTreeIterator operator++(int);
+  FreeBlocksTreeIterator operator--(int);
 
-  bool operator==(const FreeBlocksTreeConstIterator& other) const { return ftrees_.iterator == other.ftrees_.iterator; }
+  bool operator==(const FreeBlocksTreeIterator& other) const { return ftrees_.iterator == other.ftrees_.iterator; }
 
   eptree_node_info& eptree() { return eptree_; }
   const eptree_node_info& eptree() const { return eptree_; }
@@ -60,69 +55,20 @@ class FreeBlocksTreeConstIterator {
   eptree_node_info eptree_;
   ftrees_node_info ftrees_;
 };
-
-class FreeBlocksTreeIterator : public FreeBlocksTreeConstIterator {
- public:
-  using iterator_category = std::bidirectional_iterator_tag;
-  using difference_type = FreeBlocksTreeConstIterator::difference_type;
-
-  using value_type = FreeBlocksTreeConstIterator::value_type;
-  using ref_type = FreeBlocksTreeConstIterator::ref_type;
-
-  using reference = ref_type;
-  using pointer = ref_type*;
-
-  using eptree_node_info = FreeBlocksTreeConstIterator::eptree_node_info;
-  using ftrees_node_info = FreeBlocksTreeConstIterator::ftrees_node_info;
-
-  FreeBlocksTreeIterator() = default;
-  FreeBlocksTreeIterator(FreeBlocksAllocator* allocator, eptree_node_info eptree, ftrees_node_info ftrees)
-      : FreeBlocksTreeConstIterator(allocator, std::move(eptree), std::move(ftrees)) {}
-
-  reference operator*() const { return *operator->(); }
-  pointer operator->() const& { return const_cast<pointer>(FreeBlocksTreeConstIterator::operator->()); }
-
-  FreeBlocksTreeIterator& operator++();
-  FreeBlocksTreeIterator& operator--();
-
-  FreeBlocksTreeIterator operator++(int);
-  FreeBlocksTreeIterator operator--(int);
-
-  bool operator==(const FreeBlocksTreeIterator& other) const { return FreeBlocksTreeConstIterator::operator==(other); }
-};
-
-static_assert(std::bidirectional_iterator<FreeBlocksTreeConstIterator>);
 static_assert(std::bidirectional_iterator<FreeBlocksTreeIterator>);
 
 class FreeBlocksTree {
  public:
-  using iterator = FreeBlocksTreeConstIterator;
-  using const_iterator = FreeBlocksTreeConstIterator;
-  using reverse_iterator = TreeReverseIterator<iterator>;
-  using const_reverse_iterator = TreeReverseIterator<const_iterator>;
+  using iterator = FreeBlocksTreeIterator;
 
   FreeBlocksTree(FreeBlocksAllocator* allocator) : allocator_(allocator) {}
 
-  iterator begin() { return begin_impl(); }
-  iterator end() { return end_impl(); }
-  const_iterator begin() const { return begin_impl(); }
-  const_iterator end() const { return end_impl(); }
+  iterator begin() const;
+  iterator end() const;
 
-  reverse_iterator rbegin() { return reverse_iterator{end()}; }
-  reverse_iterator rend() { return reverse_iterator{begin()}; }
-  const_reverse_iterator rbegin() const { return const_reverse_iterator{end()}; }
-  const_reverse_iterator rend() const { return const_reverse_iterator{begin()}; }
-
-  const_iterator cbegin() const { return begin(); }
-  const_iterator cend() const { return end(); }
-
-  iterator find(key_type key, bool exact_match = true) { return find_impl(key, exact_match); }
-  const_iterator find(key_type key, bool exact_match = true) const { return find_impl(key, exact_match); }
+  iterator find(key_type key, bool exact_match = true) const;
 
  private:
-  iterator begin_impl() const;
-  iterator end_impl() const;
-  iterator find_impl(key_type key, bool exact_match = true) const;
-
   FreeBlocksAllocator* allocator_;
 };
+static_assert(std::ranges::bidirectional_range<FreeBlocksTree>);

--- a/src/free_blocks_tree_bucket.h
+++ b/src/free_blocks_tree_bucket.h
@@ -14,44 +14,37 @@
 #include "ftrees.h"
 #include "tree_utils.h"
 
-class FreeBlocksTreeBucketConstIterator {
+class FreeBlocksTreeBucketIterator {
  public:
   using iterator_category = std::bidirectional_iterator_tag;
   using difference_type = int;
 
-  using value_type = FTrees::const_iterator::value_type;
-  using ref_type = FTrees::const_iterator::ref_type;
+  using value_type = FTrees::iterator::value_type;
+  using ref_type = FTrees::iterator::ref_type;
 
-  using const_reference = FTrees::const_iterator::const_reference;
-  using const_pointer = FTrees::const_iterator::const_pointer;
-
-  using reference = const_reference;
-  using pointer = const_pointer;
+  using reference = FTrees::iterator::reference;
 
   using eptree_node_info = node_iterator_info<EPTree>;
   using ftree_node_info = node_iterator_info<FTree>;
 
-  FreeBlocksTreeBucketConstIterator() = default;
-  FreeBlocksTreeBucketConstIterator(FreeBlocksAllocator* allocator,
-                                    size_t block_size_index,
-                                    eptree_node_info eptree,
-                                    ftree_node_info ftree)
+  FreeBlocksTreeBucketIterator() = default;
+  FreeBlocksTreeBucketIterator(FreeBlocksAllocator* allocator,
+                               size_t block_size_index,
+                               eptree_node_info eptree,
+                               ftree_node_info ftree)
       : allocator_(allocator),
         block_size_index_(block_size_index),
         eptree_(std::move(eptree)),
         ftree_(std::move(ftree)) {}
 
-  reference operator*() const { return *operator->(); }
-  pointer operator->() const& { return reinterpret_cast<pointer>(ftree_.iterator.operator->()); }
+  reference operator*() const { return {(*ftree_.iterator)._base}; }
 
-  FreeBlocksTreeBucketConstIterator& operator++();
-  FreeBlocksTreeBucketConstIterator& operator--();
-  FreeBlocksTreeBucketConstIterator operator++(int);
-  FreeBlocksTreeBucketConstIterator operator--(int);
+  FreeBlocksTreeBucketIterator& operator++();
+  FreeBlocksTreeBucketIterator& operator--();
+  FreeBlocksTreeBucketIterator operator++(int);
+  FreeBlocksTreeBucketIterator operator--(int);
 
-  bool operator==(const FreeBlocksTreeBucketConstIterator& other) const {
-    return ftree_.iterator == other.ftree_.iterator;
-  }
+  bool operator==(const FreeBlocksTreeBucketIterator& other) const { return ftree_.iterator == other.ftree_.iterator; }
 
   size_t block_size_index() const { return block_size_index_; }
 
@@ -70,68 +63,19 @@ class FreeBlocksTreeBucketConstIterator {
   eptree_node_info eptree_;
   ftree_node_info ftree_;
 };
-static_assert(std::bidirectional_iterator<FreeBlocksTreeBucketConstIterator>);
-
-class FreeBlocksTreeBucketIterator : public FreeBlocksTreeBucketConstIterator {
- public:
-  using base = FreeBlocksTreeBucketConstIterator;
-
-  using iterator_category = std::bidirectional_iterator_tag;
-  using difference_type = base::difference_type;
-
-  using value_type = base::value_type;
-  using ref_type = base::ref_type;
-
-  using reference = ref_type;
-  using pointer = ref_type*;
-
-  using eptree_node_info = base::eptree_node_info;
-  using ftree_node_info = base::ftree_node_info;
-
-  FreeBlocksTreeBucketIterator() = default;
-  FreeBlocksTreeBucketIterator(FreeBlocksAllocator* allocator,
-                               size_t block_size_index,
-                               eptree_node_info eptree,
-                               ftree_node_info ftree)
-      : base(allocator, block_size_index, std::move(eptree), std::move(ftree)) {}
-
-  reference operator*() const { return *operator->(); }
-  pointer operator->() const& { return const_cast<pointer>(base::operator->()); }
-
-  FreeBlocksTreeBucketIterator& operator++();
-  FreeBlocksTreeBucketIterator& operator--();
-  FreeBlocksTreeBucketIterator operator++(int);
-  FreeBlocksTreeBucketIterator operator--(int);
-
-  bool operator==(const FreeBlocksTreeBucketIterator& other) const { return base::operator==(other); }
-};
 static_assert(std::bidirectional_iterator<FreeBlocksTreeBucketIterator>);
 
 class FreeBlocksTreeBucket {
  public:
   using iterator = FreeBlocksTreeBucketIterator;
-  using const_iterator = FreeBlocksTreeBucketConstIterator;
-  using reverse_iterator = TreeReverseIterator<iterator>;
-  using const_reverse_iterator = TreeReverseIterator<const_iterator>;
 
   FreeBlocksTreeBucket(FreeBlocksAllocator* allocator, size_t block_size_index)
       : allocator_(allocator), block_size_index_(block_size_index) {}
 
-  iterator begin() { return begin_impl(); }
-  iterator end() { return end_impl(); }
-  const_iterator begin() const { return begin_impl(); }
-  const_iterator end() const { return end_impl(); }
+  iterator begin() const;
+  iterator end() const;
 
-  reverse_iterator rbegin() { return reverse_iterator{end()}; }
-  reverse_iterator rend() { return reverse_iterator{begin()}; }
-  const_reverse_iterator rbegin() const { return const_reverse_iterator{end()}; }
-  const_reverse_iterator rend() const { return const_reverse_iterator{begin()}; }
-
-  const_iterator cbegin() const { return begin(); }
-  const_iterator cend() const { return end(); }
-
-  iterator find(key_type key, bool exact_match = true) { return find_impl(key, exact_match); }
-  const_iterator find(key_type key, bool exact_match = true) const { return find_impl(key, exact_match); }
+  iterator find(key_type key, bool exact_match = true) const;
 
   bool insert(FTree::iterator::value_type key_val);
   bool insert(iterator& pos, FTree::iterator::value_type key_val);
@@ -140,13 +84,10 @@ class FreeBlocksTreeBucket {
   bool erase(key_type key, std::vector<FreeBlocksRangeInfo>& blocks_to_delete);
 
  private:
-  iterator begin_impl() const;
-  iterator end_impl() const;
-  iterator find_impl(key_type key, bool exact_match = true) const;
-
   iterator find_for_insert(key_type key) const;
 
   FreeBlocksAllocator* allocator_;
 
   size_t block_size_index_;
 };
+static_assert(std::ranges::bidirectional_range<FreeBlocksTreeBucket>);

--- a/src/ftree.cpp
+++ b/src/ftree.cpp
@@ -8,10 +8,9 @@
 #include "ftree.h"
 
 template <>
-PTreeNode<FTreeLeaf_details>::const_iterator split_point(
-    const PTreeNode<FTreeLeaf_details>& node,
-    const typename PTreeNode<FTreeLeaf_details>::const_iterator& pos,
-    key_type& split_key) {
+PTreeNode<FTreeLeaf_details>::iterator split_point(const PTreeNode<FTreeLeaf_details>& node,
+                                                   const typename PTreeNode<FTreeLeaf_details>::iterator& pos,
+                                                   key_type& split_key) {
   assert(node.begin() <= pos && pos <= node.end());
   assert(node.full());
   auto res = pos;
@@ -30,6 +29,6 @@ PTreeNode<FTreeLeaf_details>::const_iterator split_point(
       res = node.begin() + 4;
       break;
   }
-  split_key = res->key;
+  split_key = (*res).key;
   return res;
 }

--- a/src/ftree.h
+++ b/src/ftree.h
@@ -14,10 +14,9 @@
 #include "tree_nodes_allocator.h"
 
 template <>
-PTreeNode<FTreeLeaf_details>::const_iterator split_point(
-    const PTreeNode<FTreeLeaf_details>& node,
-    const typename PTreeNode<FTreeLeaf_details>::const_iterator& pos,
-    key_type& split_key);
+PTreeNode<FTreeLeaf_details>::iterator split_point(const PTreeNode<FTreeLeaf_details>& node,
+                                                   const typename PTreeNode<FTreeLeaf_details>::iterator& pos,
+                                                   key_type& split_key);
 
 static_assert(sizeof(PTreeNode_details) == sizeof(FTreeLeaf_details));
 using FTreesBlockArgs = TreeNodesAllocatorArgs<FTreesBlockHeader, FTreesFooter, sizeof(PTreeNode_details)>;
@@ -39,3 +38,4 @@ class FTree : public PTree<PTreeNode_details, FTreeLeaf_details, FTreesBlockArgs
  private:
   size_t block_size_index_;
 };
+static_assert(std::ranges::bidirectional_range<FTree>);

--- a/src/ftrees.cpp
+++ b/src/ftrees.cpp
@@ -7,17 +7,17 @@
 
 #include "ftrees.h"
 
-FTreesConstIterator& FTreesConstIterator::operator++() {
+FTreesIterator& FTreesIterator::operator++() {
   assert(!is_end());
   if (is_forward_) {
     ++ftrees_[index_].iterator;
   } else {
     // Switch direction
-    key_type key = (*this)->key;
+    key_type key = (**this).key;
     reverse_end_.reset(index_);
     // todo: enumrate
     for (auto& ftree : ftrees_) {
-      while (!reverse_end_.test(ftree.node->index()) && !ftree.iterator.is_end() && (++ftree.iterator)->key < key) {
+      while (!reverse_end_.test(ftree.node->index()) && !ftree.iterator.is_end() && (*++ftree.iterator).key < key) {
       }
     }
     is_forward_ = true;
@@ -27,7 +27,7 @@ FTreesConstIterator& FTreesConstIterator::operator++() {
   return *this;
 }
 
-FTreesConstIterator& FTreesConstIterator::operator--() {
+FTreesIterator& FTreesIterator::operator--() {
   assert(!is_begin());
   if (!is_forward_) {
     if (!reverse_end_.test(index_)) {
@@ -35,14 +35,14 @@ FTreesConstIterator& FTreesConstIterator::operator--() {
     }
   } else {
     // Switch direction
-    key_type key = is_end() ? std::numeric_limits<key_type>::max() : (*this)->key;
+    key_type key = is_end() ? std::numeric_limits<key_type>::max() : (**this).key;
     for (auto& ftree : ftrees_) {
       if (ftree.iterator.is_begin()) {
-        if (ftree.iterator.is_end() || ftree.iterator->key >= key) {
+        if (ftree.iterator.is_end() || (*ftree.iterator).key >= key) {
           reverse_end_.set(ftree.node->index());
         }
       } else {
-        while (!ftree.iterator.is_begin() && (--ftree.iterator)->key > key) {
+        while (!ftree.iterator.is_begin() && (*--ftree.iterator).key > key) {
         }
       }
     }
@@ -52,36 +52,6 @@ FTreesConstIterator& FTreesConstIterator::operator--() {
   if (ftrees_[index_].iterator.is_begin()) {
     reverse_end_.set(index_);
   }
-  return *this;
-}
-
-FTreesConstIterator FTreesConstIterator::operator++(int) {
-  FTreesConstIterator tmp(*this);
-  ++(*this);
-  return tmp;
-}
-
-FTreesConstIterator FTreesConstIterator::operator--(int) {
-  FTreesConstIterator tmp(*this);
-  --(*this);
-  return tmp;
-}
-
-bool FTreesConstIterator::is_begin() const {
-  if (is_forward_) {
-    return std::ranges::all_of(ftrees_, [](const ftree_info& ftree) { return ftree.iterator.is_begin(); });
-  } else {
-    return reverse_end_.all();
-  }
-}
-
-FTreesIterator& FTreesIterator::operator++() {
-  FTreesConstIterator::operator++();
-  return *this;
-}
-
-FTreesIterator& FTreesIterator::operator--() {
-  FTreesConstIterator::operator--();
   return *this;
 }
 
@@ -97,15 +67,23 @@ FTreesIterator FTreesIterator::operator--(int) {
   return tmp;
 }
 
+bool FTreesIterator::is_begin() const {
+  if (is_forward_) {
+    return std::ranges::all_of(ftrees_, [](const ftree_info& ftree) { return ftree.iterator.is_begin(); });
+  } else {
+    return reverse_end_.all();
+  }
+}
+
 void FTrees::split(FTrees& left, FTrees& right, key_type& split_point_key) {
   // Find the ftree with most items
   auto max_ftree_it = std::ranges::max_element(ftrees_, [](const FTree& a, const FTree& b) {
     return a.header()->items_count.value() < b.header()->items_count.value();
   });
-  split_point_key = max_ftree_it->middle()->key;
+  split_point_key = (*max_ftree_it->middle()).key;
   for (auto [old_ftree, left_ftree, right_ftree] : std::views::zip(ftrees_, left.ftrees_, right.ftrees_)) {
     auto pos = old_ftree.find(split_point_key, false);
-    if (!pos.is_end() && pos->key < split_point_key)
+    if (!pos.is_end() && (*pos).key < split_point_key)
       ++pos;
     old_ftree.split_compact(left_ftree, right_ftree, pos);
   }
@@ -115,7 +93,7 @@ void FTrees::Init() {
   ftrees_[0].Init();
 }
 
-FTrees::iterator FTrees::begin_impl() const {
+FTrees::iterator FTrees::begin() const {
   std::array<typename iterator::ftree_info, kSizeBuckets.size()> ftrees_info;
   std::transform(ftrees_.begin(), ftrees_.end(), ftrees_info.begin(),
                  [](const FTree& cftree) -> typename iterator::ftree_info {
@@ -127,7 +105,7 @@ FTrees::iterator FTrees::begin_impl() const {
   return {std::move(ftrees_info), index};
 }
 
-FTrees::iterator FTrees::end_impl() const {
+FTrees::iterator FTrees::end() const {
   std::array<typename iterator::ftree_info, kSizeBuckets.size()> ftrees_info;
   std::transform(ftrees_.begin(), ftrees_.end(), ftrees_info.begin(),
                  [](const FTree& cftree) -> typename iterator::ftree_info {
@@ -137,7 +115,7 @@ FTrees::iterator FTrees::end_impl() const {
   return {std::move(ftrees_info), 0};
 }
 
-FTrees::iterator FTrees::find_impl(key_type key, bool exact_match) const {
+FTrees::iterator FTrees::find(key_type key, bool exact_match) const {
   std::array<typename iterator::ftree_info, kSizeBuckets.size()> ftrees_info;
   std::transform(ftrees_.begin(), ftrees_.end(), ftrees_info.begin(),
                  [key](const FTree& cftree) -> typename iterator::ftree_info {
@@ -146,12 +124,12 @@ FTrees::iterator FTrees::find_impl(key_type key, bool exact_match) const {
                  });
   size_t index = 0;
   if (exact_match && !std::ranges::any_of(ftrees_info, [key](const iterator::ftree_info& ftree) {
-        return !ftree.iterator.is_end() && ftree.iterator->key == key;
+        return !ftree.iterator.is_end() && (*ftree.iterator).key == key;
       })) {
-    return end_impl();
+    return end();
   }
   auto before_keys = ftrees_info | std::views::filter([key](const iterator::ftree_info& ftree) {
-                       return !ftree.iterator.is_end() && ftree.iterator->key <= key;
+                       return !ftree.iterator.is_end() && (*ftree.iterator).key <= key;
                      });
   if (!std::ranges::empty(before_keys)) {
     // take max key before or key
@@ -163,7 +141,7 @@ FTrees::iterator FTrees::find_impl(key_type key, bool exact_match) const {
     }
   } else {
     auto after_keys = ftrees_info | std::views::filter([key](const iterator::ftree_info& ftree) {
-                        return !ftree.iterator.is_end() && ftree.iterator->key > key;
+                        return !ftree.iterator.is_end() && (*ftree.iterator).key > key;
                       });
     if (!std::ranges::empty(after_keys)) {
       index = iterator::find_next_extent_index(after_keys, /*max=*/false);

--- a/src/ptree.cpp
+++ b/src/ptree.cpp
@@ -8,10 +8,9 @@
 #include "ptree.h"
 
 template <>
-PTreeNode<PTreeNode_details>::const_iterator split_point(
-    const PTreeNode<PTreeNode_details>& node,
-    const typename PTreeNode<PTreeNode_details>::const_iterator& pos,
-    key_type& split_key) {
+PTreeNode<PTreeNode_details>::iterator split_point(const PTreeNode<PTreeNode_details>& node,
+                                                   const typename PTreeNode<PTreeNode_details>::iterator& pos,
+                                                   key_type& split_key) {
   assert(node.begin() <= pos && pos <= node.end());
   assert(node.full());
   auto res = pos;
@@ -28,6 +27,6 @@ PTreeNode<PTreeNode_details>::const_iterator split_point(
       res = node.begin() + 4;
       break;
   }
-  split_key = res->key;
+  split_key = (*res).key;
   return res;
 }

--- a/src/rtree.cpp
+++ b/src/rtree.cpp
@@ -8,10 +8,9 @@
 #include "rtree.h"
 
 template <>
-PTreeNode<RTreeLeaf_details>::const_iterator split_point(
-    const PTreeNode<RTreeLeaf_details>& node,
-    const typename PTreeNode<RTreeLeaf_details>::const_iterator& pos,
-    key_type& split_key) {
+PTreeNode<RTreeLeaf_details>::iterator split_point(const PTreeNode<RTreeLeaf_details>& node,
+                                                   const typename PTreeNode<RTreeLeaf_details>::iterator& pos,
+                                                   key_type& split_key) {
   assert(node.begin() <= pos && pos <= node.end());
   assert(node.full());
   auto res = pos;
@@ -29,7 +28,7 @@ PTreeNode<RTreeLeaf_details>::const_iterator split_point(
       res = node.begin() + 3;
       break;
   }
-  split_key = res->key;
+  split_key = (*res).key;
   return res;
 }
 

--- a/src/rtree.h
+++ b/src/rtree.h
@@ -12,10 +12,9 @@
 #include "structs.h"
 
 template <>
-PTreeNode<RTreeLeaf_details>::const_iterator split_point(
-    const PTreeNode<RTreeLeaf_details>& node,
-    const typename PTreeNode<RTreeLeaf_details>::const_iterator& pos,
-    key_type& split_key);
+PTreeNode<RTreeLeaf_details>::iterator split_point(const PTreeNode<RTreeLeaf_details>& node,
+                                                   const typename PTreeNode<RTreeLeaf_details>::iterator& pos,
+                                                   key_type& split_key);
 
 static_assert(sizeof(PTreeNode_details) == sizeof(RTreeLeaf_details));
 using EPTreeBlockArgs = TreeNodesAllocatorArgs<FreeBlocksAllocatorHeader, EPTreeFooter, sizeof(PTreeNode_details)>;
@@ -31,3 +30,4 @@ class RTree : public PTree<PTreeNode_details, RTreeLeaf_details, EPTreeBlockArgs
 
   void Init(uint8_t depth, uint32_t block_number);
 };
+static_assert(std::ranges::bidirectional_range<RTree>);

--- a/tests/eptree_tests.cpp
+++ b/tests/eptree_tests.cpp
@@ -68,7 +68,7 @@ TEST_CASE("EPTreeTests") {
         })));
 
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(eptree.find(i, true)->key == i);
+      REQUIRE((*eptree.find(i, true)).key == i);
     }
   }
 
@@ -110,7 +110,7 @@ TEST_CASE("EPTreeTests") {
     auto it = eptree.begin();
     uint32_t steps = 0;
     while (it != eptree.end()) {
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
       ++it;
       ++steps;
     }
@@ -119,7 +119,7 @@ TEST_CASE("EPTreeTests") {
     while (it != eptree.begin()) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     REQUIRE(steps == 0);
     REQUIRE(it.is_begin());
@@ -127,13 +127,13 @@ TEST_CASE("EPTreeTests") {
     for (int i = 0; i < 40; ++i) {
       ++it;
       ++steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 20; ++i) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
-    REQUIRE(it->key == 20);
+    REQUIRE((*it).key == 20);
   }
 }

--- a/tests/free_blocks_tree_bucket_tests.cpp
+++ b/tests/free_blocks_tree_bucket_tests.cpp
@@ -48,7 +48,7 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
         })));
 
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(bucket.find(i, true)->key == i);
+      REQUIRE((*bucket.find(i, true)).key == i);
     }
   }
 
@@ -76,7 +76,7 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
         })));
 
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(bucket.find(i, true)->key == i);
+      REQUIRE((*bucket.find(i, true)).key == i);
     }
   }
 
@@ -145,8 +145,8 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     REQUIRE(ftree2.empty());
     REQUIRE(ftree3.empty());
     REQUIRE(bucket.find(150, false) != bucket.end());
-    REQUIRE(bucket.find(150, false)->key == 50);
-    REQUIRE(bucket.find(25, false)->key == 50);
+    REQUIRE((*bucket.find(150, false)).key == 50);
+    REQUIRE((*bucket.find(25, false)).key == 50);
     REQUIRE(
         std::ranges::equal(std::views::transform(bucket, [](const value_type& extent) -> int { return extent.key; }),
                            std::list<uint32_t>{50}));
@@ -158,8 +158,8 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     REQUIRE(ftree1.size() == 1);
     REQUIRE(ftree2.size() == 1);
     REQUIRE(ftree3.empty());
-    REQUIRE(bucket.find(150, false)->key == 50);
-    REQUIRE(bucket.find(250, false)->key == 160);
+    REQUIRE((*bucket.find(150, false)).key == 50);
+    REQUIRE((*bucket.find(250, false)).key == 160);
     REQUIRE(
         std::ranges::equal(std::views::transform(bucket, [](const value_type& extent) -> int { return extent.key; }),
                            std::list<uint32_t>{50, 160}));
@@ -173,9 +173,9 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     REQUIRE(ftree1.empty());
     REQUIRE(ftree2.size() == 1);
     REQUIRE(ftree3.empty());
-    REQUIRE(bucket.find(150, false)->key == 160);
-    REQUIRE(bucket.find(250, false)->key == 160);
-    REQUIRE(bucket.find(25, false)->key == 160);
+    REQUIRE((*bucket.find(150, false)).key == 160);
+    REQUIRE((*bucket.find(250, false)).key == 160);
+    REQUIRE((*bucket.find(25, false)).key == 160);
     REQUIRE(
         std::ranges::equal(std::views::transform(bucket, [](const value_type& extent) -> int { return extent.key; }),
                            std::list<uint32_t>{160}));
@@ -193,7 +193,7 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     auto it = bucket.begin();
     uint32_t steps = 0;
     while (it != bucket.end()) {
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
       ++it;
       ++steps;
     }
@@ -202,7 +202,7 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     while (it != bucket.begin()) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     REQUIRE(steps == 0);
     REQUIRE(it.is_begin());
@@ -210,13 +210,13 @@ TEST_CASE("FreeBlocksTreeBucketTests") {
     for (int i = 0; i < 40; ++i) {
       ++it;
       ++steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 20; ++i) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
-    REQUIRE(it->key == 20);
+    REQUIRE((*it).key == 20);
   }
 }

--- a/tests/free_blocks_tree_tests.cpp
+++ b/tests/free_blocks_tree_tests.cpp
@@ -49,7 +49,7 @@ TEST_CASE("FreeBlocksTreeTests") {
         })));
 
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(tree.find(i)->key == i);
+      REQUIRE((*tree.find(i)).key == i);
     }
   }
 
@@ -77,7 +77,7 @@ TEST_CASE("FreeBlocksTreeTests") {
         })));
 
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(tree.find(i)->key == i);
+      REQUIRE((*tree.find(i)).key == i);
     }
   }
 
@@ -147,8 +147,8 @@ TEST_CASE("FreeBlocksTreeTests") {
     REQUIRE(ftree2.empty());
     REQUIRE(ftree3.empty());
     REQUIRE(tree.find(150, false) != tree.end());
-    REQUIRE(tree.find(150, false)->key == 50);
-    REQUIRE(tree.find(25, false)->key == 50);
+    REQUIRE((*tree.find(150, false)).key == 50);
+    REQUIRE((*tree.find(25, false)).key == 50);
     REQUIRE(std::ranges::equal(std::views::transform(tree, [](const value_type& extent) -> int { return extent.key; }),
                                std::list<uint32_t>{50}));
     REQUIRE(std::ranges::equal(
@@ -159,8 +159,8 @@ TEST_CASE("FreeBlocksTreeTests") {
     REQUIRE(ftree1.size() == 1);
     REQUIRE(ftree2.size() == 1);
     REQUIRE(ftree3.empty());
-    REQUIRE(tree.find(150, false)->key == 50);
-    REQUIRE(tree.find(250, false)->key == 160);
+    REQUIRE((*tree.find(150, false)).key == 50);
+    REQUIRE((*tree.find(250, false)).key == 160);
     REQUIRE(std::ranges::equal(std::views::transform(tree, [](const value_type& extent) -> int { return extent.key; }),
                                std::list<uint32_t>{50, 160}));
     REQUIRE(std::ranges::equal(
@@ -173,9 +173,9 @@ TEST_CASE("FreeBlocksTreeTests") {
     REQUIRE(ftree1.empty());
     REQUIRE(ftree2.size() == 1);
     REQUIRE(ftree3.empty());
-    REQUIRE(tree.find(150, false)->key == 160);
-    REQUIRE(tree.find(250, false)->key == 160);
-    REQUIRE(tree.find(25, false)->key == 160);
+    REQUIRE((*tree.find(150, false)).key == 160);
+    REQUIRE((*tree.find(250, false)).key == 160);
+    REQUIRE((*tree.find(25, false)).key == 160);
     REQUIRE(std::ranges::equal(std::views::transform(tree, [](const value_type& extent) -> int { return extent.key; }),
                                std::list<uint32_t>{160}));
     REQUIRE(std::ranges::equal(
@@ -192,7 +192,7 @@ TEST_CASE("FreeBlocksTreeTests") {
     auto it = tree.begin();
     uint32_t steps = 0;
     while (it != tree.end()) {
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
       ++it;
       ++steps;
     }
@@ -201,7 +201,7 @@ TEST_CASE("FreeBlocksTreeTests") {
     while (it != tree.begin()) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     REQUIRE(steps == 0);
     REQUIRE(it.is_begin());
@@ -209,13 +209,13 @@ TEST_CASE("FreeBlocksTreeTests") {
     for (int i = 0; i < 40; ++i) {
       ++it;
       ++steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 20; ++i) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
-    REQUIRE(it->key == 20);
+    REQUIRE((*it).key == 20);
   }
 }

--- a/tests/ftree_tests.cpp
+++ b/tests/ftree_tests.cpp
@@ -96,8 +96,8 @@ TEST_CASE("FTreeTests") {
     REQUIRE(std::distance(ftree.begin(), ftree.end()) == kItemsCount);
     REQUIRE(std::ranges::equal(ftrees[0], ftree));
     for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftree.find(i)->key == i);
-      REQUIRE(ftree.find(i)->value == static_cast<nibble>(i % 16));
+      REQUIRE((*ftree.find(i)).key == i);
+      REQUIRE((*ftree.find(i)).value == static_cast<nibble>(i % 16));
     }
   }
 
@@ -110,7 +110,7 @@ TEST_CASE("FTreeTests") {
     auto it = ftrees[0].begin();
     uint32_t steps = 0;
     while (it != ftrees[0].end()) {
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
       ++it;
       ++steps;
     }
@@ -119,7 +119,7 @@ TEST_CASE("FTreeTests") {
     while (it != ftrees[0].begin()) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     REQUIRE(steps == 0);
     REQUIRE(it.is_begin());
@@ -127,23 +127,23 @@ TEST_CASE("FTreeTests") {
     for (int i = 0; i < 4; ++i) {
       ++it;
       ++steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 2; ++i) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 40; ++i) {
       ++it;
       ++steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 20; ++i) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
-    REQUIRE(it->key == 22);
+    REQUIRE((*it).key == 22);
   }
 }

--- a/tests/ftrees_tests.cpp
+++ b/tests/ftrees_tests.cpp
@@ -71,7 +71,7 @@ TEST_CASE("FTreesTests") {
     auto it = ftrees.begin();
     uint32_t steps = 0;
     while (it != ftrees.end()) {
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
       ++it;
       ++steps;
     }
@@ -80,21 +80,22 @@ TEST_CASE("FTreesTests") {
     while (it != ftrees.begin()) {
       --it;
       --steps;
-      REQUIRE(it->key == steps);
+      REQUIRE((*it).key == steps);
     }
     REQUIRE(steps == 0);
     REQUIRE(it.is_begin());
 
     for (int i = 0; i < 40; ++i) {
-      UNSCOPED_INFO(it->key);
       ++it;
+      ++steps;
+      REQUIRE((*it).key == steps);
     }
     for (int i = 0; i < 20; ++i) {
-      UNSCOPED_INFO(it->key);
       --it;
+      --steps;
+      REQUIRE((*it).key == steps);
     }
-    UNSCOPED_INFO(it->key);
-    REQUIRE(it->key == 20);
+    REQUIRE((*it).key == 20);
   }
 
   SECTION("check find") {
@@ -107,7 +108,7 @@ TEST_CASE("FTreesTests") {
     REQUIRE(it.is_end());
 
     it = ftrees.find(523, false);
-    REQUIRE(it->key == 522);
+    REQUIRE((*it).key == 522);
 
     REQUIRE(std::ranges::equal(
         std::views::transform(std::ranges::subrange(ftrees.begin(), it),
@@ -128,7 +129,7 @@ TEST_CASE("FTreesTests") {
             })));
 
     it = ftrees.find(840);
-    REQUIRE(it->key == 840);
+    REQUIRE((*it).key == 840);
 
     REQUIRE(std::ranges::equal(
         std::views::transform(std::ranges::subrange(ftrees.begin(), it),
@@ -148,10 +149,10 @@ TEST_CASE("FTreesTests") {
               return {i * 2, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
             })));
 
-    REQUIRE(ftrees.find(4, false)->key == 4);
-    REQUIRE(ftrees.find(6, false)->key == 6);
-    REQUIRE((++ftrees.find(4, false))->key == 6);
-    REQUIRE((++ftrees.find(14, false))->key == 16);
+    REQUIRE((*ftrees.find(4, false)).key == 4);
+    REQUIRE((*ftrees.find(6, false)).key == 6);
+    REQUIRE((*++ftrees.find(4, false)).key == 6);
+    REQUIRE((*++ftrees.find(14, false)).key == 16);
   }
 
   SECTION("test split") {

--- a/tests/rtree_tests.cpp
+++ b/tests/rtree_tests.cpp
@@ -151,7 +151,7 @@ TEST_CASE("RTreeTests") {
         })));
 
     for (uint32_t i = 0; i < index; ++i) {
-      REQUIRE(rtree.find(i, true)->key == i);
+      REQUIRE((*rtree.find(i, true)).key == i);
     }
   }
 


### PR DESCRIPTION
1. Remove `operator->` and the hacks to support it
2. Remove const and reverse iterators (we didn't actually used them)