### PR TITLE
Return block_size_log2 as uint8_t

### DIFF
--- a/src/area.h
+++ b/src/area.h
@@ -51,7 +51,7 @@ class Area {
     return area_blocks_count << (block_size_log2() - log2_size(BlockSize::Physical));
   }
 
-  size_t block_size_log2() const { return header()->block_size_log2.value(); }
+  uint8_t block_size_log2() const { return header()->block_size_log2.value(); }
   size_t block_size() const { return size_t{1} << block_size_log2(); }
 
   uint32_t physical_block_number() const { return header_block_->physical_block_number(); }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -40,8 +40,7 @@ class File::DataCategoryReader {
   virtual size_t GetMetadataSize() const = 0;
   virtual size_t GetMetadataItemsCount() const {
     return FileLayout::MetadataItemsCount(FileLayout::CategoryFromValue(file_->metadata()->size_category.value()),
-                                          file_->metadata()->size_on_disk.value(),
-                                          static_cast<uint8_t>(file_->quota()->block_size_log2()));
+                                          file_->metadata()->size_on_disk.value(), file_->quota()->block_size_log2());
   }
 
   virtual std::span<const std::byte> GetData(size_t offset, size_t size) = 0;
@@ -290,7 +289,7 @@ class File::DataCategory4Reader : public File::DataCategory3Reader {
   }
 
   size_t ClustersInBlock() const {
-    return FileLayout::ClustersPerClusterMetadataBlock(static_cast<uint8_t>(file_->quota()->block_size_log2()));
+    return FileLayout::ClustersPerClusterMetadataBlock(file_->quota()->block_size_log2());
   }
 };
 


### PR DESCRIPTION
Change `Area::block_size_log2()` to return `uint8_t` and remove redundant `uint8_t` casts at call sites.

Validation:
- Configured GCC 14 test build in `/tmp/wfslib-build-tests-gcc14`
- Built Debug tests
- Ran CTest: 22/22 passed