### PR TITLE
Refactor test structure

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,10 +5,7 @@ find_package(Catch2 CONFIG REQUIRED)
 
 enable_testing()
 
-add_executable(${PROJECT_NAME}
-  # Requirements: P2374R4 and P2164R9
-  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:directory_map_tests.cpp>
-  $<$<NOT:$<CXX_COMPILER_ID:Clang>>:directory_tree_tests.cpp>
+set(WFSLIB_BEHAVIOR_TEST_SOURCES
   eptree_tests.cpp
   file_layout_tests.cpp
   free_blocks_allocator_tests.cpp
@@ -19,10 +16,31 @@ add_executable(${PROJECT_NAME}
   rtree_tests.cpp
   sub_block_allocator_tests.cpp
   tree_nodes_allocator_tests.cpp
+)
+
+# Requirements: P2374R4 and P2164R9.
+if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  list(APPEND WFSLIB_BEHAVIOR_TEST_SOURCES
+    directory_map_tests.cpp
+    directory_tree_tests.cpp
+  )
+endif()
+
+set(WFSLIB_TEST_SUPPORT_SOURCES
   utils/test_area.cpp
   utils/test_block.cpp
   utils/test_blocks_device.cpp
   utils/test_free_blocks_allocator.cpp
+)
+
+add_executable(${PROJECT_NAME}
+  ${WFSLIB_BEHAVIOR_TEST_SOURCES}
+  ${WFSLIB_TEST_SUPPORT_SOURCES}
+)
+
+source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES
+  ${WFSLIB_BEHAVIOR_TEST_SOURCES}
+  ${WFSLIB_TEST_SUPPORT_SOURCES}
 )
 
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)

--- a/tests/directory_map_tests.cpp
+++ b/tests/directory_map_tests.cpp
@@ -8,15 +8,22 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <format>
+#include <memory>
 #include <ranges>
+#include <string>
+#include <vector>
 
 #include <wfslib/wfs_device.h>
 
 #include "directory_map.h"
 #include "free_blocks_allocator.h"
 #include "quota_area.h"
+#include "sub_block_allocator.h"
 
-#include "utils/test_blocks_device.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
 namespace {
@@ -34,231 +41,212 @@ class TestEntryMetadata {
   std::vector<std::byte> data_;
 };
 
-};  // namespace
+class DirectoryMapFixture : public MetadataBlockFixture {
+ public:
+  DirectoryMapFixture() { dir_tree.Init(); }
 
-TEST_CASE("DirectoryMapTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto wfs_device = *WfsDevice::Create(test_device);
-  auto root_block = *wfs_device->GetRootArea()->AllocMetadataBlock();
+  std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
+  std::shared_ptr<Block> root_block = *wfs_device->GetRootArea()->AllocMetadataBlock();
   DirectoryMap dir_tree{wfs_device->GetRootArea(), root_block};
-  dir_tree.Init();
+};
 
-  SECTION("Check empty tree size") {
-    REQUIRE(dir_tree.size() == 0);
+std::string EntryName(uint32_t index, int width = 5) {
+  return std::format("{:0{}}", index, width);
+}
+
+void InsertFixedSizeEntries(DirectoryMap& dir_tree, uint32_t entries_count, int width = 5) {
+  TestEntryMetadata metadata(6);
+  for (uint32_t i = 0; i < entries_count; ++i) {
+    metadata.data()->flags = i;
+    REQUIRE(dir_tree.insert(EntryName(i, width), metadata.data()));
+  }
+}
+
+void RequireEntriesInOrder(const DirectoryMap& dir_tree, uint32_t entries_count, int width = 5) {
+  REQUIRE(dir_tree.size() == entries_count);
+  REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == static_cast<int>(entries_count));
+  for (auto [index, entry] : std::views::enumerate(dir_tree)) {
+    auto i = static_cast<uint32_t>(index);
+    CHECK(entry.name == EntryName(i, width));
+    CHECK(entry.metadata.get()->flags.value() == i);
+  }
+}
+
+constexpr int kDirectoryMapStressEntries = 100000;
+
+}  // namespace
+
+TEST_CASE_METHOD(DirectoryMapFixture, "DirectoryMap is empty after initialization", "[directory-map][unit]") {
+  REQUIRE(dir_tree.size() == 0);
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture, "DirectoryMap inserts sorted entries", "[directory-map][stress]") {
+  InsertFixedSizeEntries(dir_tree, kDirectoryMapStressEntries);
+
+  RequireEntriesInOrder(dir_tree, kDirectoryMapStressEntries);
+  REQUIRE(std::ranges::equal(
+      std::views::transform(std::views::reverse(dir_tree),
+                            [](const auto& entry) -> int { return entry.metadata.get()->flags.value(); }),
+      std::views::reverse(std::views::iota(0, kDirectoryMapStressEntries))));
+
+  for (uint32_t i = 0; i < kDirectoryMapStressEntries; ++i) {
+    CAPTURE(i);
+    auto entry = dir_tree.find(EntryName(i));
+    REQUIRE(!entry.is_end());
+    CHECK((*entry).metadata.get()->flags.value() == i);
+    CHECK((*entry).name == EntryName(i));
+  }
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap frees inline metadata after removing two entries",
+                 "[directory-map][unit]") {
+  SubBlockAllocator<DirectoryTreeHeader> allocator{root_block};
+  auto free_bytes_1 = allocator.GetFreeBytes();
+  TestEntryMetadata metadata(6);
+  REQUIRE(dir_tree.insert("a", metadata.data()));
+  auto free_bytes_2 = allocator.GetFreeBytes();
+  CHECK(free_bytes_2 != free_bytes_1);
+  REQUIRE(dir_tree.insert("aa", metadata.data()));
+  CHECK(free_bytes_2 != allocator.GetFreeBytes());
+  REQUIRE(dir_tree.erase("aa"));
+  CHECK(free_bytes_2 == allocator.GetFreeBytes());
+  REQUIRE(dir_tree.erase("a"));
+  CHECK(free_bytes_1 == allocator.GetFreeBytes());
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture, "DirectoryMap inserts shuffled entries", "[directory-map][stress]") {
+  auto unsorted_keys = createShuffledKeysArray<kDirectoryMapStressEntries>();
+  TestEntryMetadata metadata(6);
+  for (auto i : unsorted_keys) {
+    metadata.data()->flags = i;
+    REQUIRE(dir_tree.insert(EntryName(i), metadata.data()));
   }
 
-  SECTION("insert entries sorted") {
-    const int kEntriesCount = 100000;
-    TestEntryMetadata metadata(6);
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      metadata.data()->flags = i;
-      REQUIRE(dir_tree.insert(std::format("{:05}", i), metadata.data()));
-    }
-    REQUIRE(dir_tree.size() == kEntriesCount);
-    REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == kEntriesCount);
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.name == std::format("{:05}", i));
-      CHECK(entry.metadata.get()->flags.value() == i);
-      CHECK(entry.metadata.get()->metadata_log2_size.value() == 6);
-    }
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(dir_tree),
-                              [](const auto& entry) -> int { return entry.metadata.get()->flags.value(); }),
-        std::views::reverse(std::views::iota(0, kEntriesCount))));
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      auto entry = dir_tree.find(std::format("{:05}", i));
-      REQUIRE(!entry.is_end());
-      CHECK((*entry).metadata.get()->flags.value() == i);
-      CHECK((*entry).name == std::format("{:05}", i));
-    }
+  RequireEntriesInOrder(dir_tree, kDirectoryMapStressEntries);
+  for (uint32_t i = 0; i < kDirectoryMapStressEntries; ++i) {
+    CAPTURE(i);
+    auto entry = dir_tree.find(EntryName(i));
+    REQUIRE(!entry.is_end());
+    CHECK((*entry).metadata.get()->flags.value() == i);
+    CHECK((*entry).name == EntryName(i));
+  }
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap preserves variable metadata sizes",
+                 "[directory-map][integration]") {
+  constexpr int kEntriesCount = 10000;
+  auto unsorted_keys = createShuffledKeysArray<kEntriesCount>();
+  for (auto i : unsorted_keys) {
+    TestEntryMetadata metadata((i % 5) + 6);
+    metadata.data()->flags = i;
+    REQUIRE(dir_tree.insert(EntryName(i, 4), metadata.data()));
   }
 
-  SECTION("insert and remove one two entries") {
-    SubBlockAllocator<DirectoryTreeHeader> allocator{root_block};
-    auto free_bytes_1 = allocator.GetFreeBytes();
-    TestEntryMetadata metadata(6);
-    REQUIRE(dir_tree.insert("a", metadata.data()));
-    auto free_bytes_2 = allocator.GetFreeBytes();
-    CHECK(free_bytes_2 != free_bytes_1);
-    REQUIRE(dir_tree.insert("aa", metadata.data()));
-    CHECK(free_bytes_2 != allocator.GetFreeBytes());
-    REQUIRE(dir_tree.erase("aa"));
-    CHECK(free_bytes_2 == allocator.GetFreeBytes());
-    REQUIRE(dir_tree.erase("a"));
-    CHECK(free_bytes_1 == allocator.GetFreeBytes());
+  REQUIRE(dir_tree.size() == kEntriesCount);
+  REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == kEntriesCount);
+  for (auto [index, entry] : std::views::enumerate(dir_tree)) {
+    auto i = static_cast<uint32_t>(index);
+    CHECK(entry.name == EntryName(i, 4));
+    CHECK(entry.metadata.get()->flags.value() == i);
+    CHECK(entry.metadata.get()->metadata_log2_size.value() == (i % 5) + 6);
+  }
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap removes shuffled entries and releases blocks",
+                 "[directory-map][stress]") {
+  auto free_blocks = (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count();
+  InsertFixedSizeEntries(dir_tree, kDirectoryMapStressEntries);
+  CHECK(free_blocks != (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+
+  auto unsorted_indexes = createShuffledKeysArray<kDirectoryMapStressEntries>();
+  auto middle = unsorted_indexes.begin() + kDirectoryMapStressEntries / 2;
+  for (auto i : std::ranges::subrange(unsorted_indexes.begin(), middle)) {
+    CAPTURE(i);
+    REQUIRE(dir_tree.erase(EntryName(i)));
   }
 
-  SECTION("insert entries unsorted") {
-    constexpr int kEntriesCount = 100000;
-    auto unsorted_keys = createShuffledKeysArray<kEntriesCount>();
-    TestEntryMetadata metadata(6);
-    for (auto i : unsorted_keys) {
-      metadata.data()->flags = i;
-      REQUIRE(dir_tree.insert(std::format("{:05}", i), metadata.data()));
-    }
-    REQUIRE(dir_tree.size() == kEntriesCount);
-    REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == kEntriesCount);
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.name == std::format("{:05}", i));
-      CHECK(entry.metadata.get()->flags.value() == i);
-      CHECK(entry.metadata.get()->metadata_log2_size.value() == 6);
-    }
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      auto entry = dir_tree.find(std::format("{:05}", i));
-      REQUIRE(!entry.is_end());
-      CHECK((*entry).metadata.get()->flags.value() == i);
-      CHECK((*entry).name == std::format("{:05}", i));
-    }
+  auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_indexes.end()));
+  std::ranges::sort(sorted_upper_half);
+  REQUIRE(std::ranges::equal(
+      std::views::transform(dir_tree, [](const auto& entry) -> int { return entry.metadata.get()->flags.value(); }),
+      sorted_upper_half));
+
+  for (auto i : std::ranges::subrange(middle, unsorted_indexes.end())) {
+    CAPTURE(i);
+    REQUIRE(dir_tree.erase(EntryName(i)));
   }
 
-  SECTION("insert entries unsorted different metadata size") {
-    constexpr int kEntriesCount = 10000;
-    auto unsorted_keys = createShuffledKeysArray<kEntriesCount>();
-    for (auto i : unsorted_keys) {
-      TestEntryMetadata metadata((i % 5) + 6);
-      metadata.data()->flags = i;
-      REQUIRE(dir_tree.insert(std::format("{:04}", i), metadata.data()));
-    }
-    REQUIRE(dir_tree.size() == kEntriesCount);
-    REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == kEntriesCount);
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.name == std::format("{:04}", i));
-      CHECK(entry.metadata.get()->flags.value() == i);
-      CHECK(entry.metadata.get()->metadata_log2_size.value() == (i % 5) + 6);
-    }
+  CHECK(dir_tree.size() == 0);
+  CHECK(dir_tree.begin() == dir_tree.end());
+  CHECK(free_blocks == (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap iterator walks forward and backward",
+                 "[directory-map][iterator][stress]") {
+  TestEntryMetadata metadata(6);
+  for (uint32_t i = 0; i < kDirectoryMapStressEntries; ++i) {
+    REQUIRE(dir_tree.insert(EntryName(i), metadata.data()));
   }
 
-  SECTION("remove entries randomly") {
-    constexpr int kEntriesCount = 100000;
-    auto free_blocks = (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count();
-    TestEntryMetadata metadata(6);
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      metadata.data()->flags = i;
-      REQUIRE(dir_tree.insert(std::format("{:05}", i), metadata.data()));
-    }
-    CHECK(free_blocks != (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+  auto it = dir_tree.begin();
+  uint32_t steps = 0;
+  while (it != dir_tree.end()) {
+    REQUIRE((*it).name == EntryName(steps));
+    ++it;
+    ++steps;
+  }
+  REQUIRE(steps == kDirectoryMapStressEntries);
+  REQUIRE(it.is_end());
+  while (it != dir_tree.begin()) {
+    --it;
+    --steps;
+    REQUIRE((*it).name == EntryName(steps));
+  }
+  REQUIRE(steps == 0);
+  REQUIRE(it.is_begin());
 
-    auto unsorted_indexes = createShuffledKeysArray<kEntriesCount>();
-    auto middle = unsorted_indexes.begin() + kEntriesCount / 2;
-    // Remove half the entries first
-    for (auto i : std::ranges::subrange(unsorted_indexes.begin(), middle)) {
-      REQUIRE(dir_tree.erase(std::format("{:05}", i)));
-    }
+  for (int i = 0; i < 40; ++i) {
+    ++it;
+    ++steps;
+    REQUIRE((*it).name == EntryName(steps));
+  }
+  for (int i = 0; i < 20; ++i) {
+    --it;
+    --steps;
+    REQUIRE((*it).name == EntryName(steps));
+  }
+  REQUIRE((*it).name == EntryName(20));
+}
 
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_indexes.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right entries were deleted
-    REQUIRE(std::ranges::equal(
-        std::views::transform(dir_tree, [](const auto& entry) -> int { return entry.metadata.get()->flags.value(); }),
-        sorted_upper_half));
-
-    // Remove the second half
-    for (auto i : std::ranges::subrange(middle, unsorted_indexes.end())) {
-      REQUIRE(dir_tree.erase(std::format("{:05}", i)));
-    }
-
-    // Should be empty
-    CHECK(dir_tree.size() == 0);
-    CHECK(dir_tree.begin() == dir_tree.end());
-    // Everything should have been released.
-    CHECK(free_blocks == (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap keeps remaining entries when erase must split instead of merge",
+                 "[directory-map][white-box]") {
+  TestEntryMetadata metadata(6);
+  for (uint32_t i = 0; i < 80; ++i) {
+    REQUIRE(dir_tree.insert(EntryName(10000 + i), metadata.data()));
+  }
+  for (uint32_t i = 0; i < 200; ++i) {
+    REQUIRE(dir_tree.insert(EntryName(11000 + i), metadata.data()));
   }
 
-  SECTION("remove entries randomly") {
-    constexpr int kEntriesCount = 100000;
-    auto free_blocks = (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count();
-    TestEntryMetadata metadata(6);
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      metadata.data()->flags = i;
-      REQUIRE(dir_tree.insert(std::format("{:05}", i), metadata.data()));
-    }
-    CHECK(free_blocks != (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
-
-    auto unsorted_indexes = createShuffledKeysArray<kEntriesCount>();
-    auto middle = unsorted_indexes.begin() + kEntriesCount / 2;
-    // Remove half the entries first
-    for (auto i : std::ranges::subrange(unsorted_indexes.begin(), middle)) {
-      REQUIRE(dir_tree.erase(std::format("{:05}", i)));
-    }
-
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_indexes.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right entries were deleted
-    REQUIRE(std::ranges::equal(
-        std::views::transform(dir_tree, [](const auto& entry) -> int { return entry.metadata.get()->flags.value(); }),
-        sorted_upper_half));
-
-    // Remove the second half
-    for (auto i : std::ranges::subrange(middle, unsorted_indexes.end())) {
-      REQUIRE(dir_tree.erase(std::format("{:05}", i)));
-    }
-
-    // Should be empty
-    CHECK(dir_tree.size() == 0);
-    CHECK(dir_tree.begin() == dir_tree.end());
-    // Everything should have been released.
-    CHECK(free_blocks == (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+  SubBlockAllocator<DirectoryTreeHeader> allocator{*wfs_device->GetRootArea()->LoadMetadataBlock(10)};
+  while (allocator.Alloc(8)) {
   }
 
-  SECTION("check backward/forward iterator") {
-    constexpr int kEntriesCount = 100000;
-    TestEntryMetadata metadata(6);
-    for (uint32_t i = 0; i < kEntriesCount; ++i) {
-      REQUIRE(dir_tree.insert(std::format("{:05}", i), metadata.data()));
-    }
-
-    auto it = dir_tree.begin();
-    uint32_t steps = 0;
-    while (it != dir_tree.end()) {
-      REQUIRE((*it).name == std::format("{:05}", steps));
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kEntriesCount);
-    REQUIRE(it.is_end());
-    while (it != dir_tree.begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).name == std::format("{:05}", steps));
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
-
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).name == std::format("{:05}", steps));
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).name == std::format("{:05}", steps));
-    }
-    REQUIRE((*it).name == std::format("{:05}", 20));
+  for (uint32_t i = 0; i < 200; ++i) {
+    REQUIRE(dir_tree.erase(EntryName(11000 + i)));
   }
-
-  SECTION("split tree during erase") {
-    TestEntryMetadata metadata(6);
-    for (uint32_t i = 0; i < 80; ++i) {
-      REQUIRE(dir_tree.insert(std::format("{:05}", 10000 + i), metadata.data()));
-    }
-    for (uint32_t i = 0; i < 200; ++i) {
-      REQUIRE(dir_tree.insert(std::format("{:05}", 11000 + i), metadata.data()));
-    }
-    SubBlockAllocator<DirectoryTreeHeader> allocator{*wfs_device->GetRootArea()->LoadMetadataBlock(10)};
-    // Fill it so we won't be able to go to the merge flow
-    while (allocator.Alloc(8))
-      ;
-    for (uint32_t i = 0; i < 200; ++i) {
-      REQUIRE(dir_tree.erase(std::format("{:05}", 11000 + i)));
-    }
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.name == std::format("{:05}", 10000 + i));
-    }
-    for (uint32_t i = 0; i < 80; ++i) {
-      auto entry = dir_tree.find(std::format("{:05}", 10000 + i));
-      REQUIRE(!entry.is_end());
-      CHECK((*entry).name == std::format("{:05}", 10000 + i));
-    }
+  for (auto [index, entry] : std::views::enumerate(dir_tree)) {
+    auto i = static_cast<uint32_t>(index);
+    CHECK(entry.name == EntryName(10000 + i));
+  }
+  for (uint32_t i = 0; i < 80; ++i) {
+    auto entry = dir_tree.find(EntryName(10000 + i));
+    REQUIRE(!entry.is_end());
+    CHECK((*entry).name == EntryName(10000 + i));
   }
 }

--- a/tests/directory_tree_tests.cpp
+++ b/tests/directory_tree_tests.cpp
@@ -9,12 +9,14 @@
 
 #include <algorithm>
 #include <array>
+#include <ranges>
+#include <string>
+#include <tuple>
+#include <vector>
 
 #include "directory_tree.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
 namespace {
@@ -56,277 +58,289 @@ class TestDirectoryTree : public DirectoryTree<uint16_t> {
   }
 };
 
-}  // namespace
+class DirectoryTreeFixture : public MetadataBlockFixture {
+ public:
+  DirectoryTreeFixture() { dir_tree.Init(true); }
 
-TEST_CASE("DirectoryTreeTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto directory_tree_block = TestBlock::LoadMetadataBlock(test_device, 0);
+  std::shared_ptr<TestBlock> directory_tree_block = LoadMetadataBlock(0);
   TestDirectoryTree dir_tree{directory_tree_block};
-  dir_tree.Init(true);
+};
 
-  SECTION("Check empty tree size") {
-    REQUIRE(dir_tree.size() == 0);
-  }
-
-  SECTION("insert linear entries sorted") {
-    const int kEntries = 10;
-    for (uint16_t i = 0; i < kEntries; ++i) {
-      REQUIRE(dir_tree.insert({std::string(i + 1, 'a'), i}));
-    }
-    REQUIRE(dir_tree.size() == kEntries);
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.key() == std::string(i + 1, 'a'));
-      CHECK(entry.value() == static_cast<uint16_t>(i));
-    }
-  }
-
-  SECTION("insert linear entries reverse") {
-    const int kEntries = 10;
-    for (int i = 0; i < kEntries; ++i) {
-      REQUIRE(dir_tree.insert({std::string(kEntries - i, 'a'), static_cast<uint16_t>(kEntries - 1 - i)}));
-    }
-    REQUIRE(dir_tree.size() == kEntries);
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.key() == std::string(i + 1, 'a'));
-      CHECK(entry.value() == static_cast<uint16_t>(i));
-    }
-  }
-
-  SECTION("insert and erase entries randomlly") {
-    constexpr std::array<char, 3> chars = {'a', 'b', 'c'};
-    auto one_char = std::views::cartesian_product(chars) |
-                    std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                    std::ranges::to<std::vector>();
-    auto two_chars = std::views::cartesian_product(chars, chars) |
+std::vector<std::string> CartesianDirectoryKeys() {
+  constexpr std::array<char, 3> chars = {'a', 'b', 'c'};
+  auto one_char = std::views::cartesian_product(chars) |
+                  std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
+                  std::ranges::to<std::vector>();
+  auto two_chars = std::views::cartesian_product(chars, chars) |
+                   std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
+                   std::ranges::to<std::vector>();
+  auto three_chars = std::views::cartesian_product(chars, chars, chars) |
                      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
                      std::ranges::to<std::vector>();
-    auto three_chars = std::views::cartesian_product(chars, chars, chars) |
-                       std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                       std::ranges::to<std::vector>();
-    auto four_chars = std::views::cartesian_product(chars, chars, chars, chars) |
-                      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                      std::ranges::to<std::vector>();
-    auto keys =
-        std::ranges::to<std::vector>(std::views::join(std::vector{one_char, two_chars, three_chars, four_chars}));
-    std::ranges::sort(keys);
+  auto four_chars = std::views::cartesian_product(chars, chars, chars, chars) |
+                    std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
+                    std::ranges::to<std::vector>();
+  auto keys = std::ranges::to<std::vector>(std::views::join(std::vector{one_char, two_chars, three_chars, four_chars}));
+  std::ranges::sort(keys);
+  return keys;
+}
 
-    auto unsorted_keys_indxes = createShuffledKeysArray<3 + 3 * 3 + 3 * 3 * 3 + 3 * 3 * 3 * 3>();
-    for (uint16_t i = 0; i < keys.size(); ++i) {
-      REQUIRE(dir_tree.insert({keys[unsorted_keys_indxes[i]], static_cast<uint16_t>(unsorted_keys_indxes[i])}));
-    }
-    REQUIRE(dir_tree.size() == keys.size());
-    REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == static_cast<int>(keys.size()));
-    for (auto [i, entry] : std::views::enumerate(dir_tree)) {
-      CHECK(entry.key() == keys[i]);
-      CHECK(entry.value() == static_cast<uint16_t>(i));
-    }
-    for (uint16_t i = 0; i < keys.size(); ++i) {
-      auto it = dir_tree.find(keys[unsorted_keys_indxes[i]]);
-      REQUIRE(it != dir_tree.end());
-      dir_tree.erase(it);
-    }
-    REQUIRE(dir_tree.size() == 0);
-    REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 0);
+void ExhaustLargeFreeBlocks(TestDirectoryTree& dir_tree) {
+  for (int i = 0; i < 7; ++i) {
+    dir_tree.Alloc(0x400);
+  }
+  dir_tree.Alloc(0x200);
+  dir_tree.Alloc(0x100);
+  dir_tree.Alloc(0x80);
+}
 
-    REQUIRE(dir_tree.allocated_bytes() == 0);
+}  // namespace
+
+TEST_CASE_METHOD(DirectoryTreeFixture, "DirectoryTree is empty after initialization", "[directory-tree][unit]") {
+  REQUIRE(dir_tree.size() == 0);
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture, "DirectoryTree inserts sorted linear entries", "[directory-tree][unit]") {
+  const int kEntries = 10;
+  for (uint16_t i = 0; i < kEntries; ++i) {
+    REQUIRE(dir_tree.insert({std::string(i + 1, 'a'), i}));
+  }
+  REQUIRE(dir_tree.size() == kEntries);
+  for (auto [i, entry] : std::views::enumerate(dir_tree)) {
+    CHECK(entry.key() == std::string(i + 1, 'a'));
+    CHECK(entry.value() == static_cast<uint16_t>(i));
+  }
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture, "DirectoryTree inserts reverse linear entries", "[directory-tree][unit]") {
+  const int kEntries = 10;
+  for (int i = 0; i < kEntries; ++i) {
+    REQUIRE(dir_tree.insert({std::string(kEntries - i, 'a'), static_cast<uint16_t>(kEntries - 1 - i)}));
+  }
+  REQUIRE(dir_tree.size() == kEntries);
+  for (auto [i, entry] : std::views::enumerate(dir_tree)) {
+    CHECK(entry.key() == std::string(i + 1, 'a'));
+    CHECK(entry.value() == static_cast<uint16_t>(i));
+  }
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree inserts and erases shuffled cartesian keys",
+                 "[directory-tree][integration]") {
+  auto keys = CartesianDirectoryKeys();
+  auto unsorted_key_indexes = createShuffledKeysArray<3 + 3 * 3 + 3 * 3 * 3 + 3 * 3 * 3 * 3>();
+  for (uint16_t i = 0; i < keys.size(); ++i) {
+    REQUIRE(dir_tree.insert({keys[unsorted_key_indexes[i]], static_cast<uint16_t>(unsorted_key_indexes[i])}));
+  }
+  REQUIRE(dir_tree.size() == keys.size());
+  REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == static_cast<int>(keys.size()));
+  for (auto [i, entry] : std::views::enumerate(dir_tree)) {
+    CHECK(entry.key() == keys[i]);
+    CHECK(entry.value() == static_cast<uint16_t>(i));
   }
 
-  SECTION("insert alphabet") {
-    for (char i = 'a'; i <= 'z'; ++i) {
-      REQUIRE(dir_tree.insert({std::string{i}, static_cast<uint16_t>(i)}));
-    }
-    REQUIRE(dir_tree.size() == 26);
-    char i = 'a';
-    for (const auto& entry : dir_tree) {
-      CHECK(entry.key() == std::string{i});
-      CHECK(entry.value() == static_cast<uint16_t>(i++));
-    }
-  }
-
-  SECTION("fail to alloc new node") {
-    for (int i = 0; i < 7; ++i)
-      dir_tree.Alloc(0x400);
-    dir_tree.Alloc(0x200);
-    dir_tree.Alloc(0x100);
-    dir_tree.Alloc(0x80);
-    dir_tree.Alloc(0x20);
-    dir_tree.Alloc(0x10);
-    dir_tree.Alloc(0x8);
-    REQUIRE(dir_tree.free_bytes() == 8);
-    REQUIRE(dir_tree.insert({"a", 0}));
-    CHECK(dir_tree.size() == 1);
-    CHECK((*dir_tree.begin()).key() == "a");
-    CHECK(!dir_tree.insert({"b", 0}));
-    CHECK(dir_tree.size() == 1);
-    CHECK((*dir_tree.begin()).key() == "a");
-  }
-
-  SECTION("fail to split") {
-    for (int i = 0; i < 7; ++i)
-      dir_tree.Alloc(0x400);
-    dir_tree.Alloc(0x200);
-    dir_tree.Alloc(0x100);
-    dir_tree.Alloc(0x80);
-    dir_tree.Alloc(0x20);
-    dir_tree.Alloc(0x10);
-    REQUIRE(dir_tree.free_bytes() == 0x10);
-    REQUIRE(dir_tree.insert({"a", 0}));
-    CHECK(dir_tree.size() == 1);
-    CHECK((*dir_tree.begin()).key() == "a");
-    CHECK(dir_tree.free_bytes() == 8);
-    CHECK(!dir_tree.insert({"b", 0}));
-    CHECK(dir_tree.size() == 1);
-    CHECK((*dir_tree.begin()).key() == "a");
-    CHECK(dir_tree.free_bytes() == 8);
-  }
-
-  SECTION("shrink when split and full") {
-    for (int i = 0; i < 7; ++i)
-      dir_tree.Alloc(0x400);
-    dir_tree.Alloc(0x200);
-    dir_tree.Alloc(0x100);
-    dir_tree.Alloc(0x80);
-    REQUIRE(dir_tree.free_bytes() == 0x40);
-    REQUIRE(dir_tree.insert({"aaaaaaaaaaaaaaaaaaaaaaa", 0}));
-    CHECK(dir_tree.free_bytes() == 0x20);
-    CHECK(dir_tree.size() == 1);
-    CHECK((*dir_tree.begin()).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
-    // This will cause a shrink
-    REQUIRE(dir_tree.insert({"a", 0}));
-    CHECK(dir_tree.free_bytes() == 0x10);
-    CHECK(dir_tree.size() == 2);
-    auto it = dir_tree.begin();
-    CHECK((*it).key() == "a");
-    CHECK((*++it).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
-    // This will cause a second shrink
-    REQUIRE(dir_tree.insert({"b", 0}));
-    CHECK(dir_tree.free_bytes() == 8);
-    CHECK(dir_tree.size() == 3);
-    it = dir_tree.begin();
-    CHECK((*it).key() == "a");
-    CHECK((*++it).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
-    CHECK((*++it).key() == "b");
-  }
-
-  SECTION("merge when full") {
-    for (int i = 0; i < 7; ++i)
-      dir_tree.Alloc(0x400);
-    dir_tree.Alloc(0x200);
-    dir_tree.Alloc(0x100);
-    dir_tree.Alloc(0x80);
-    dir_tree.Alloc(0x10);
-    REQUIRE(dir_tree.free_bytes() == 0x30);
-    REQUIRE(dir_tree.insert({"aaaaaaaaaaaa", 1}));
-    REQUIRE(dir_tree.insert({"aaaaaaaab", 2}));
-    REQUIRE(dir_tree.free_bytes() == 0x10);
-    auto it = dir_tree.find("aaaaaaaab");
+  for (uint16_t i = 0; i < keys.size(); ++i) {
+    auto it = dir_tree.find(keys[unsorted_key_indexes[i]]);
     REQUIRE(it != dir_tree.end());
     dir_tree.erase(it);
-    CHECK(dir_tree.size() == 1);
-    CHECK(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 1);
-    CHECK((*dir_tree.begin()).key() == "aaaaaaaaaaaa");
-    CHECK((*dir_tree.begin()).value() == 1);
-    CHECK(dir_tree.allocated_bytes() == 0x20);
   }
+  REQUIRE(dir_tree.size() == 0);
+  REQUIRE(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 0);
+  REQUIRE(dir_tree.allocated_bytes() == 0);
+}
 
-  SECTION("merge when full 2") {
-    for (int i = 0; i < 7; ++i)
-      dir_tree.Alloc(0x400);
-    dir_tree.Alloc(0x200);
-    dir_tree.Alloc(0x100);
-    dir_tree.Alloc(0x40);
-    dir_tree.Alloc(0x20);
-    dir_tree.Alloc(0x8);
-    REQUIRE(dir_tree.insert({"b", 1}));
-    REQUIRE(dir_tree.insert({"aaaaaaaaaaaa", 2}));
-    REQUIRE(dir_tree.insert({"aaaaaaaab", 3}));
-    REQUIRE(dir_tree.insert({"aaaaaaaaaaaab", 4}));
-    REQUIRE(dir_tree.insert({"aaaaaaaaaaaac", 5}));
-    CHECK(dir_tree.free_bytes() == 0x10);
-    auto it = dir_tree.find("aaaaaaaab");
+TEST_CASE_METHOD(DirectoryTreeFixture, "DirectoryTree inserts alphabet entries", "[directory-tree][unit]") {
+  for (char i = 'a'; i <= 'z'; ++i) {
+    REQUIRE(dir_tree.insert({std::string{i}, static_cast<uint16_t>(i)}));
+  }
+  REQUIRE(dir_tree.size() == 26);
+  char i = 'a';
+  for (const auto& entry : dir_tree) {
+    CHECK(entry.key() == std::string{i});
+    CHECK(entry.value() == static_cast<uint16_t>(i++));
+  }
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree preserves existing entry when new node allocation fails",
+                 "[directory-tree][white-box]") {
+  ExhaustLargeFreeBlocks(dir_tree);
+  dir_tree.Alloc(0x20);
+  dir_tree.Alloc(0x10);
+  dir_tree.Alloc(0x8);
+  REQUIRE(dir_tree.free_bytes() == 8);
+  REQUIRE(dir_tree.insert({"a", 0}));
+  CHECK(dir_tree.size() == 1);
+  CHECK((*dir_tree.begin()).key() == "a");
+  CHECK(!dir_tree.insert({"b", 0}));
+  CHECK(dir_tree.size() == 1);
+  CHECK((*dir_tree.begin()).key() == "a");
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree preserves existing entry when split allocation fails",
+                 "[directory-tree][white-box]") {
+  ExhaustLargeFreeBlocks(dir_tree);
+  dir_tree.Alloc(0x20);
+  dir_tree.Alloc(0x10);
+  REQUIRE(dir_tree.free_bytes() == 0x10);
+  REQUIRE(dir_tree.insert({"a", 0}));
+  CHECK(dir_tree.size() == 1);
+  CHECK((*dir_tree.begin()).key() == "a");
+  CHECK(dir_tree.free_bytes() == 8);
+  CHECK(!dir_tree.insert({"b", 0}));
+  CHECK(dir_tree.size() == 1);
+  CHECK((*dir_tree.begin()).key() == "a");
+  CHECK(dir_tree.free_bytes() == 8);
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree shrinks nodes while splitting under allocation pressure",
+                 "[directory-tree][white-box]") {
+  ExhaustLargeFreeBlocks(dir_tree);
+  REQUIRE(dir_tree.free_bytes() == 0x40);
+  REQUIRE(dir_tree.insert({"aaaaaaaaaaaaaaaaaaaaaaa", 0}));
+  CHECK(dir_tree.free_bytes() == 0x20);
+  CHECK(dir_tree.size() == 1);
+  CHECK((*dir_tree.begin()).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
+
+  REQUIRE(dir_tree.insert({"a", 0}));
+  CHECK(dir_tree.free_bytes() == 0x10);
+  CHECK(dir_tree.size() == 2);
+  auto it = dir_tree.begin();
+  CHECK((*it).key() == "a");
+  CHECK((*++it).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
+
+  REQUIRE(dir_tree.insert({"b", 0}));
+  CHECK(dir_tree.free_bytes() == 8);
+  CHECK(dir_tree.size() == 3);
+  it = dir_tree.begin();
+  CHECK((*it).key() == "a");
+  CHECK((*++it).key() == "aaaaaaaaaaaaaaaaaaaaaaa");
+  CHECK((*++it).key() == "b");
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree merges nodes under allocation pressure",
+                 "[directory-tree][white-box]") {
+  ExhaustLargeFreeBlocks(dir_tree);
+  dir_tree.Alloc(0x10);
+  REQUIRE(dir_tree.free_bytes() == 0x30);
+  REQUIRE(dir_tree.insert({"aaaaaaaaaaaa", 1}));
+  REQUIRE(dir_tree.insert({"aaaaaaaab", 2}));
+  REQUIRE(dir_tree.free_bytes() == 0x10);
+  auto it = dir_tree.find("aaaaaaaab");
+  REQUIRE(it != dir_tree.end());
+  dir_tree.erase(it);
+  CHECK(dir_tree.size() == 1);
+  CHECK(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 1);
+  CHECK((*dir_tree.begin()).key() == "aaaaaaaaaaaa");
+  CHECK((*dir_tree.begin()).value() == 1);
+  CHECK(dir_tree.allocated_bytes() == 0x20);
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree merges multi-entry nodes under allocation pressure",
+                 "[directory-tree][white-box]") {
+  for (int i = 0; i < 7; ++i) {
+    dir_tree.Alloc(0x400);
+  }
+  dir_tree.Alloc(0x200);
+  dir_tree.Alloc(0x100);
+  dir_tree.Alloc(0x40);
+  dir_tree.Alloc(0x20);
+  dir_tree.Alloc(0x8);
+  REQUIRE(dir_tree.insert({"b", 1}));
+  REQUIRE(dir_tree.insert({"aaaaaaaaaaaa", 2}));
+  REQUIRE(dir_tree.insert({"aaaaaaaab", 3}));
+  REQUIRE(dir_tree.insert({"aaaaaaaaaaaab", 4}));
+  REQUIRE(dir_tree.insert({"aaaaaaaaaaaac", 5}));
+  CHECK(dir_tree.free_bytes() == 0x10);
+  auto it = dir_tree.find("aaaaaaaab");
+  REQUIRE(it != dir_tree.end());
+  dir_tree.erase(it);
+  CHECK(dir_tree.size() == 4);
+  CHECK(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 4);
+  it = dir_tree.begin();
+  CHECK((*it).key() == "aaaaaaaaaaaa");
+  CHECK((*it++).value() == 2);
+  CHECK((*it).key() == "aaaaaaaaaaaab");
+  CHECK((*it++).value() == 4);
+  CHECK((*it).key() == "aaaaaaaaaaaac");
+  CHECK((*it++).value() == 5);
+  CHECK((*it).key() == "b");
+  CHECK((*it++).value() == 1);
+  CHECK(dir_tree.allocated_bytes() == 0x40);
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture, "DirectoryTree splits into two output trees", "[directory-tree][unit]") {
+  REQUIRE(dir_tree.insert({"a", 1}));
+  REQUIRE(dir_tree.insert({"a1", 2}));
+  REQUIRE(dir_tree.insert({"aa", 3}));
+  REQUIRE(dir_tree.insert({"aaaaa1", 4}));
+  REQUIRE(dir_tree.insert({"aaaaa2", 5}));
+  REQUIRE(dir_tree.insert({"aaaaa2a", 6}));
+  REQUIRE(dir_tree.insert({"aaaab1", 7}));
+  REQUIRE(dir_tree.insert({"aaaab2", 8}));
+  auto split_point = dir_tree.find("aaaaa2a");
+  REQUIRE(split_point != dir_tree.end());
+  REQUIRE(dir_tree.size() == 8);
+
+  std::array<TestDirectoryTree, 2> new_trees{TestDirectoryTree{LoadMetadataBlock(1)},
+                                             TestDirectoryTree{LoadMetadataBlock(2)}};
+  new_trees[0].Init(false);
+  new_trees[1].Init(false);
+
+  dir_tree.split(new_trees[0], new_trees[1], split_point);
+  CHECK(new_trees[0].size() == 5);
+  CHECK(new_trees[1].size() == 3);
+  CHECK(std::ranges::distance(new_trees[0].begin(), new_trees[0].end()) == 5);
+  CHECK(std::ranges::distance(new_trees[1].begin(), new_trees[1].end()) == 3);
+  auto it = new_trees[0].begin();
+  CHECK((*it).key() == "a");
+  CHECK((*it++).value() == 1);
+  CHECK((*it).key() == "a1");
+  CHECK((*it++).value() == 2);
+  CHECK((*it).key() == "aa");
+  CHECK((*it++).value() == 3);
+  CHECK((*it).key() == "aaaaa1");
+  CHECK((*it++).value() == 4);
+  CHECK((*it).key() == "aaaaa2");
+  CHECK((*it++).value() == 5);
+  it = new_trees[1].begin();
+  CHECK((*it).key() == "aaaaa2a");
+  CHECK((*it++).value() == 6);
+  CHECK((*it).key() == "aaaab1");
+  CHECK((*it++).value() == 7);
+  CHECK((*it).key() == "aaaab2");
+  CHECK((*it++).value() == 8);
+}
+
+TEST_CASE_METHOD(DirectoryTreeFixture,
+                 "DirectoryTree non-exact find returns nearest lower key",
+                 "[directory-tree][unit]") {
+  static const std::vector<std::string> kKeys{
+      {"2", "3", "33", "33331", "333311", "333312", "33333", "5", "55", "5555", "555555"}};
+  static const std::vector<std::tuple<std::string, std::string>> kExpectedResults{{{"0", "2"},
+                                                                                   {"3", "3"},
+                                                                                   {"32", "3"},
+                                                                                   {"330", "33"},
+                                                                                   {"3331", "33"},
+                                                                                   {"33332", "333312"},
+                                                                                   {"3334", "33333"},
+                                                                                   {"4", "33333"},
+                                                                                   {"54", "5"},
+                                                                                   {"5554", "55"},
+                                                                                   {"55554", "5555"},
+                                                                                   {"555556", "555555"},
+                                                                                   {"6", "555555"}}};
+  for (const auto& key : kKeys) {
+    REQUIRE(dir_tree.insert({key, 0}));
+  }
+  for (const auto& [key, result] : kExpectedResults) {
+    auto it = dir_tree.find(key, /*exact_match=*/false);
     REQUIRE(it != dir_tree.end());
-    dir_tree.erase(it);
-    CHECK(dir_tree.size() == 4);
-    CHECK(std::ranges::distance(dir_tree.begin(), dir_tree.end()) == 4);
-    it = dir_tree.begin();
-    CHECK((*it).key() == "aaaaaaaaaaaa");
-    CHECK((*it++).value() == 2);
-    CHECK((*it).key() == "aaaaaaaaaaaab");
-    CHECK((*it++).value() == 4);
-    CHECK((*it).key() == "aaaaaaaaaaaac");
-    CHECK((*it++).value() == 5);
-    CHECK((*it).key() == "b");
-    CHECK((*it++).value() == 1);
-    CHECK(dir_tree.allocated_bytes() == 0x40);
-  }
-
-  SECTION("split") {
-    REQUIRE(dir_tree.insert({"a", 1}));
-    REQUIRE(dir_tree.insert({"a1", 2}));
-    REQUIRE(dir_tree.insert({"aa", 3}));
-    REQUIRE(dir_tree.insert({"aaaaa1", 4}));
-    REQUIRE(dir_tree.insert({"aaaaa2", 5}));
-    REQUIRE(dir_tree.insert({"aaaaa2a", 6}));
-    REQUIRE(dir_tree.insert({"aaaab1", 7}));
-    REQUIRE(dir_tree.insert({"aaaab2", 8}));
-    auto split_point = dir_tree.find("aaaaa2a");
-    REQUIRE(split_point != dir_tree.end());
-    REQUIRE(dir_tree.size() == 8);
-
-    std::array<TestDirectoryTree, 2> new_trees{TestDirectoryTree{TestBlock::LoadMetadataBlock(test_device, 1)},
-                                               TestDirectoryTree{TestBlock::LoadMetadataBlock(test_device, 2)}};
-    new_trees[0].Init(false);
-    new_trees[1].Init(false);
-
-    dir_tree.split(new_trees[0], new_trees[1], split_point);
-    CHECK(new_trees[0].size() == 5);
-    CHECK(new_trees[1].size() == 3);
-    CHECK(std::ranges::distance(new_trees[0].begin(), new_trees[0].end()) == 5);
-    CHECK(std::ranges::distance(new_trees[1].begin(), new_trees[1].end()) == 3);
-    auto it = new_trees[0].begin();
-    CHECK((*it).key() == "a");
-    CHECK((*it++).value() == 1);
-    CHECK((*it).key() == "a1");
-    CHECK((*it++).value() == 2);
-    CHECK((*it).key() == "aa");
-    CHECK((*it++).value() == 3);
-    CHECK((*it).key() == "aaaaa1");
-    CHECK((*it++).value() == 4);
-    CHECK((*it).key() == "aaaaa2");
-    CHECK((*it++).value() == 5);
-    it = new_trees[1].begin();
-    CHECK((*it).key() == "aaaaa2a");
-    CHECK((*it++).value() == 6);
-    CHECK((*it).key() == "aaaab1");
-    CHECK((*it++).value() == 7);
-    CHECK((*it).key() == "aaaab2");
-    CHECK((*it++).value() == 8);
-  }
-
-  SECTION("find non exact") {
-    // Should cover all the possible cases
-    static const std::vector<std::string> kKeys{
-        {"2", "3", "33", "33331", "333311", "333312", "33333", "5", "55", "5555", "555555"}};
-    static const std::vector<std::tuple<std::string, std::string>> kExpectedResults{{{"0", "2"},
-                                                                                     {"3", "3"},
-                                                                                     {"32", "3"},
-                                                                                     {"330", "33"},
-                                                                                     {"3331", "33"},
-                                                                                     {"33332", "333312"},
-                                                                                     {"3334", "33333"},
-                                                                                     {"4", "33333"},
-                                                                                     {"54", "5"},
-                                                                                     {"5554", "55"},
-                                                                                     {"55554", "5555"},
-                                                                                     {"555556", "555555"},
-                                                                                     {"6", "555555"}}};
-    for (const auto& key : kKeys)
-      REQUIRE(dir_tree.insert({key, 0}));
-    for (const auto& [key, result] : kExpectedResults) {
-      auto it = dir_tree.find(key, /*exact_match=*/false);
-      REQUIRE(it != dir_tree.end());
-      CAPTURE(key);
-      CHECK((*it).key() == result);
-    }
+    CAPTURE(key);
+    CHECK((*it).key() == result);
   }
 }

--- a/tests/eptree_tests.cpp
+++ b/tests/eptree_tests.cpp
@@ -12,121 +12,93 @@
 
 #include "eptree.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
-TEST_CASE("EPTreeTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto allocator_block = TestBlock::LoadMetadataBlock(test_device, 0);
-  TestFreeBlocksAllocator allocator{allocator_block, test_device};
-  allocator.Init(1000000);
+namespace {
+
+class EPTreeFixture : public FreeBlocksAllocatorFixture {
+ public:
+  EPTreeFixture() {
+    allocator_initialized = allocator.Init(1000000);
+    eptree.Init(/*block_number=*/0);
+  }
+
   EPTree eptree{&allocator};
-  eptree.Init(/*block_number=*/0);
+  bool allocator_initialized = false;
+};
 
-  SECTION("insert items sorted") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(eptree.insert({i, i + 1}));
-    }
+constexpr uint32_t kEPTreeStressItems = 600 * 300;
 
-    REQUIRE(eptree.tree_header()->depth.value() == 3);
+}  // namespace
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            eptree, [](const auto& extent) -> std::pair<uint32_t, uint32_t> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(0, kItemsCount),
-                              [](int i) -> std::pair<uint32_t, uint32_t> { return {i, i + 1}; })));
+TEST_CASE_METHOD(EPTreeFixture, "EPTree inserts sorted extents and grows depth", "[eptree][tree][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kEPTreeStressItems; ++i) {
+    REQUIRE(eptree.insert({i, i + 1}));
   }
 
-  SECTION("insert items unsorted") {
-    constexpr int kItemsCount = 600 * 300;
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    for (auto key : unsorted_keys) {
-      REQUIRE(eptree.insert({key, key + 1}));
-    }
+  REQUIRE(eptree.tree_header()->depth.value() == 3);
+  REQUIRE(CollectKeyValues(eptree) == SequentialKeyValues(kEPTreeStressItems));
+}
 
-    // Check that the tree is sorted
-    auto keys = std::views::transform(eptree, [](const auto& extent) -> uint32_t { return extent.key(); });
-    auto sorted_keys = unsorted_keys;
-    std::ranges::sort(sorted_keys);
-    REQUIRE(std::ranges::equal(sorted_keys, keys));
+TEST_CASE_METHOD(EPTreeFixture, "EPTree keeps unsorted inserts ordered and searchable", "[eptree][tree][stress]") {
+  REQUIRE(allocator_initialized);
 
-    // Check the values
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            eptree, [](const auto& extent) -> std::pair<uint32_t, uint32_t> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(0, kItemsCount),
-                              [](int i) -> std::pair<uint32_t, uint32_t> { return {i, i + 1}; })));
-
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*eptree.find(i, true)).key() == i);
-    }
+  auto unsorted_keys = createShuffledKeysArray<kEPTreeStressItems>();
+  for (auto key : unsorted_keys) {
+    REQUIRE(eptree.insert({key, key + 1}));
   }
 
-  SECTION("erase items randomly") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(eptree.insert({i, 0}));
-    }
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    auto middle = unsorted_keys.begin() + kItemsCount / 2;
-    std::vector<FreeBlocksRangeInfo> blocks_to_delete;
-    // Remove half the items first
-    for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
-      REQUIRE(eptree.erase(key, blocks_to_delete));
-    }
+  auto sorted_keys = unsorted_keys;
+  std::ranges::sort(sorted_keys);
+  REQUIRE(CollectKeys(eptree) == sorted_keys);
+  REQUIRE(CollectKeyValues(eptree) == SequentialKeyValues(kEPTreeStressItems));
 
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right items were deleted
-    REQUIRE(std::ranges::equal(std::views::transform(eptree, [](const auto& extent) -> int { return extent.key(); }),
-                               sorted_upper_half));
+  for (uint32_t i = 0; i < kEPTreeStressItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*eptree.find(i, true)).key() == i);
+  }
+}
 
-    // Remove the second half
-    for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
-      REQUIRE(eptree.erase(key, blocks_to_delete));
-    }
+TEST_CASE_METHOD(EPTreeFixture,
+                 "EPTree erases shuffled extents and collapses to an empty root",
+                 "[eptree][tree][stress]") {
+  REQUIRE(allocator_initialized);
 
-    // Should be empty
-    REQUIRE(eptree.begin() == eptree.end());
-    REQUIRE(eptree.tree_header()->depth.value() == 1);
+  for (uint32_t i = 0; i < kEPTreeStressItems; ++i) {
+    REQUIRE(eptree.insert({i, 0}));
   }
 
-  SECTION("check backward/forward iterator") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(eptree.insert({i, i}));
-    }
-
-    auto it = eptree.begin();
-    uint32_t steps = 0;
-    while (it != eptree.end()) {
-      REQUIRE((*it).key() == steps);
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kItemsCount);
-    REQUIRE(it.is_end());
-    while (it != eptree.begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
-
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE((*it).key() == 20);
+  auto unsorted_keys = createShuffledKeysArray<kEPTreeStressItems>();
+  auto middle = unsorted_keys.begin() + kEPTreeStressItems / 2;
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
+    CAPTURE(key);
+    REQUIRE(eptree.erase(key, blocks_to_delete));
   }
+
+  auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
+  std::ranges::sort(sorted_upper_half);
+  REQUIRE(CollectKeys(eptree) == sorted_upper_half);
+
+  for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
+    CAPTURE(key);
+    REQUIRE(eptree.erase(key, blocks_to_delete));
+  }
+
+  REQUIRE(eptree.begin() == eptree.end());
+  REQUIRE(eptree.tree_header()->depth.value() == 1);
+}
+
+TEST_CASE_METHOD(EPTreeFixture, "EPTree iterator walks forward and backward", "[eptree][tree][iterator][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kEPTreeStressItems; ++i) {
+    REQUIRE(eptree.insert({i, i}));
+  }
+
+  RequireBidirectionalIteration(eptree, kEPTreeStressItems, [](const auto& extent) { return extent.key(); });
 }

--- a/tests/free_blocks_allocator_tests.cpp
+++ b/tests/free_blocks_allocator_tests.cpp
@@ -12,324 +12,286 @@
 
 #include "free_blocks_tree.h"
 
-#include "utils/test_area.h"
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 
-TEST_CASE("FreeBlocksAllocatorTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto area_block = TestBlock::LoadMetadataBlock(test_device, 0);
-  auto allocator_block = TestBlock::LoadMetadataBlock(test_device, 1);
-  auto area = std::make_shared<TestArea>(std::move(area_block));
-  TestFreeBlocksAllocator allocator{allocator_block, test_device, area};
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates all single blocks from cache",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kCacheBlocksCount = 100;
+  REQUIRE(allocator.Init(kCacheBlocksCount));
+  allocator.set_blocks_cache_size_log2(1);
 
-  SECTION("Alloc single blocks from cache") {
-    const uint32_t kCacheBlocksCount = 100;
-    REQUIRE(allocator.Init(kCacheBlocksCount));
-    // Set cache available
-    allocator.set_blocks_cache_size_log2(1);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, false));
 
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
+  auto blocks = allocator.AllocBlocks(kCacheBlocksCount, BlockType::Single, true);
+  REQUIRE(blocks);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
+  REQUIRE(*blocks == SequentialKeys(kCacheBlocksCount, allocator.initial_frees_block_number()));
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
+}
 
-    // Empty tree, should fail alloc from it
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, false));
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates cache blocks one by one",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kCacheBlocksCount = 100;
+  REQUIRE(allocator.Init(kCacheBlocksCount));
+  allocator.set_blocks_cache_size_log2(1);
 
-    auto blocks = allocator.AllocBlocks(kCacheBlocksCount, BlockType::Single, true);
-    REQUIRE(blocks);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, false));
 
-    REQUIRE(blocks->size() == kCacheBlocksCount);
-    REQUIRE(std::ranges::equal(*blocks, std::views::iota(allocator.initial_frees_block_number(),
-                                                         allocator.initial_frees_block_number() + kCacheBlocksCount)));
-
-    // no more free blocks
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
-  }
-
-  SECTION("Alloc single blocks from cache one by one") {
-    const uint32_t kCacheBlocksCount = 100;
-    REQUIRE(allocator.Init(kCacheBlocksCount));
-    // Set cache available
-    allocator.set_blocks_cache_size_log2(1);
-
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
-
-    // Empty tree, should fail alloc from it
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, false));
-
-    for (uint32_t i = 0; i < kCacheBlocksCount; ++i) {
-      auto blocks = allocator.AllocBlocks(1, BlockType::Single, true);
-      REQUIRE(blocks);
-      REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount - i - 1);
-      REQUIRE(blocks->size() == 1);
-      REQUIRE((*blocks)[0] == allocator.initial_frees_block_number() + i);
-    }
-
-    // no more free blocks
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
-  }
-
-  SECTION("Alloc large block from cache") {
-    const uint32_t kCacheBlocksCount = 100;
-    REQUIRE(allocator.Init(kCacheBlocksCount));
-    // Set cache available
-    allocator.set_blocks_cache_size_log2(1);
-
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
-    // Can't alloc non single block from cache
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Large, true));
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
-  }
-
-  SECTION("Alloc single blocks from tree") {
-    const uint32_t kTreeBlocksCount = 100;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
-
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
-
-    auto blocks = allocator.AllocBlocks(kTreeBlocksCount, BlockType::Single, true);
-    REQUIRE(blocks);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
-
-    REQUIRE(blocks->size() == kTreeBlocksCount);
-    REQUIRE(std::ranges::equal(*blocks, std::views::iota(allocator.initial_frees_block_number(),
-                                                         allocator.initial_frees_block_number() + kTreeBlocksCount)));
-
-    // no more free blocks
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
-  }
-
-  SECTION("Alloc single blocks from tree one by one") {
-    const uint32_t kTreeBlocksCount = 100;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
-
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
-
-    std::vector<uint32_t> allocated_blocks;
-    for (uint32_t i = 0; i < kTreeBlocksCount; ++i) {
-      auto blocks = allocator.AllocBlocks(1, BlockType::Single, true);
-      REQUIRE(blocks);
-      REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount - i - 1);
-      REQUIRE(blocks->size() == 1);
-      allocated_blocks.push_back((*blocks)[0]);
-    }
-    // Since we allocate small block seperatly we will consume the smallest bucket first and won't alloc it in serial
-    // order.
-    std::ranges::sort(allocated_blocks);
-    REQUIRE(std::ranges::equal(allocated_blocks,
-                               std::views::iota(allocator.initial_frees_block_number(),
-                                                allocator.initial_frees_block_number() + kTreeBlocksCount)));
-
-    // no more free blocks
-    REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
-  }
-
-  SECTION("Initialize huge area") {
-    const uint32_t kTreeBlocksCount = (1 << 28) - (10);  // max size minus few blocks
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-
-    auto current_block_number = allocator.initial_frees_block_number();
-    FreeBlocksTree tree{&allocator};
-    std::vector<size_t> extent_indexes;
-    for (const auto& extent : tree) {
-      REQUIRE(extent.block_number() == current_block_number);
-      current_block_number += extent.blocks_count();
-      extent_indexes.push_back(extent.bucket_index);
-    }
-
-    REQUIRE(current_block_number == allocator.initial_frees_block_number() + kTreeBlocksCount);
-    REQUIRE(extent_indexes.size() == 16);
-    REQUIRE(std::ranges::equal(extent_indexes, std::vector<size_t>({0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 5, 4, 3, 2, 1, 0})));
-    // minus 2 because the beginning and the end are not aligned.
-    uint32_t blocks_to_alloc = (1 << (28 - 6)) - 2;
-    auto blocks = allocator.AllocBlocks(blocks_to_alloc, BlockType::Cluster, false);
-    REQUIRE(blocks.has_value());
-    REQUIRE(blocks->size() == blocks_to_alloc);
-    // should be first aligned block number
-    REQUIRE((*blocks)[0] == 1 << 6);
-    REQUIRE(std::ranges::equal(*blocks, std::views::transform(std::views::iota(uint32_t{0}, blocks_to_alloc),
-                                                              [](auto i) { return (i + 1) << 6; })));
-    REQUIRE((kTreeBlocksCount - (blocks_to_alloc << 6)) == allocator.GetHeader()->free_blocks_count.value());
-
-    extent_indexes.clear();
-    for (const auto& extent : tree) {
-      extent_indexes.push_back(extent.bucket_index);
-    }
-
-    // Should have allocated all the larger allocation sizes
-    auto single_block = allocator.AllocBlocks(1, BlockType::Single, false);
-    REQUIRE(std::ranges::equal(extent_indexes, std::vector<size_t>({0, 1, 1, 0})));
-    REQUIRE(single_block.has_value());
-    // should allocate first block now
-    REQUIRE(single_block->at(0) == allocator.initial_frees_block_number());
-  }
-
-  SECTION("Free single blocks at sequantial order") {
-    const uint32_t kBlocksToFree = 10000;
-    // For tree structures.
-    const uint32_t kCacheBlocksCount = 600;
-    REQUIRE(allocator.Init(kCacheBlocksCount));
-
-    REQUIRE(std::ranges::all_of(std::views::iota(uint32_t{0}, kBlocksToFree), [&allocator](uint32_t i) -> bool {
-      return allocator.AddFreeBlocks({i + allocator.initial_frees_block_number() + kCacheBlocksCount, 1});
-    }));
-
-    auto current_block_number = allocator.initial_frees_block_number() + kCacheBlocksCount;
-    FreeBlocksTree tree{&allocator};
-    std::vector<size_t> extent_indexes;
-    for (const auto& extent : tree) {
-      REQUIRE(extent.block_number() == current_block_number);
-      current_block_number += extent.blocks_count();
-      extent_indexes.push_back(extent.bucket_index);
-    }
-    REQUIRE(current_block_number == allocator.initial_frees_block_number() + kCacheBlocksCount + kBlocksToFree);
-
-    REQUIRE(extent_indexes.size() == 7);
-    REQUIRE(std::ranges::equal(extent_indexes, std::vector<size_t>({0, 1, 2, 3, 2, 1, 0})));
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() - allocator.GetHeader()->free_blocks_cache_count.value() ==
-            kBlocksToFree);
-  }
-
-  SECTION("Free single blocks at random order") {
-    const uint32_t kBlocksToFree = 10000;
-    // For tree structures.
-    const uint32_t kCacheBlocksCount = 600;
-    REQUIRE(allocator.Init(kCacheBlocksCount));
-
-    auto blocks_to_free = std::ranges::to<std::vector>(std::views::iota(uint32_t{0}, kBlocksToFree));
-
-    std::ranges::shuffle(blocks_to_free, std::default_random_engine{Catch::getSeed()});
-    REQUIRE(std::ranges::all_of(blocks_to_free, [&allocator](uint32_t i) -> bool {
-      return allocator.AddFreeBlocks({i + allocator.initial_frees_block_number() + kCacheBlocksCount, 1});
-    }));
-
-    auto current_block_number = allocator.initial_frees_block_number() + kCacheBlocksCount;
-    FreeBlocksTree tree{&allocator};
-    std::vector<size_t> extent_indexes;
-    uint32_t released_ftrees = 0;
-    for (const auto& extent : tree) {
-      if (extent.block_number() < allocator.initial_frees_block_number() + kCacheBlocksCount) {
-        // The released FTrees that were alloced from the cache are released back to the tree.
-        released_ftrees += extent.blocks_count();
-        continue;
-      }
-      REQUIRE(extent.block_number() == current_block_number);
-      current_block_number += extent.blocks_count();
-      extent_indexes.push_back(extent.bucket_index);
-    }
-    REQUIRE(current_block_number == allocator.initial_frees_block_number() + kCacheBlocksCount + kBlocksToFree);
-
-    REQUIRE(extent_indexes.size() == 7);
-    REQUIRE(std::ranges::equal(extent_indexes, std::vector<size_t>({0, 1, 2, 3, 2, 1, 0})));
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() - allocator.GetHeader()->free_blocks_cache_count.value() -
-                released_ftrees ==
-            kBlocksToFree);
-  }
-
-  SECTION("Replansish cache") {
-    const uint32_t kTreeBlocksCount = 10000;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // cache size (8)
-    allocator.set_blocks_cache_size_log2(3);
-
+  for (uint32_t i = 0; i < kCacheBlocksCount; ++i) {
     auto blocks = allocator.AllocBlocks(1, BlockType::Single, true);
     REQUIRE(blocks);
-    // Should be aligned to data from big enough extent
-    REQUIRE(blocks->at(0) == 8);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount - 1);
-    REQUIRE(allocator.GetHeader()->free_blocks_cache.value() == 9);
-    REQUIRE(allocator.GetHeader()->free_blocks_cache_count.value() == 7);
-    REQUIRE_FALSE(allocator.IsRangeIsFree({9, 1}));
-    REQUIRE(allocator.IsRangeIsFree({3, 1}));
+    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount - i - 1);
+    REQUIRE(*blocks == std::vector<uint32_t>{allocator.initial_frees_block_number() + i});
+  }
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator does not allocate large blocks from cache",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kCacheBlocksCount = 100;
+  REQUIRE(allocator.Init(kCacheBlocksCount));
+  allocator.set_blocks_cache_size_log2(1);
+
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Large, true));
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kCacheBlocksCount);
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates all single blocks from tree",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+
+  auto blocks = allocator.AllocBlocks(kTreeBlocksCount, BlockType::Single, true);
+  REQUIRE(blocks);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
+  REQUIRE(*blocks == SequentialKeys(kTreeBlocksCount, allocator.initial_frees_block_number()));
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates tree blocks one by one",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+
+  std::vector<uint32_t> allocated_blocks;
+  for (uint32_t i = 0; i < kTreeBlocksCount; ++i) {
+    auto blocks = allocator.AllocBlocks(1, BlockType::Single, true);
+    REQUIRE(blocks);
+    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount - i - 1);
+    REQUIRE(blocks->size() == 1);
+    allocated_blocks.push_back((*blocks)[0]);
+  }
+  std::ranges::sort(allocated_blocks);
+  REQUIRE(allocated_blocks == SequentialKeys(kTreeBlocksCount, allocator.initial_frees_block_number()));
+  REQUIRE_FALSE(allocator.AllocBlocks(1, BlockType::Single, true));
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator initializes the largest representable area",
+                 "[free-blocks][allocator][stress]") {
+  const uint32_t kTreeBlocksCount = (1 << 28) - 10;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+
+  auto current_block_number = allocator.initial_frees_block_number();
+  FreeBlocksTree tree{&allocator};
+  std::vector<size_t> extent_indexes;
+  for (const auto& extent : tree) {
+    REQUIRE(extent.block_number() == current_block_number);
+    current_block_number += extent.blocks_count();
+    extent_indexes.push_back(extent.bucket_index);
   }
 
-  SECTION("Alloc area blocks") {
-    const uint32_t kTreeBlocksCount = 100;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
+  REQUIRE(current_block_number == allocator.initial_frees_block_number() + kTreeBlocksCount);
+  REQUIRE(extent_indexes == std::vector<size_t>({0, 1, 2, 3, 4, 5, 6, 6, 6, 6, 5, 4, 3, 2, 1, 0}));
 
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+  uint32_t blocks_to_alloc = (1 << (28 - 6)) - 2;
+  auto blocks = allocator.AllocBlocks(blocks_to_alloc, BlockType::Cluster, false);
+  REQUIRE(blocks);
+  REQUIRE(blocks->size() == blocks_to_alloc);
+  REQUIRE(blocks->at(0) == 1 << 6);
+  REQUIRE(*blocks == CollectRange(std::views::iota(uint32_t{0}, blocks_to_alloc), [](auto i) { return (i + 1) << 6; }));
+  REQUIRE((kTreeBlocksCount - (blocks_to_alloc << 6)) == allocator.GetHeader()->free_blocks_count.value());
 
-    auto ranges = allocator.AllocAreaBlocks(kTreeBlocksCount, BlockType::Single);
-    REQUIRE(ranges);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
-
-    REQUIRE(ranges->size() == 1);
-    REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number());
-    REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount);
+  extent_indexes.clear();
+  for (const auto& extent : tree) {
+    extent_indexes.push_back(extent.bucket_index);
   }
 
-  SECTION("Alloc half area blocks") {
-    const uint32_t kTreeBlocksCount = 100;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
+  auto single_block = allocator.AllocBlocks(1, BlockType::Single, false);
+  REQUIRE(extent_indexes == std::vector<size_t>({0, 1, 1, 0}));
+  REQUIRE(single_block);
+  REQUIRE(single_block->at(0) == allocator.initial_frees_block_number());
+}
 
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator merges sequentially freed single blocks",
+                 "[free-blocks][allocator][integration]") {
+  const uint32_t kBlocksToFree = 10000;
+  const uint32_t kCacheBlocksCount = 600;
+  REQUIRE(allocator.Init(kCacheBlocksCount));
 
-    auto ranges = allocator.AllocAreaBlocks(kTreeBlocksCount / 2, BlockType::Single);
-    REQUIRE(ranges);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount / 2);
+  REQUIRE(std::ranges::all_of(std::views::iota(uint32_t{0}, kBlocksToFree), [this](uint32_t i) {
+    return allocator.AddFreeBlocks({i + allocator.initial_frees_block_number() + kCacheBlocksCount, 1});
+  }));
 
-    // Should be aligned to end
-    REQUIRE(ranges->size() == 1);
-    REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
-    REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
-    REQUIRE(allocator.IsRangeIsFree({allocator.initial_frees_block_number(), kTreeBlocksCount / 2}));
-    REQUIRE_FALSE(
-        allocator.IsRangeIsFree({allocator.initial_frees_block_number() + kTreeBlocksCount / 2, kTreeBlocksCount / 2}));
+  auto current_block_number = allocator.initial_frees_block_number() + kCacheBlocksCount;
+  FreeBlocksTree tree{&allocator};
+  std::vector<size_t> extent_indexes;
+  for (const auto& extent : tree) {
+    REQUIRE(extent.block_number() == current_block_number);
+    current_block_number += extent.blocks_count();
+    extent_indexes.push_back(extent.bucket_index);
   }
+  REQUIRE(current_block_number == allocator.initial_frees_block_number() + kCacheBlocksCount + kBlocksToFree);
+  REQUIRE(extent_indexes == std::vector<size_t>({0, 1, 2, 3, 2, 1, 0}));
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() - allocator.GetHeader()->free_blocks_cache_count.value() ==
+          kBlocksToFree);
+}
 
-  SECTION("Alloc fragmented area") {
-    const uint32_t kTreeBlocksCount = 100;
-    const uint32_t kAreaBlocksToAlloc = 150;
-    const uint32_t kSecondFragmentAddress = 1000;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator merges randomly freed single blocks",
+                 "[free-blocks][allocator][integration]") {
+  const uint32_t kBlocksToFree = 10000;
+  const uint32_t kCacheBlocksCount = 600;
+  REQUIRE(allocator.Init(kCacheBlocksCount));
 
-    REQUIRE(allocator.AddFreeBlocks({kSecondFragmentAddress, kTreeBlocksCount}));
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2);
+  auto blocks_to_free = SequentialKeys(kBlocksToFree);
+  std::ranges::shuffle(blocks_to_free, std::default_random_engine{Catch::getSeed()});
+  REQUIRE(std::ranges::all_of(blocks_to_free, [this](uint32_t i) {
+    return allocator.AddFreeBlocks({i + allocator.initial_frees_block_number() + kCacheBlocksCount, 1});
+  }));
 
-    auto ranges = allocator.AllocAreaBlocks(kAreaBlocksToAlloc, BlockType::Single);
-    REQUIRE(ranges);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2 - kAreaBlocksToAlloc);
-
-    REQUIRE(ranges->size() == 2);
-    REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
-    REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
-    REQUIRE(ranges->at(1).block_number == kSecondFragmentAddress);
-    REQUIRE(ranges->at(1).blocks_count == kTreeBlocksCount);
+  auto current_block_number = allocator.initial_frees_block_number() + kCacheBlocksCount;
+  FreeBlocksTree tree{&allocator};
+  std::vector<size_t> extent_indexes;
+  uint32_t released_ftrees = 0;
+  for (const auto& extent : tree) {
+    if (extent.block_number() < allocator.initial_frees_block_number() + kCacheBlocksCount) {
+      released_ftrees += extent.blocks_count();
+      continue;
+    }
+    REQUIRE(extent.block_number() == current_block_number);
+    current_block_number += extent.blocks_count();
+    extent_indexes.push_back(extent.bucket_index);
   }
+  REQUIRE(current_block_number == allocator.initial_frees_block_number() + kCacheBlocksCount + kBlocksToFree);
+  REQUIRE(extent_indexes == std::vector<size_t>({0, 1, 2, 3, 2, 1, 0}));
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() - allocator.GetHeader()->free_blocks_cache_count.value() -
+              released_ftrees ==
+          kBlocksToFree);
+}
 
-  SECTION("Alloc fragmented area 2") {
-    const uint32_t kTreeBlocksCount = 100;
-    const uint32_t kAreaBlocksToAlloc = 150;
-    const uint32_t kSecondFragmentAddress = 1000;
-    const uint32_t kThirdFragmentAddress = 2000;
-    REQUIRE(allocator.Init(0, kTreeBlocksCount));
-    // no cache
-    allocator.set_blocks_cache_size_log2(0);
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator replenishes cache from the tree",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 10000;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(3);
 
-    REQUIRE(allocator.AddFreeBlocks({kSecondFragmentAddress, kTreeBlocksCount / 2}));
-    REQUIRE(allocator.AddFreeBlocks({kThirdFragmentAddress, kTreeBlocksCount}));
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2.5);
+  auto blocks = allocator.AllocBlocks(1, BlockType::Single, true);
+  REQUIRE(blocks);
+  REQUIRE(blocks->at(0) == 8);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount - 1);
+  REQUIRE(allocator.GetHeader()->free_blocks_cache.value() == 9);
+  REQUIRE(allocator.GetHeader()->free_blocks_cache_count.value() == 7);
+  REQUIRE_FALSE(allocator.IsRangeIsFree({9, 1}));
+  REQUIRE(allocator.IsRangeIsFree({3, 1}));
+}
 
-    auto ranges = allocator.AllocAreaBlocks(kAreaBlocksToAlloc, BlockType::Single);
-    REQUIRE(ranges);
-    REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2.5 - kAreaBlocksToAlloc);
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates one area range",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
 
-    // Second fragment should be ignore because it is the smallest
-    REQUIRE(ranges->size() == 2);
-    REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
-    REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
-    REQUIRE(ranges->at(1).block_number == kThirdFragmentAddress);
-    REQUIRE(ranges->at(1).blocks_count == kTreeBlocksCount);
-  }
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+
+  auto ranges = allocator.AllocAreaBlocks(kTreeBlocksCount, BlockType::Single);
+  REQUIRE(ranges);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 0);
+  REQUIRE(ranges->size() == 1);
+  REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number());
+  REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount);
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates the second half of one area range",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount);
+
+  auto ranges = allocator.AllocAreaBlocks(kTreeBlocksCount / 2, BlockType::Single);
+  REQUIRE(ranges);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount / 2);
+  REQUIRE(ranges->size() == 1);
+  REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
+  REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
+  REQUIRE(allocator.IsRangeIsFree({allocator.initial_frees_block_number(), kTreeBlocksCount / 2}));
+  REQUIRE_FALSE(
+      allocator.IsRangeIsFree({allocator.initial_frees_block_number() + kTreeBlocksCount / 2, kTreeBlocksCount / 2}));
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator allocates fragmented area ranges",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  const uint32_t kAreaBlocksToAlloc = 150;
+  const uint32_t kSecondFragmentAddress = 1000;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.AddFreeBlocks({kSecondFragmentAddress, kTreeBlocksCount}));
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2);
+
+  auto ranges = allocator.AllocAreaBlocks(kAreaBlocksToAlloc, BlockType::Single);
+  REQUIRE(ranges);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 2 - kAreaBlocksToAlloc);
+  REQUIRE(ranges->size() == 2);
+  REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
+  REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
+  REQUIRE(ranges->at(1).block_number == kSecondFragmentAddress);
+  REQUIRE(ranges->at(1).blocks_count == kTreeBlocksCount);
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator skips too-small area fragments",
+                 "[free-blocks][allocator][unit]") {
+  const uint32_t kTreeBlocksCount = 100;
+  const uint32_t kAreaBlocksToAlloc = 150;
+  const uint32_t kSecondFragmentAddress = 1000;
+  const uint32_t kThirdFragmentAddress = 2000;
+  REQUIRE(allocator.Init(0, kTreeBlocksCount));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.AddFreeBlocks({kSecondFragmentAddress, kTreeBlocksCount / 2}));
+  REQUIRE(allocator.AddFreeBlocks({kThirdFragmentAddress, kTreeBlocksCount}));
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 5 / 2);
+
+  auto ranges = allocator.AllocAreaBlocks(kAreaBlocksToAlloc, BlockType::Single);
+  REQUIRE(ranges);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == kTreeBlocksCount * 5 / 2 - kAreaBlocksToAlloc);
+  REQUIRE(ranges->size() == 2);
+  REQUIRE(ranges->at(0).block_number == allocator.initial_frees_block_number() + kTreeBlocksCount / 2);
+  REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
+  REQUIRE(ranges->at(1).block_number == kThirdFragmentAddress);
+  REQUIRE(ranges->at(1).blocks_count == kTreeBlocksCount);
 }

--- a/tests/free_blocks_tree_bucket_tests.cpp
+++ b/tests/free_blocks_tree_bucket_tests.cpp
@@ -12,204 +12,171 @@
 
 #include "free_blocks_tree_bucket.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
-TEST_CASE("FreeBlocksTreeBucketTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto allocator_block = TestBlock::LoadMetadataBlock(test_device, 0);
-  TestFreeBlocksAllocator allocator{allocator_block, test_device};
-  REQUIRE(allocator.Init(1000000));
+namespace {
 
+class FreeBlocksTreeBucketFixture : public FreeBlocksAllocatorFixture {
+ public:
+  FreeBlocksTreeBucketFixture() { allocator_initialized = allocator.Init(1000000); }
+
+  bool allocator_initialized = false;
   FreeBlocksTreeBucket bucket{&allocator, 3};
+};
 
-  SECTION("iterate empty tree") {
-    REQUIRE(std::distance(bucket.begin(), bucket.end()) == 0);
+constexpr int kFreeBlocksBucketStressItems = 600 * 300;
+
+}  // namespace
+
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket is empty after initialization",
+                 "[free-blocks][tree-bucket][unit]") {
+  REQUIRE(allocator_initialized);
+
+  REQUIRE(std::distance(bucket.begin(), bucket.end()) == 0);
+}
+
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket inserts sorted extents",
+                 "[free-blocks][tree-bucket][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kFreeBlocksBucketStressItems; ++i) {
+    REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
   }
 
-  SECTION("insert items sorted") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
-    }
+  REQUIRE(CollectFreeExtents(bucket) == SequentialFreeExtents(kFreeBlocksBucketStressItems, 3));
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(bucket,
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, kItemsCount), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i, static_cast<nibble>(i % 16), static_cast<size_t>(3)};
-        })));
+  for (uint32_t i = 0; i < kFreeBlocksBucketStressItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*bucket.find(i, true)).key() == i);
+  }
+}
 
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*bucket.find(i, true)).key() == i);
-    }
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket keeps unsorted inserts ordered and searchable",
+                 "[free-blocks][tree-bucket][stress]") {
+  REQUIRE(allocator_initialized);
+
+  auto unsorted_keys = createShuffledKeysArray<kFreeBlocksBucketStressItems>();
+  for (auto key : unsorted_keys) {
+    REQUIRE(bucket.insert({key, static_cast<nibble>(key % 16)}));
   }
 
-  SECTION("insert items unsorted") {
-    constexpr int kItemsCount = 600 * 300;
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    for (auto key : unsorted_keys) {
-      REQUIRE(bucket.insert({key, static_cast<nibble>(key % 16)}));
-    }
+  auto sorted_keys = unsorted_keys;
+  std::ranges::sort(sorted_keys);
+  REQUIRE(CollectKeys(bucket) == sorted_keys);
+  REQUIRE(CollectFreeExtents(bucket) == SequentialFreeExtents(kFreeBlocksBucketStressItems, 3));
 
-    // Check that the tree is sorted
-    auto keys = std::views::transform(bucket, [](const auto& extent) -> uint32_t { return extent.key(); });
-    auto sorted_keys = unsorted_keys;
-    std::ranges::sort(sorted_keys);
-    REQUIRE(std::ranges::equal(sorted_keys, keys));
+  for (uint32_t i = 0; i < kFreeBlocksBucketStressItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*bucket.find(i, true)).key() == i);
+  }
+}
 
-    // Check the values
-    REQUIRE(std::ranges::equal(
-        std::views::transform(bucket,
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, kItemsCount), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i, static_cast<nibble>(i % 16), static_cast<size_t>(3)};
-        })));
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket erases shuffled extents and releases backing blocks",
+                 "[free-blocks][tree-bucket][stress]") {
+  REQUIRE(allocator_initialized);
 
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*bucket.find(i, true)).key() == i);
-    }
+  for (uint32_t i = 0; i < kFreeBlocksBucketStressItems; ++i) {
+    REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
   }
 
-  SECTION("erase items randomly") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
-    }
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    auto middle = unsorted_keys.begin() + kItemsCount / 2;
-    std::vector<FreeBlocksRangeInfo> blocks_to_delete;
-    // Remove half the items first
-    for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
-      REQUIRE(bucket.erase(key, blocks_to_delete));
-    }
-
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right items were deleted
-    REQUIRE(std::ranges::equal(std::views::transform(bucket, [](const auto& extent) -> int { return extent.key(); }),
-                               sorted_upper_half));
-
-    // Remove the second half
-    for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
-      REQUIRE(bucket.erase(key, blocks_to_delete));
-    }
-
-    // Should be empty
-    REQUIRE(bucket.begin() == bucket.end());
-
-    auto blocks_numbers_to_delete = std::ranges::to<std::vector>(
-        std::views::transform(blocks_to_delete, [](const FreeBlocksRangeInfo& range) { return range.block_number; }));
-
-    std::ranges::sort(blocks_numbers_to_delete);
-    // Check deleted blocks, everything beside first ftree should be deleted
-    REQUIRE(std::ranges::equal(blocks_numbers_to_delete, std::views::iota(allocator.initial_frees_block_number(),
-                                                                          allocator.AllocFreeBlockFromCache())));
+  auto unsorted_keys = createShuffledKeysArray<kFreeBlocksBucketStressItems>();
+  auto middle = unsorted_keys.begin() + kFreeBlocksBucketStressItems / 2;
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
+    CAPTURE(key);
+    REQUIRE(bucket.erase(key, blocks_to_delete));
   }
 
-  SECTION("empty ftree find") {
-    EPTree eptree{&allocator};
-    // Have three empty ftrees, check that items are added to the correct ones, and check how find works with them.
-    auto ftree_100_to_200_block_number = allocator.AllocFreeBlockFromCache();
-    auto ftree_100_to_200_block = allocator.LoadAllocatorBlock(ftree_100_to_200_block_number, true);
-    FTreesBlock{ftree_100_to_200_block}.Init();
-    REQUIRE(eptree.insert({100, ftree_100_to_200_block_number}));
-    auto ftree_200_plus_block_number = allocator.AllocFreeBlockFromCache();
-    auto ftree_200_plus_block = allocator.LoadAllocatorBlock(ftree_200_plus_block_number, true);
-    FTreesBlock{ftree_200_plus_block}.Init();
-    REQUIRE(eptree.insert({200, ftree_200_plus_block_number}));
+  auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
+  std::ranges::sort(sorted_upper_half);
+  REQUIRE(CollectKeys(bucket) == sorted_upper_half);
 
-    auto ftree_0_to_100_block = allocator.LoadAllocatorBlock(allocator.initial_ftrees_block_number(), false);
-    FTree ftree1{ftree_0_to_100_block, 3};
-    FTree ftree2{ftree_100_to_200_block, 3};
-    FTree ftree3{ftree_200_plus_block, 3};
-
-    REQUIRE(ftree1.empty());
-    REQUIRE(ftree2.empty());
-    REQUIRE(ftree3.empty());
-    REQUIRE(bucket.find(150, false) == bucket.end());
-
-    // insert to first ftree
-    REQUIRE(bucket.insert({50, nibble{0}}));
-    REQUIRE(ftree1.size() == 1);
-    REQUIRE(ftree2.empty());
-    REQUIRE(ftree3.empty());
-    REQUIRE(bucket.find(150, false) != bucket.end());
-    REQUIRE((*bucket.find(150, false)).key() == 50);
-    REQUIRE((*bucket.find(25, false)).key() == 50);
-    REQUIRE(std::ranges::equal(std::views::transform(bucket, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{50}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(bucket), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{50}));
-
-    REQUIRE(bucket.insert({160, nibble{0}}));
-    REQUIRE(ftree1.size() == 1);
-    REQUIRE(ftree2.size() == 1);
-    REQUIRE(ftree3.empty());
-    REQUIRE((*bucket.find(150, false)).key() == 50);
-    REQUIRE((*bucket.find(250, false)).key() == 160);
-    REQUIRE(std::ranges::equal(std::views::transform(bucket, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{50, 160}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(bucket), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{160, 50}));
-
-    std::vector<FreeBlocksRangeInfo> blocks_to_delete;
-    REQUIRE(bucket.erase(50, blocks_to_delete));
-    REQUIRE(blocks_to_delete.empty());  // first block should delete it
-    REQUIRE(ftree1.empty());
-    REQUIRE(ftree2.size() == 1);
-    REQUIRE(ftree3.empty());
-    REQUIRE((*bucket.find(150, false)).key() == 160);
-    REQUIRE((*bucket.find(250, false)).key() == 160);
-    REQUIRE((*bucket.find(25, false)).key() == 160);
-    REQUIRE(std::ranges::equal(std::views::transform(bucket, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{160}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(bucket), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{160}));
+  for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
+    CAPTURE(key);
+    REQUIRE(bucket.erase(key, blocks_to_delete));
   }
 
-  SECTION("check backward/forward iterator") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
-    }
+  REQUIRE(bucket.begin() == bucket.end());
 
-    auto it = bucket.begin();
-    uint32_t steps = 0;
-    while (it != bucket.end()) {
-      REQUIRE((*it).key() == steps);
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kItemsCount);
-    REQUIRE(it.is_end());
-    while (it != bucket.begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
+  auto blocks_numbers_to_delete =
+      CollectRange(blocks_to_delete, [](const FreeBlocksRangeInfo& range) { return range.block_number; });
+  std::ranges::sort(blocks_numbers_to_delete);
+  REQUIRE(blocks_numbers_to_delete ==
+          SequentialKeys(allocator.AllocFreeBlockFromCache() - allocator.initial_frees_block_number(),
+                         allocator.initial_frees_block_number()));
+}
 
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE((*it).key() == 20);
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket skips empty FTrees during non-exact find",
+                 "[free-blocks][tree-bucket][unit]") {
+  REQUIRE(allocator_initialized);
+
+  EPTree eptree{&allocator};
+  auto ftree_100_to_200_block_number = allocator.AllocFreeBlockFromCache();
+  auto ftree_100_to_200_block = allocator.LoadAllocatorBlock(ftree_100_to_200_block_number, true);
+  FTreesBlock{ftree_100_to_200_block}.Init();
+  REQUIRE(eptree.insert({100, ftree_100_to_200_block_number}));
+  auto ftree_200_plus_block_number = allocator.AllocFreeBlockFromCache();
+  auto ftree_200_plus_block = allocator.LoadAllocatorBlock(ftree_200_plus_block_number, true);
+  FTreesBlock{ftree_200_plus_block}.Init();
+  REQUIRE(eptree.insert({200, ftree_200_plus_block_number}));
+
+  auto ftree_0_to_100_block = allocator.LoadAllocatorBlock(allocator.initial_ftrees_block_number(), false);
+  FTree ftree1{ftree_0_to_100_block, 3};
+  FTree ftree2{ftree_100_to_200_block, 3};
+  FTree ftree3{ftree_200_plus_block, 3};
+
+  REQUIRE(ftree1.empty());
+  REQUIRE(ftree2.empty());
+  REQUIRE(ftree3.empty());
+  REQUIRE(bucket.find(150, false) == bucket.end());
+
+  REQUIRE(bucket.insert({50, nibble{0}}));
+  REQUIRE(ftree1.size() == 1);
+  REQUIRE(ftree2.empty());
+  REQUIRE(ftree3.empty());
+  REQUIRE(bucket.find(150, false) != bucket.end());
+  REQUIRE((*bucket.find(150, false)).key() == 50);
+  REQUIRE((*bucket.find(25, false)).key() == 50);
+  REQUIRE(CollectKeys(bucket) == std::vector<uint32_t>{50});
+  REQUIRE(CollectKeys(std::views::reverse(bucket)) == std::vector<uint32_t>{50});
+
+  REQUIRE(bucket.insert({160, nibble{0}}));
+  REQUIRE(ftree1.size() == 1);
+  REQUIRE(ftree2.size() == 1);
+  REQUIRE(ftree3.empty());
+  REQUIRE((*bucket.find(150, false)).key() == 50);
+  REQUIRE((*bucket.find(250, false)).key() == 160);
+  REQUIRE(CollectKeys(bucket) == std::vector<uint32_t>{50, 160});
+  REQUIRE(CollectKeys(std::views::reverse(bucket)) == std::vector<uint32_t>{160, 50});
+
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  REQUIRE(bucket.erase(50, blocks_to_delete));
+  REQUIRE(blocks_to_delete.empty());
+  REQUIRE(ftree1.empty());
+  REQUIRE(ftree2.size() == 1);
+  REQUIRE(ftree3.empty());
+  REQUIRE((*bucket.find(150, false)).key() == 160);
+  REQUIRE((*bucket.find(250, false)).key() == 160);
+  REQUIRE((*bucket.find(25, false)).key() == 160);
+  REQUIRE(CollectKeys(bucket) == std::vector<uint32_t>{160});
+  REQUIRE(CollectKeys(std::views::reverse(bucket)) == std::vector<uint32_t>{160});
+}
+
+TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
+                 "FreeBlocksTreeBucket iterator walks forward and backward",
+                 "[free-blocks][tree-bucket][iterator][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kFreeBlocksBucketStressItems; ++i) {
+    REQUIRE(bucket.insert({i, static_cast<nibble>(i % 16)}));
   }
+
+  RequireBidirectionalIteration(bucket, kFreeBlocksBucketStressItems, [](const auto& extent) { return extent.key(); });
 }

--- a/tests/free_blocks_tree_tests.cpp
+++ b/tests/free_blocks_tree_tests.cpp
@@ -13,205 +13,181 @@
 #include "free_blocks_tree.h"
 #include "free_blocks_tree_bucket.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
-TEST_CASE("FreeBlocksTreeTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto allocator_block = TestBlock::LoadMetadataBlock(test_device, 0);
-  TestFreeBlocksAllocator allocator{allocator_block, test_device};
-  REQUIRE(allocator.Init(1000000));
+namespace {
 
+class FreeBlocksTreeFixture : public FreeBlocksAllocatorFixture {
+ public:
+  FreeBlocksTreeFixture() { allocator_initialized = allocator.Init(1000000); }
+
+  bool allocator_initialized = false;
   FreeBlocksTree tree{&allocator};
+};
 
-  SECTION("iterate empty tree") {
-    REQUIRE(std::distance(tree.begin(), tree.end()) == 0);
+constexpr int kFreeBlocksTreeStressItems = 600 * 300;
+
+void InsertIntoBucket(TestFreeBlocksAllocator& allocator, uint32_t key) {
+  REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.insert({key, static_cast<nibble>(key % 16)}));
+}
+
+std::vector<std::tuple<uint32_t, nibble, size_t>> ExpectedTreeExtents(uint32_t count) {
+  std::vector<std::tuple<uint32_t, nibble, size_t>> values;
+  values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values.emplace_back(i, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size()));
+  }
+  return values;
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(FreeBlocksTreeFixture, "FreeBlocksTree is empty after initialization", "[free-blocks][tree][unit]") {
+  REQUIRE(allocator_initialized);
+
+  REQUIRE(std::distance(tree.begin(), tree.end()) == 0);
+}
+
+TEST_CASE_METHOD(FreeBlocksTreeFixture, "FreeBlocksTree inserts sorted extents", "[free-blocks][tree][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kFreeBlocksTreeStressItems; ++i) {
+    InsertIntoBucket(allocator, i);
   }
 
-  SECTION("insert items sorted") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, i % kSizeBuckets.size()}.insert({i, static_cast<nibble>(i % 16)}));
-    }
+  REQUIRE(CollectFreeExtents(tree) == ExpectedTreeExtents(kFreeBlocksTreeStressItems));
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(tree,
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, kItemsCount), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
-        })));
+  for (uint32_t i = 0; i < kFreeBlocksTreeStressItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*tree.find(i)).key() == i);
+  }
+}
 
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*tree.find(i)).key() == i);
-    }
+TEST_CASE_METHOD(FreeBlocksTreeFixture,
+                 "FreeBlocksTree keeps unsorted inserts ordered and searchable",
+                 "[free-blocks][tree][stress]") {
+  REQUIRE(allocator_initialized);
+
+  auto unsorted_keys = createShuffledKeysArray<kFreeBlocksTreeStressItems>();
+  for (auto key : unsorted_keys) {
+    InsertIntoBucket(allocator, key);
   }
 
-  SECTION("insert items unsorted") {
-    constexpr int kItemsCount = 600 * 300;
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    for (auto key : unsorted_keys) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.insert({key, static_cast<nibble>(key % 16)}));
-    }
+  auto sorted_keys = unsorted_keys;
+  std::ranges::sort(sorted_keys);
+  REQUIRE(CollectKeys(tree) == sorted_keys);
+  REQUIRE(CollectFreeExtents(tree) == ExpectedTreeExtents(kFreeBlocksTreeStressItems));
 
-    // Check that the tree is sorted
-    auto keys = std::views::transform(tree, [](const auto& extent) -> uint32_t { return extent.key(); });
-    auto sorted_keys = unsorted_keys;
-    std::ranges::sort(sorted_keys);
-    REQUIRE(std::ranges::equal(sorted_keys, keys));
+  for (uint32_t i = 0; i < kFreeBlocksTreeStressItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*tree.find(i)).key() == i);
+  }
+}
 
-    // Check the values
-    REQUIRE(std::ranges::equal(
-        std::views::transform(tree,
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, kItemsCount), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
-        })));
+TEST_CASE_METHOD(FreeBlocksTreeFixture,
+                 "FreeBlocksTree erases shuffled extents and releases backing blocks",
+                 "[free-blocks][tree][stress]") {
+  REQUIRE(allocator_initialized);
 
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*tree.find(i)).key() == i);
-    }
+  for (uint32_t i = 0; i < kFreeBlocksTreeStressItems; ++i) {
+    InsertIntoBucket(allocator, i);
   }
 
-  SECTION("erase items randomly") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, i % kSizeBuckets.size()}.insert({i, static_cast<nibble>(i % 16)}));
-    }
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    auto middle = unsorted_keys.begin() + kItemsCount / 2;
-    std::vector<FreeBlocksRangeInfo> blocks_to_delete;
-    // Remove half the items first
-    for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.erase(key, blocks_to_delete));
-    }
-
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right items were deleted
-    REQUIRE(std::ranges::equal(std::views::transform(tree, [](const auto& extent) -> int { return extent.key(); }),
-                               sorted_upper_half));
-
-    // Remove the second half
-    for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.erase(key, blocks_to_delete));
-    }
-
-    // Should be empty
-    REQUIRE(tree.begin() == tree.end());
-
-    auto blocks_numbers_to_delete = std::ranges::to<std::vector>(
-        std::views::transform(blocks_to_delete, [](const FreeBlocksRangeInfo& range) { return range.block_number; }));
-
-    std::ranges::sort(blocks_numbers_to_delete);
-    // Check deleted blocks, everything beside first ftree should be deleted
-    REQUIRE(std::ranges::equal(blocks_numbers_to_delete, std::views::iota(allocator.initial_frees_block_number(),
-                                                                          allocator.AllocFreeBlockFromCache())));
+  auto unsorted_keys = createShuffledKeysArray<kFreeBlocksTreeStressItems>();
+  auto middle = unsorted_keys.begin() + kFreeBlocksTreeStressItems / 2;
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
+    CAPTURE(key);
+    REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.erase(key, blocks_to_delete));
   }
 
-  SECTION("empty ftree find") {
-    EPTree eptree{&allocator};
-    // Have three empty ftrees, check that items areadded to the correct ones, and check how find works with them.
-    FreeBlocksTreeBucket bucket{&allocator, 3};
-    auto ftree_100_to_200_block_number = allocator.AllocFreeBlockFromCache();
-    auto ftree_100_to_200_block = allocator.LoadAllocatorBlock(ftree_100_to_200_block_number, true);
-    FTreesBlock{ftree_100_to_200_block}.Init();
-    REQUIRE(eptree.insert({100, ftree_100_to_200_block_number}));
-    auto ftree_200_plus_block_number = allocator.AllocFreeBlockFromCache();
-    auto ftree_200_plus_block = allocator.LoadAllocatorBlock(ftree_200_plus_block_number, true);
-    FTreesBlock{ftree_200_plus_block}.Init();
-    REQUIRE(eptree.insert({200, ftree_200_plus_block_number}));
+  auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
+  std::ranges::sort(sorted_upper_half);
+  REQUIRE(CollectKeys(tree) == sorted_upper_half);
 
-    auto ftree_0_to_100_block = allocator.LoadAllocatorBlock(allocator.initial_ftrees_block_number(), false);
-    FTree ftree1{ftree_0_to_100_block, 3};
-    FTree ftree2{ftree_100_to_200_block, 3};
-    FTree ftree3{ftree_200_plus_block, 3};
-
-    REQUIRE(ftree1.empty());
-    REQUIRE(ftree2.empty());
-    REQUIRE(ftree3.empty());
-    REQUIRE(tree.find(150, false) == tree.end());
-
-    // insert to first ftree
-    REQUIRE(bucket.insert({50, nibble{0}}));
-    REQUIRE(ftree1.size() == 1);
-    REQUIRE(ftree2.empty());
-    REQUIRE(ftree3.empty());
-    REQUIRE(tree.find(150, false) != tree.end());
-    REQUIRE((*tree.find(150, false)).key() == 50);
-    REQUIRE((*tree.find(25, false)).key() == 50);
-    REQUIRE(std::ranges::equal(std::views::transform(tree, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{50}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(tree), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{50}));
-
-    REQUIRE(bucket.insert({160, nibble{0}}));
-    REQUIRE(ftree1.size() == 1);
-    REQUIRE(ftree2.size() == 1);
-    REQUIRE(ftree3.empty());
-    REQUIRE((*tree.find(150, false)).key() == 50);
-    REQUIRE((*tree.find(250, false)).key() == 160);
-    REQUIRE(std::ranges::equal(std::views::transform(tree, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{50, 160}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(tree), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{160, 50}));
-
-    std::vector<FreeBlocksRangeInfo> blocks_to_delete;
-    REQUIRE(bucket.erase(50, blocks_to_delete));
-    REQUIRE(blocks_to_delete.empty());  // first block should delete it
-    REQUIRE(ftree1.empty());
-    REQUIRE(ftree2.size() == 1);
-    REQUIRE(ftree3.empty());
-    REQUIRE((*tree.find(150, false)).key() == 160);
-    REQUIRE((*tree.find(250, false)).key() == 160);
-    REQUIRE((*tree.find(25, false)).key() == 160);
-    REQUIRE(std::ranges::equal(std::views::transform(tree, [](const auto& extent) -> int { return extent.key(); }),
-                               std::list<uint32_t>{160}));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::views::reverse(tree), [](const auto& extent) -> int { return extent.key(); }),
-        std::list<uint32_t>{160}));
+  for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
+    CAPTURE(key);
+    REQUIRE(FreeBlocksTreeBucket{&allocator, key % kSizeBuckets.size()}.erase(key, blocks_to_delete));
   }
 
-  SECTION("check backward/forward iterator") {
-    constexpr int kItemsCount = 600 * 300;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(FreeBlocksTreeBucket{&allocator, i % kSizeBuckets.size()}.insert({i, static_cast<nibble>(i % 16)}));
-    }
+  REQUIRE(tree.begin() == tree.end());
 
-    auto it = tree.begin();
-    uint32_t steps = 0;
-    while (it != tree.end()) {
-      REQUIRE((*it).key() == steps);
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kItemsCount);
-    REQUIRE(it.is_end());
-    while (it != tree.begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
+  auto blocks_numbers_to_delete =
+      CollectRange(blocks_to_delete, [](const FreeBlocksRangeInfo& range) { return range.block_number; });
+  std::ranges::sort(blocks_numbers_to_delete);
+  REQUIRE(blocks_numbers_to_delete ==
+          SequentialKeys(allocator.AllocFreeBlockFromCache() - allocator.initial_frees_block_number(),
+                         allocator.initial_frees_block_number()));
+}
 
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE((*it).key() == 20);
+TEST_CASE_METHOD(FreeBlocksTreeFixture,
+                 "FreeBlocksTree skips empty FTrees during non-exact find",
+                 "[free-blocks][tree][unit]") {
+  REQUIRE(allocator_initialized);
+
+  EPTree eptree{&allocator};
+  FreeBlocksTreeBucket bucket{&allocator, 3};
+  auto ftree_100_to_200_block_number = allocator.AllocFreeBlockFromCache();
+  auto ftree_100_to_200_block = allocator.LoadAllocatorBlock(ftree_100_to_200_block_number, true);
+  FTreesBlock{ftree_100_to_200_block}.Init();
+  REQUIRE(eptree.insert({100, ftree_100_to_200_block_number}));
+  auto ftree_200_plus_block_number = allocator.AllocFreeBlockFromCache();
+  auto ftree_200_plus_block = allocator.LoadAllocatorBlock(ftree_200_plus_block_number, true);
+  FTreesBlock{ftree_200_plus_block}.Init();
+  REQUIRE(eptree.insert({200, ftree_200_plus_block_number}));
+
+  auto ftree_0_to_100_block = allocator.LoadAllocatorBlock(allocator.initial_ftrees_block_number(), false);
+  FTree ftree1{ftree_0_to_100_block, 3};
+  FTree ftree2{ftree_100_to_200_block, 3};
+  FTree ftree3{ftree_200_plus_block, 3};
+
+  REQUIRE(ftree1.empty());
+  REQUIRE(ftree2.empty());
+  REQUIRE(ftree3.empty());
+  REQUIRE(tree.find(150, false) == tree.end());
+
+  REQUIRE(bucket.insert({50, nibble{0}}));
+  REQUIRE(ftree1.size() == 1);
+  REQUIRE(ftree2.empty());
+  REQUIRE(ftree3.empty());
+  REQUIRE(tree.find(150, false) != tree.end());
+  REQUIRE((*tree.find(150, false)).key() == 50);
+  REQUIRE((*tree.find(25, false)).key() == 50);
+  REQUIRE(CollectKeys(tree) == std::vector<uint32_t>{50});
+  REQUIRE(CollectKeys(std::views::reverse(tree)) == std::vector<uint32_t>{50});
+
+  REQUIRE(bucket.insert({160, nibble{0}}));
+  REQUIRE(ftree1.size() == 1);
+  REQUIRE(ftree2.size() == 1);
+  REQUIRE(ftree3.empty());
+  REQUIRE((*tree.find(150, false)).key() == 50);
+  REQUIRE((*tree.find(250, false)).key() == 160);
+  REQUIRE(CollectKeys(tree) == std::vector<uint32_t>{50, 160});
+  REQUIRE(CollectKeys(std::views::reverse(tree)) == std::vector<uint32_t>{160, 50});
+
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  REQUIRE(bucket.erase(50, blocks_to_delete));
+  REQUIRE(blocks_to_delete.empty());
+  REQUIRE(ftree1.empty());
+  REQUIRE(ftree2.size() == 1);
+  REQUIRE(ftree3.empty());
+  REQUIRE((*tree.find(150, false)).key() == 160);
+  REQUIRE((*tree.find(250, false)).key() == 160);
+  REQUIRE((*tree.find(25, false)).key() == 160);
+  REQUIRE(CollectKeys(tree) == std::vector<uint32_t>{160});
+  REQUIRE(CollectKeys(std::views::reverse(tree)) == std::vector<uint32_t>{160});
+}
+
+TEST_CASE_METHOD(FreeBlocksTreeFixture,
+                 "FreeBlocksTree iterator walks forward and backward",
+                 "[free-blocks][tree][iterator][stress]") {
+  REQUIRE(allocator_initialized);
+
+  for (uint32_t i = 0; i < kFreeBlocksTreeStressItems; ++i) {
+    InsertIntoBucket(allocator, i);
   }
+
+  RequireBidirectionalIteration(tree, kFreeBlocksTreeStressItems, [](const auto& extent) { return extent.key(); });
 }

--- a/tests/ftree_tests.cpp
+++ b/tests/ftree_tests.cpp
@@ -12,131 +12,92 @@
 
 #include "ftree.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 
-TEST_CASE("FTreeTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto ftrees_block = TestBlock::LoadMetadataBlock(test_device, 0);
-  FTreesBlock{ftrees_block}.Init();
+namespace {
 
-  auto ftrees = std::ranges::iota_view(size_t{0}, kSizeBuckets.size()) |
-                std::views::transform([&ftrees_block](size_t i) -> FTree { return FTree{ftrees_block, i}; }) |
-                std::ranges::to<std::vector>();
-
-  SECTION("Check empty ftree size") {
-    for (size_t i = 0; i < kSizeBuckets.size(); ++i)
-      REQUIRE(ftrees[i].size() == 0);
+class FTreeFixture : public MetadataBlockFixture {
+ public:
+  FTreeFixture() {
+    FTreesBlock{ftrees_block}.Init();
+    ftrees = std::ranges::iota_view(size_t{0}, kSizeBuckets.size()) |
+             std::views::transform([this](size_t i) -> FTree { return FTree{ftrees_block, i}; }) |
+             std::ranges::to<std::vector>();
   }
 
-  SECTION("insert and erase sorted item") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
-    }
+  std::shared_ptr<TestBlock> ftrees_block = LoadMetadataBlock(0);
+  std::vector<FTree> ftrees;
+};
 
-    // Tree should fill now
-    uint32_t inserted = 0;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      inserted += ftrees[1].insert({i, static_cast<nibble>(i % 16)}) ? 1 : 0;
-    }
-    REQUIRE(inserted < kItemsCount);
+constexpr int kFTreeItems = 500;
 
-    // should be full
-    REQUIRE_FALSE(ftrees[2].insert({0, nibble{0}}));
+auto CollectFTreeValues(FTree& ftree) {
+  return CollectRange(ftree,
+                      [](const auto& extent) -> std::pair<uint32_t, nibble> { return {extent.key(), extent.value()}; });
+}
 
-    REQUIRE(ftrees[0].size() == kItemsCount);
-    REQUIRE(ftrees[1].size() == inserted);
-    REQUIRE(ftrees[2].size() == 0);
+}  // namespace
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            ftrees[0],
-            [](const auto& extent) -> std::pair<uint32_t, nibble> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(0, kItemsCount),
-                              [](int i) -> std::pair<uint32_t, nibble> { return {i, static_cast<nibble>(i % 16)}; })));
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            ftrees[1],
-            [](const auto& extent) -> std::pair<uint32_t, nibble> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(uint32_t{0}, inserted),
-                              [](int i) -> std::pair<uint32_t, nibble> { return {i, static_cast<nibble>(i % 16)}; })));
+TEST_CASE_METHOD(FTreeFixture, "FTree buckets are empty after initialization", "[ftree][unit]") {
+  for (size_t i = 0; i < kSizeBuckets.size(); ++i) {
+    REQUIRE(ftrees[i].size() == 0);
+  }
+}
 
-    ftrees[0].erase(ftrees[0].begin(), ftrees[0].end());
-    REQUIRE(ftrees[0].size() == 0);
-
-    // Should be able to fill ftrees[2] now
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees[2].insert({i, static_cast<nibble>(i % 16)}));
-    }
-    REQUIRE(ftrees[2].size() == kItemsCount);
+TEST_CASE_METHOD(FTreeFixture, "FTree erases data and frees space for another bucket", "[ftree][unit]") {
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
   }
 
-  SECTION("insert compact") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
-    }
-    REQUIRE(ftrees[0].size() == kItemsCount);
+  uint32_t inserted = 0;
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    inserted += ftrees[1].insert({i, static_cast<nibble>(i % 16)}) ? 1 : 0;
+  }
+  REQUIRE(inserted < kFTreeItems);
+  REQUIRE_FALSE(ftrees[2].insert({0, nibble{0}}));
 
-    FTree ftree{TestBlock::LoadMetadataBlock(test_device, 1), 0};
-    ftree.Init();
-    REQUIRE(ftree.insert_compact(ftrees[0].begin(), ftrees[0].end()));
+  REQUIRE(ftrees[0].size() == kFTreeItems);
+  REQUIRE(ftrees[1].size() == inserted);
+  REQUIRE(ftrees[2].size() == 0);
+  REQUIRE(CollectFTreeValues(ftrees[0]) == SequentialNibbleValues(kFTreeItems));
 
-    // Check that the tree is completly identical and valid.
-    REQUIRE(ftree.size() == kItemsCount);
-    REQUIRE(std::distance(ftree.begin(), ftree.end()) == kItemsCount);
-    REQUIRE(std::ranges::equal(ftrees[0], ftree));
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE((*ftree.find(i)).key() == i);
-      REQUIRE((*ftree.find(i)).value() == static_cast<nibble>(i % 16));
-    }
+  auto expected_inserted = SequentialNibbleValues(inserted);
+  REQUIRE(CollectFTreeValues(ftrees[1]) == expected_inserted);
+
+  ftrees[0].erase(ftrees[0].begin(), ftrees[0].end());
+  REQUIRE(ftrees[0].size() == 0);
+
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    REQUIRE(ftrees[2].insert({i, static_cast<nibble>(i % 16)}));
+  }
+  REQUIRE(ftrees[2].size() == kFTreeItems);
+}
+
+TEST_CASE_METHOD(FTreeFixture, "FTree compact insert produces an equivalent tree", "[ftree][unit]") {
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
+  }
+  REQUIRE(ftrees[0].size() == kFTreeItems);
+
+  FTree ftree{LoadMetadataBlock(1), 0};
+  ftree.Init();
+  REQUIRE(ftree.insert_compact(ftrees[0].begin(), ftrees[0].end()));
+
+  REQUIRE(ftree.size() == kFTreeItems);
+  REQUIRE(std::distance(ftree.begin(), ftree.end()) == kFTreeItems);
+  REQUIRE(std::ranges::equal(ftrees[0], ftree));
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    CAPTURE(i);
+    REQUIRE((*ftree.find(i)).key() == i);
+    REQUIRE((*ftree.find(i)).value() == static_cast<nibble>(i % 16));
+  }
+}
+
+TEST_CASE_METHOD(FTreeFixture, "FTree iterator walks forward and backward", "[ftree][iterator][unit]") {
+  for (uint32_t i = 0; i < kFTreeItems; ++i) {
+    REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
   }
 
-  SECTION("check backward/forward iterator") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees[0].insert({i, static_cast<nibble>(i % 16)}));
-    }
-
-    auto it = ftrees[0].begin();
-    uint32_t steps = 0;
-    while (it != ftrees[0].end()) {
-      REQUIRE((*it).key() == steps);
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kItemsCount);
-    REQUIRE(it.is_end());
-    while (it != ftrees[0].begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
-
-    for (int i = 0; i < 4; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 2; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE((*it).key() == 22);
-  }
+  RequireBidirectionalIteration(ftrees[0], kFTreeItems, [](const auto& extent) { return extent.key(); }, 44, 22);
 }

--- a/tests/ftrees_tests.cpp
+++ b/tests/ftrees_tests.cpp
@@ -8,201 +8,136 @@
 #include <catch2/catch_test_macros.hpp>
 
 #include <algorithm>
+#include <array>
 #include <ranges>
 
 #include "ftrees.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 
-TEST_CASE("FTreesTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto ftrees_block = TestBlock::LoadMetadataBlock(test_device, 0);
+namespace {
+
+class FTreesFixture : public MetadataBlockFixture {
+ public:
+  FTreesFixture() { ftrees.Init(); }
+
+  std::shared_ptr<TestBlock> ftrees_block = LoadMetadataBlock(0);
   FTrees ftrees{ftrees_block};
-  ftrees.Init();
+};
 
-  SECTION("Check empty ftrees empty") {
-    REQUIRE(ftrees.empty());
+constexpr int kFTreesItems = 500;
+
+std::vector<std::tuple<uint32_t, nibble, size_t>> ExpectedFTreesExtents(uint32_t count) {
+  std::vector<std::tuple<uint32_t, nibble, size_t>> values;
+  values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values.emplace_back(i, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size()));
+  }
+  return values;
+}
+
+std::vector<std::tuple<uint32_t, nibble, size_t>> ExpectedEvenKeyExtents(uint32_t begin, uint32_t end) {
+  std::vector<std::tuple<uint32_t, nibble, size_t>> values;
+  values.reserve(end - begin);
+  for (uint32_t i = begin; i < end; ++i) {
+    values.emplace_back(i * 2, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size()));
+  }
+  return values;
+}
+
+void InsertRoundRobin(FTrees& ftrees, uint32_t count, size_t buckets_count = kSizeBuckets.size()) {
+  for (uint32_t i = 0; i < count; ++i) {
+    REQUIRE(ftrees.ftrees()[i % buckets_count].insert({i, static_cast<nibble>(i % 16)}));
+  }
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees is empty after initialization", "[ftrees][unit]") {
+  REQUIRE(ftrees.empty());
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees inserts sorted extents across buckets", "[ftrees][unit]") {
+  InsertRoundRobin(ftrees, kFTreesItems);
+
+  REQUIRE(!ftrees.empty());
+  REQUIRE(ftrees.size() == kFTreesItems);
+  REQUIRE(CollectFreeExtents(ftrees) == ExpectedFTreesExtents(kFTreesItems));
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees reverse iterator walks descending extents", "[ftrees][iterator][unit]") {
+  InsertRoundRobin(ftrees, kFTreesItems);
+
+  auto expected = ExpectedFTreesExtents(kFTreesItems);
+  std::ranges::reverse(expected);
+  REQUIRE(CollectFreeExtents(std::views::reverse(ftrees)) == expected);
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees iterator walks forward and backward", "[ftrees][iterator][unit]") {
+  InsertRoundRobin(ftrees, kFTreesItems, kSizeBuckets.size() - 2);
+
+  RequireBidirectionalIteration(ftrees, kFTreesItems, [](const auto& extent) { return extent.key(); });
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees find returns exact and nearest extents", "[ftrees][unit]") {
+  for (uint32_t i = 0; i < kFTreesItems; ++i) {
+    REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i * 2, static_cast<nibble>(i % 16)}));
   }
 
-  SECTION("insert sorted items") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i, static_cast<nibble>(i % 16)}));
-    }
-    REQUIRE(!ftrees.empty());
-    REQUIRE(ftrees.size() == kItemsCount);
+  auto it = ftrees.find(523);
+  REQUIRE(it.is_end());
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(ftrees,
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, kItemsCount), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
-        })));
+  it = ftrees.find(523, false);
+  REQUIRE((*it).key() == 522);
+  REQUIRE(CollectFreeExtents(std::ranges::subrange(ftrees.begin(), it)) == ExpectedEvenKeyExtents(0, 522 / 2));
+  REQUIRE(CollectFreeExtents(std::ranges::subrange(it, ftrees.end())) == ExpectedEvenKeyExtents(522 / 2, kFTreesItems));
+
+  it = ftrees.find(840);
+  REQUIRE((*it).key() == 840);
+  REQUIRE(CollectFreeExtents(std::ranges::subrange(ftrees.begin(), it)) == ExpectedEvenKeyExtents(0, 840 / 2));
+  REQUIRE(CollectFreeExtents(std::ranges::subrange(it, ftrees.end())) == ExpectedEvenKeyExtents(840 / 2, kFTreesItems));
+
+  REQUIRE((*ftrees.find(4, false)).key() == 4);
+  REQUIRE((*ftrees.find(6, false)).key() == 6);
+  REQUIRE((*++ftrees.find(4, false)).key() == 6);
+  REQUIRE((*++ftrees.find(14, false)).key() == 16);
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees split preserves both halves", "[ftrees][unit]") {
+  InsertRoundRobin(ftrees, kFTreesItems);
+
+  key_type split_point;
+  std::array<FTrees, 2> new_ftrees{FTrees{LoadMetadataBlock(1)}, FTrees{LoadMetadataBlock(2)}};
+  new_ftrees[0].Init();
+  new_ftrees[1].Init();
+  ftrees.split(new_ftrees[0], new_ftrees[1], split_point);
+
+  REQUIRE(split_point == 252);
+  REQUIRE(new_ftrees[0].size() == split_point);
+  REQUIRE(new_ftrees[1].size() == kFTreesItems - split_point);
+  REQUIRE(std::ranges::size(new_ftrees[0]) == split_point);
+  REQUIRE(std::ranges::size(new_ftrees[1]) == kFTreesItems - split_point);
+  REQUIRE(std::ranges::distance(new_ftrees[0].begin(), new_ftrees[0].end()) == static_cast<int>(split_point));
+  REQUIRE(std::ranges::distance(new_ftrees[1].begin(), new_ftrees[1].end()) ==
+          static_cast<int>(kFTreesItems - split_point));
+  REQUIRE(std::ranges::equal(std::ranges::subrange(ftrees.begin(), ftrees.find(split_point)), new_ftrees[0]));
+  REQUIRE(std::ranges::equal(std::ranges::subrange(ftrees.find(split_point), ftrees.end()), new_ftrees[1]));
+}
+
+TEST_CASE_METHOD(FTreesFixture, "FTrees split chooses the middle of the largest bucket", "[ftrees][unit]") {
+  for (uint32_t i = 0; i < kFTreesItems; ++i) {
+    REQUIRE(ftrees.ftrees()[5].insert({i, static_cast<nibble>(i % 16)}));
   }
+  REQUIRE(ftrees.ftrees()[4].insert({700, nibble{0}}));
+  REQUIRE(ftrees.ftrees()[6].insert({800, nibble{0}}));
+  REQUIRE(ftrees.ftrees()[2].insert({1000, nibble{0}}));
 
-  SECTION("check backward iterator") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i, static_cast<nibble>(i % 16)}));
-    }
+  key_type split_point;
+  std::array<FTrees, 2> new_ftrees{FTrees{LoadMetadataBlock(1)}, FTrees{LoadMetadataBlock(2)}};
+  new_ftrees[0].Init();
+  new_ftrees[1].Init();
+  ftrees.split(new_ftrees[0], new_ftrees[1], split_point);
 
-    REQUIRE(std::ranges::equal(std::views::transform(std::views::reverse(ftrees),
-                                                     [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {extent.key(), extent.value(), extent.bucket_index};
-                                                     }),
-                               std::views::transform(std::views::reverse(std::views::iota(0, kItemsCount)),
-                                                     [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {i, static_cast<nibble>(i % 16),
-                                                               static_cast<size_t>(i % kSizeBuckets.size())};
-                                                     })));
-  }
-
-  SECTION("check backward/forward iterator") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[i % (kSizeBuckets.size() - 2)].insert({i, static_cast<nibble>(i % 16)}));
-    }
-
-    auto it = ftrees.begin();
-    uint32_t steps = 0;
-    while (it != ftrees.end()) {
-      REQUIRE((*it).key() == steps);
-      ++it;
-      ++steps;
-    }
-    REQUIRE(steps == kItemsCount);
-    REQUIRE(it.is_end());
-    while (it != ftrees.begin()) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE(steps == 0);
-    REQUIRE(it.is_begin());
-
-    for (int i = 0; i < 40; ++i) {
-      ++it;
-      ++steps;
-      REQUIRE((*it).key() == steps);
-    }
-    for (int i = 0; i < 20; ++i) {
-      --it;
-      --steps;
-      REQUIRE((*it).key() == steps);
-    }
-    REQUIRE((*it).key() == 20);
-  }
-
-  SECTION("check find") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i * 2, static_cast<nibble>(i % 16)}));
-    }
-
-    auto it = ftrees.find(523);
-    REQUIRE(it.is_end());
-
-    it = ftrees.find(523, false);
-    REQUIRE((*it).key() == 522);
-
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::ranges::subrange(ftrees.begin(), it),
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, 522 / 2), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i * 2, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
-        })));
-    REQUIRE(std::ranges::equal(std::views::transform(std::ranges::subrange(it, ftrees.end()),
-                                                     [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {extent.key(), extent.value(), extent.bucket_index};
-                                                     }),
-                               std::views::transform(std::views::iota(522 / 2, kItemsCount),
-                                                     [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {i * 2, static_cast<nibble>(i % 16),
-                                                               static_cast<size_t>(i % kSizeBuckets.size())};
-                                                     })));
-
-    it = ftrees.find(840);
-    REQUIRE((*it).key() == 840);
-
-    REQUIRE(std::ranges::equal(
-        std::views::transform(std::ranges::subrange(ftrees.begin(), it),
-                              [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                return {extent.key(), extent.value(), extent.bucket_index};
-                              }),
-        std::views::transform(std::views::iota(0, 840 / 2), [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-          return {i * 2, static_cast<nibble>(i % 16), static_cast<size_t>(i % kSizeBuckets.size())};
-        })));
-    REQUIRE(std::ranges::equal(std::views::transform(std::ranges::subrange(it, ftrees.end()),
-                                                     [](const auto& extent) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {extent.key(), extent.value(), extent.bucket_index};
-                                                     }),
-                               std::views::transform(std::views::iota(840 / 2, kItemsCount),
-                                                     [](int i) -> std::tuple<uint32_t, nibble, size_t> {
-                                                       return {i * 2, static_cast<nibble>(i % 16),
-                                                               static_cast<size_t>(i % kSizeBuckets.size())};
-                                                     })));
-
-    REQUIRE((*ftrees.find(4, false)).key() == 4);
-    REQUIRE((*ftrees.find(6, false)).key() == 6);
-    REQUIRE((*++ftrees.find(4, false)).key() == 6);
-    REQUIRE((*++ftrees.find(14, false)).key() == 16);
-  }
-
-  SECTION("test split") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i, static_cast<nibble>(i % 16)}));
-    }
-
-    key_type split_point;
-    std::array<FTrees, 2> new_ftrees{FTrees{TestBlock::LoadMetadataBlock(test_device, 1)},
-                                     FTrees{TestBlock::LoadMetadataBlock(test_device, 2)}};
-    new_ftrees[0].Init();
-    new_ftrees[1].Init();
-    ftrees.split(new_ftrees[0], new_ftrees[1], split_point);
-
-    // Should be the middle key of the ftree with most items, so somewhere around the actual center in our case
-    REQUIRE(split_point == 252);
-
-    REQUIRE(new_ftrees[0].size() == split_point);
-    REQUIRE(new_ftrees[1].size() == kItemsCount - split_point);
-
-    REQUIRE(std::ranges::size(new_ftrees[0]) == split_point);
-    REQUIRE(std::ranges::size(new_ftrees[1]) == kItemsCount - split_point);
-
-    REQUIRE(std::ranges::distance(new_ftrees[0].begin(), new_ftrees[0].end()) == static_cast<int>(split_point));
-    REQUIRE(std::ranges::distance(new_ftrees[1].begin(), new_ftrees[1].end()) ==
-            static_cast<int>(kItemsCount - split_point));
-
-    REQUIRE(std::ranges::equal(std::ranges::subrange(ftrees.begin(), ftrees.find(split_point)), new_ftrees[0]));
-    REQUIRE(std::ranges::equal(std::ranges::subrange(ftrees.find(split_point), ftrees.end()), new_ftrees[1]));
-    // REQUIRE(std::ranges::equal(ftrees, std::views::join(new_ftrees)));
-  }
-
-  SECTION("test split middle") {
-    // insert many items to ftrees[5]
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(ftrees.ftrees()[5].insert({i, static_cast<nibble>(i % 16)}));
-    }
-    REQUIRE(ftrees.ftrees()[4].insert({700, nibble{0}}));
-    REQUIRE(ftrees.ftrees()[6].insert({800, nibble{0}}));
-    REQUIRE(ftrees.ftrees()[2].insert({1000, nibble{0}}));
-
-    key_type split_point;
-    std::array<FTrees, 2> new_ftrees{FTrees{TestBlock::LoadMetadataBlock(test_device, 1)},
-                                     FTrees{TestBlock::LoadMetadataBlock(test_device, 2)}};
-    new_ftrees[0].Init();
-    new_ftrees[1].Init();
-    ftrees.split(new_ftrees[0], new_ftrees[1], split_point);
-
-    // Should be the middle key of the ftree with most items
-    REQUIRE(split_point == 250);
-  }
+  REQUIRE(split_point == 250);
 }

--- a/tests/rtree_tests.cpp
+++ b/tests/rtree_tests.cpp
@@ -12,211 +12,183 @@
 
 #include "rtree.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
-#include "utils/test_free_blocks_allocator.h"
+#include "utils/range_assertions.h"
+#include "utils/test_fixtures.h"
 #include "utils/test_utils.h"
 
-TEST_CASE("RTreeTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto rtree_block = TestBlock::LoadMetadataBlock(test_device, 0);
+namespace {
+
+class RTreeFixture : public MetadataBlockFixture {
+ public:
+  RTreeFixture() { rtree.Init(/*depth=*/1, /*block_number=*/0); }
+
+  std::shared_ptr<TestBlock> rtree_block = LoadMetadataBlock(0);
   RTree rtree{rtree_block};
-  rtree.Init(/*depth=*/1, /*block_number=*/0);
+};
 
-  SECTION("Check empty rtree size") {
-    REQUIRE(rtree.size() == 0);
+constexpr int kRTreeItems = 500;
+
+void InsertSequential(RTree& rtree, uint32_t count, uint32_t value = 0) {
+  for (uint32_t i = 0; i < count; ++i) {
+    REQUIRE(rtree.insert({i, value ? value : i + 1}));
   }
+}
 
-  SECTION("insert items sorted") {
-    uint32_t index = 0;
-    for (int i = 0; i < 4; ++i) {
-      REQUIRE(rtree.insert({index, index + 1}));
-      ++index;
-    }
-    REQUIRE(rtree.size() == index);
-    // No parent nodes yet
-    REQUIRE(rtree.header()->tree_depth.value() == 0);
-    REQUIRE(rtree.begin().parents().size() == 0);
-    REQUIRE(rtree.begin().leaf().node.full());
+}  // namespace
 
-    // for (auto [i, extent] : std::views::enumerate(rtree)) {
-    //  REQUIRE(extent.key == static_cast<uint32_t>(i));
-    //  REQUIRE(extent.value == static_cast<uint32_t>(i + 1));
-    //}
+TEST_CASE_METHOD(RTreeFixture, "RTree is empty after initialization", "[rtree][unit]") {
+  REQUIRE(rtree.size() == 0);
+}
 
+TEST_CASE_METHOD(RTreeFixture, "RTree sorted inserts grow through expected split depths", "[rtree][tree][white-box]") {
+  uint32_t index = 0;
+  for (int i = 0; i < 4; ++i) {
     REQUIRE(rtree.insert({index, index + 1}));
     ++index;
+  }
+  REQUIRE(rtree.size() == index);
+  REQUIRE(rtree.header()->tree_depth.value() == 0);
+  REQUIRE(rtree.begin().parents().size() == 0);
+  REQUIRE(rtree.begin().leaf().node.full());
 
-    auto it = rtree.begin();
-    REQUIRE(rtree.header()->tree_depth.value() == 1);
-    REQUIRE(it.parents().size() == 1);
-    REQUIRE(it.parents()[0].node.size() == 2);  // the two splitted nodes
-    // Should have splitted it to 3/1 + plus the new one
-    REQUIRE(it.leaf().node.size() == 3);
-    // Go to next node
-    for (int i = 0; i < 3; ++i)
-      ++it;
-    REQUIRE(it.leaf().node.size() == 2);
+  REQUIRE(rtree.insert({index, index + 1}));
+  ++index;
 
-    // Now fill the second one 5 more times
-    for (int i = 0; i < 3 * 5 - 1; ++i) {
-      REQUIRE(rtree.insert({index, index + 1}));
-      ++index;
-    }
-    REQUIRE(rtree.size() == index);
-    // Still one parent, but it is full now
-    it = rtree.end();
-    REQUIRE(rtree.header()->tree_depth.value() == 1);
-    REQUIRE(it.parents()[0].node.full());
-    REQUIRE(it.leaf().node.full());
+  auto it = rtree.begin();
+  REQUIRE(rtree.header()->tree_depth.value() == 1);
+  REQUIRE(it.parents().size() == 1);
+  REQUIRE(it.parents()[0].node.size() == 2);
+  REQUIRE(it.leaf().node.size() == 3);
+  for (int i = 0; i < 3; ++i) {
+    ++it;
+  }
+  REQUIRE(it.leaf().node.size() == 2);
 
+  for (int i = 0; i < 3 * 5 - 1; ++i) {
     REQUIRE(rtree.insert({index, index + 1}));
     ++index;
-    // new parent
-    it = rtree.end();
-    REQUIRE(rtree.header()->tree_depth.value() == 2);
-    REQUIRE(it.parents().size() == 2);
-    REQUIRE(it.parents()[0].node.size() == 2);  // the two splitted nodes
-    REQUIRE(it.parents()[1].node.size() == 3);  // should have been splitted 4/2 + the new one
-    REQUIRE(it.leaf().node.size() == 2);
+  }
+  REQUIRE(rtree.size() == index);
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 1);
+  REQUIRE(it.parents()[0].node.full());
+  REQUIRE(it.leaf().node.full());
 
-    // Now fill our parent again 4 X 5 times
-    for (int i = 0; i < 3 * 4 * 5 - 1; ++i) {
-      REQUIRE(rtree.insert({index, index + 1}));
-      ++index;
-    }
-    REQUIRE(rtree.size() == index);
-    it = rtree.end();
-    // our parents should be full now
-    REQUIRE(rtree.header()->tree_depth.value() == 2);
-    REQUIRE(it.parents().size() == 2);
-    REQUIRE(it.parents()[0].node.full());
-    REQUIRE(it.parents()[1].node.full());
-    REQUIRE(it.leaf().node.full());
+  REQUIRE(rtree.insert({index, index + 1}));
+  ++index;
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 2);
+  REQUIRE(it.parents().size() == 2);
+  REQUIRE(it.parents()[0].node.size() == 2);
+  REQUIRE(it.parents()[1].node.size() == 3);
+  REQUIRE(it.leaf().node.size() == 2);
 
-    // Now we should grow by another depth
+  for (int i = 0; i < 3 * 4 * 5 - 1; ++i) {
     REQUIRE(rtree.insert({index, index + 1}));
     ++index;
+  }
+  REQUIRE(rtree.size() == index);
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 2);
+  REQUIRE(it.parents().size() == 2);
+  REQUIRE(it.parents()[0].node.full());
+  REQUIRE(it.parents()[1].node.full());
+  REQUIRE(it.leaf().node.full());
 
-    it = rtree.end();
-    REQUIRE(rtree.header()->tree_depth.value() == 3);
-    REQUIRE(it.parents().size() == 3);
-    REQUIRE(it.parents()[0].node.size() == 2);  // the two splitted nodes
-    REQUIRE(it.parents()[1].node.size() == 3);  // should have been splitted 4/2
-    REQUIRE(it.parents()[2].node.size() == 3);  // should have been splitted 4/2
-    REQUIRE(it.leaf().node.size() == 2);
+  REQUIRE(rtree.insert({index, index + 1}));
+  ++index;
 
-    // Now fill our parent again 4 X 4 X 5 times
-    for (int i = 0; i < 3 * 4 * 4 * 5 - 1; ++i) {
-      REQUIRE(rtree.insert({index, index + 1}));
-      ++index;
-    }
-    REQUIRE(rtree.size() == index);
-    it = rtree.end();
-    // our parents should be full now
-    REQUIRE(rtree.header()->tree_depth.value() == 3);
-    REQUIRE(it.parents().size() == 3);
-    REQUIRE(it.parents()[0].node.full());
-    REQUIRE(it.parents()[1].node.full());
-    REQUIRE(it.parents()[2].node.full());
-    REQUIRE(it.leaf().node.full());
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 3);
+  REQUIRE(it.parents().size() == 3);
+  REQUIRE(it.parents()[0].node.size() == 2);
+  REQUIRE(it.parents()[1].node.size() == 3);
+  REQUIRE(it.parents()[2].node.size() == 3);
+  REQUIRE(it.leaf().node.size() == 2);
 
-    // Now we should grow by another depth
+  for (int i = 0; i < 3 * 4 * 4 * 5 - 1; ++i) {
     REQUIRE(rtree.insert({index, index + 1}));
     ++index;
+  }
+  REQUIRE(rtree.size() == index);
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 3);
+  REQUIRE(it.parents().size() == 3);
+  REQUIRE(it.parents()[0].node.full());
+  REQUIRE(it.parents()[1].node.full());
+  REQUIRE(it.parents()[2].node.full());
+  REQUIRE(it.leaf().node.full());
 
-    it = rtree.end();
-    REQUIRE(rtree.header()->tree_depth.value() == 4);
-    REQUIRE(it.parents().size() == 4);
-    REQUIRE(it.parents()[0].node.size() == 2);  // the two splitted nodes
-    REQUIRE(it.parents()[1].node.size() == 3);  // should have been splitted 4/2
-    REQUIRE(it.parents()[2].node.size() == 3);  // should have been splitted 4/2
-    REQUIRE(it.parents()[3].node.size() == 3);  // should have been splitted 4/2
-    REQUIRE(it.leaf().node.size() == 2);
+  REQUIRE(rtree.insert({index, index + 1}));
+  ++index;
 
-    // Now fill our tree until full
-    while (rtree.insert({index, index + 1})) {
-      ++index;
-    }
-    REQUIRE(!rtree.begin().parents()[0].node.full());
+  it = rtree.end();
+  REQUIRE(rtree.header()->tree_depth.value() == 4);
+  REQUIRE(it.parents().size() == 4);
+  REQUIRE(it.parents()[0].node.size() == 2);
+  REQUIRE(it.parents()[1].node.size() == 3);
+  REQUIRE(it.parents()[2].node.size() == 3);
+  REQUIRE(it.parents()[3].node.size() == 3);
+  REQUIRE(it.leaf().node.size() == 2);
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            rtree, [](const auto& extent) -> std::pair<uint32_t, uint32_t> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(0, static_cast<int>(index)),
-                              [](int i) -> std::pair<uint32_t, uint32_t> { return {i, i + 1}; })));
+  while (rtree.insert({index, index + 1})) {
+    ++index;
+  }
+  REQUIRE(!rtree.begin().parents()[0].node.full());
+  REQUIRE(CollectKeyValues(rtree) == SequentialKeyValues(index));
 
-    for (uint32_t i = 0; i < index; ++i) {
-      REQUIRE((*rtree.find(i, true)).key() == i);
-    }
+  for (uint32_t i = 0; i < index; ++i) {
+    CAPTURE(i);
+    REQUIRE((*rtree.find(i, true)).key() == i);
+  }
+}
+
+TEST_CASE_METHOD(RTreeFixture, "RTree keeps unsorted inserts ordered", "[rtree][tree][unit]") {
+  auto unsorted_keys = createShuffledKeysArray<kRTreeItems>();
+  for (auto key : unsorted_keys) {
+    REQUIRE(rtree.insert({key, key + 1}));
   }
 
-  SECTION("insert items unsorted") {
-    constexpr int kItemsCount = 500;
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    for (auto key : unsorted_keys) {
-      REQUIRE(rtree.insert({key, key + 1}));
-    }
+  auto sorted_keys = unsorted_keys;
+  std::ranges::sort(sorted_keys);
+  REQUIRE(CollectKeys(rtree) == sorted_keys);
+  REQUIRE(CollectKeyValues(rtree) == SequentialKeyValues(kRTreeItems));
+}
 
-    // Check that the tree is sorted
-    auto keys = std::views::transform(rtree, [](const auto& extent) -> uint32_t { return extent.key(); });
-    auto sorted_keys = unsorted_keys;
-    std::ranges::sort(sorted_keys);
-    REQUIRE(std::ranges::equal(keys, sorted_keys));
+TEST_CASE_METHOD(RTreeFixture, "RTree erases all sorted items and can be reused", "[rtree][tree][unit]") {
+  InsertSequential(rtree, kRTreeItems);
+  for (uint32_t i = 0; i < kRTreeItems; ++i) {
+    CAPTURE(i);
+    REQUIRE(rtree.erase(i));
+  }
+  REQUIRE(rtree.begin() == rtree.end());
+  REQUIRE(rtree.empty());
+  REQUIRE(rtree.header()->tree_depth.value() == 0);
 
-    REQUIRE(std::ranges::equal(
-        std::views::transform(
-            rtree, [](const auto& extent) -> std::pair<uint32_t, uint32_t> { return {extent.key(), extent.value()}; }),
-        std::views::transform(std::views::iota(0, static_cast<int>(kItemsCount)),
-                              [](int i) -> std::pair<uint32_t, uint32_t> { return {i, i + 1}; })));
+  InsertSequential(rtree, kRTreeItems);
+  REQUIRE(CollectKeys(rtree) == SequentialKeys(kRTreeItems));
+}
+
+TEST_CASE_METHOD(RTreeFixture, "RTree erases shuffled items and collapses empty", "[rtree][tree][unit]") {
+  InsertSequential(rtree, kRTreeItems);
+
+  auto unsorted_keys = createShuffledKeysArray<kRTreeItems>();
+  auto middle = unsorted_keys.begin() + kRTreeItems / 2;
+  for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
+    CAPTURE(key);
+    REQUIRE(rtree.erase(key));
   }
 
-  SECTION("erase items after inserting") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(rtree.insert({i, 0}));
-    }
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(rtree.erase(i));
-    }
-    REQUIRE(rtree.begin() == rtree.end());
-    REQUIRE(rtree.empty());
-    REQUIRE(rtree.header()->tree_depth.value() == 0);
+  auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
+  std::ranges::sort(sorted_upper_half);
+  REQUIRE(CollectKeys(rtree) == sorted_upper_half);
 
-    // Check that we can insert items again
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(rtree.insert({i, 0}));
-    }
-    REQUIRE(std::ranges::equal(std::views::transform(rtree, [](const auto& extent) -> int { return extent.key(); }),
-                               std::ranges::iota_view(0, kItemsCount)));
+  for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
+    CAPTURE(key);
+    REQUIRE(rtree.erase(key));
   }
 
-  SECTION("erase items randomly") {
-    constexpr int kItemsCount = 500;
-    for (uint32_t i = 0; i < kItemsCount; ++i) {
-      REQUIRE(rtree.insert({i, 0}));
-    }
-    auto unsorted_keys = createShuffledKeysArray<kItemsCount>();
-    auto middle = unsorted_keys.begin() + kItemsCount / 2;
-    // Remove half the items first
-    for (auto key : std::ranges::subrange(unsorted_keys.begin(), middle)) {
-      REQUIRE(rtree.erase(key));
-    }
-
-    auto sorted_upper_half = std::ranges::to<std::vector>(std::ranges::subrange(middle, unsorted_keys.end()));
-    std::ranges::sort(sorted_upper_half);
-    // Ensure that the right items were deleted
-    REQUIRE(std::ranges::equal(std::views::transform(rtree, [](const auto& extent) -> int { return extent.key(); }),
-                               sorted_upper_half));
-
-    // Remove the second half
-    for (auto key : std::ranges::subrange(middle, unsorted_keys.end())) {
-      REQUIRE(rtree.erase(key));
-    }
-
-    // Should be empty
-    REQUIRE(rtree.begin() == rtree.end());
-    REQUIRE(rtree.empty());
-    REQUIRE(rtree.header()->tree_depth.value() == 0);
-  }
+  REQUIRE(rtree.begin() == rtree.end());
+  REQUIRE(rtree.empty());
+  REQUIRE(rtree.header()->tree_depth.value() == 0);
 }

--- a/tests/sub_block_allocator_tests.cpp
+++ b/tests/sub_block_allocator_tests.cpp
@@ -9,8 +9,7 @@
 
 #include "sub_block_allocator.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
+#include "utils/test_fixtures.h"
 
 namespace {
 
@@ -30,133 +29,139 @@ class TestSubBlockAllocator : public SubBlockAllocator<DummyExtraHeader> {
   }
 };
 
+class SubBlockAllocatorFixture : public MetadataBlockFixture {
+ public:
+  SubBlockAllocatorFixture() { allocator.Init(); }
+
+  std::shared_ptr<TestBlock> block = LoadMetadataBlock(0);
+  TestSubBlockAllocator allocator{block};
+};
+
+void RequireInitialFreeListState(const TestSubBlockAllocator& allocator) {
+  auto* allocator_header = allocator.get_allocator_header();
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
+  REQUIRE(allocator_header->free_list[1].free_blocks_count.value() == 0);
+  REQUIRE(allocator_header->free_list[2].free_blocks_count.value() == 0);
+  REQUIRE(allocator_header->free_list[3].free_blocks_count.value() == 1);
+  REQUIRE(allocator_header->free_list[4].free_blocks_count.value() == 1);
+  REQUIRE(allocator_header->free_list[5].free_blocks_count.value() == 1);
+  REQUIRE(allocator_header->free_list[6].free_blocks_count.value() == 1);
+  REQUIRE(allocator_header->free_list[7].free_blocks_count.value() == 7);
+}
+
 }  // namespace
 
-TEST_CASE("SubBlockAllocatorTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto block = TestBlock::LoadMetadataBlock(test_device, 0);
-  TestSubBlockAllocator allocator{block};
-  allocator.Init();
+TEST_CASE_METHOD(SubBlockAllocatorFixture,
+                 "SubBlockAllocator initializes expected free lists",
+                 "[sub-block-allocator][white-box]") {
   REQUIRE(sizeof(MetadataBlockHeader) + sizeof(SubBlockAllocatorStruct) + sizeof(DummyExtraHeader) == 64);
 
-  SECTION("Check initial heap state") {
-    auto* allocator_header = allocator.get_allocator_header();
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[1].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[2].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[3].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[4].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[5].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[6].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[7].free_blocks_count.value() == 7);
+  RequireInitialFreeListState(allocator);
+  auto* allocator_header = allocator.get_allocator_header();
+  CHECK(allocator_header->free_list[3].head.value() == 0x40);
+  CHECK(allocator_header->free_list[4].head.value() == 0x80);
+  CHECK(allocator_header->free_list[5].head.value() == 0x100);
+  CHECK(allocator_header->free_list[6].head.value() == 0x200);
+  CHECK(allocator_header->free_list[7].head.value() == 0x400);
 
-    CHECK(allocator_header->free_list[3].head.value() == 0x40);
-    CHECK(allocator_header->free_list[4].head.value() == 0x80);
-    CHECK(allocator_header->free_list[5].head.value() == 0x100);
-    CHECK(allocator_header->free_list[6].head.value() == 0x200);
-    CHECK(allocator_header->free_list[7].head.value() == 0x400);
+  auto one_freelist_entry = allocator.get_freelist_entry(allocator_header->free_list[3].head.value());
+  CHECK(one_freelist_entry->next.value() == allocator_header->free_list[3].head.value());
+  CHECK(one_freelist_entry->prev.value() == allocator_header->free_list[3].head.value());
 
-    auto one_freelist_entry = allocator.get_freelist_entry(allocator_header->free_list[3].head.value());
-    CHECK(one_freelist_entry->next.value() == allocator_header->free_list[3].head.value());
-    CHECK(one_freelist_entry->prev.value() == allocator_header->free_list[3].head.value());
+  auto current_freelist_entry = allocator.get_freelist_entry(allocator_header->free_list[7].head.value());
+  CHECK(current_freelist_entry->next.value() == 0x800);
+  CHECK(current_freelist_entry->prev.value() == 0x1c00);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0xc00);
+  CHECK(current_freelist_entry->prev.value() == 0x400);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0x1000);
+  CHECK(current_freelist_entry->prev.value() == 0x800);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0x1400);
+  CHECK(current_freelist_entry->prev.value() == 0xc00);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0x1800);
+  CHECK(current_freelist_entry->prev.value() == 0x1000);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0x1c00);
+  CHECK(current_freelist_entry->prev.value() == 0x1400);
+  current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
+  CHECK(current_freelist_entry->next.value() == 0x400);
+  CHECK(current_freelist_entry->prev.value() == 0x1800);
+}
 
-    auto current_freelist_entry = allocator.get_freelist_entry(allocator_header->free_list[7].head.value());
-    CHECK(current_freelist_entry->next.value() == 0x800);
-    CHECK(current_freelist_entry->prev.value() == 0x1c00);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0xc00);
-    CHECK(current_freelist_entry->prev.value() == 0x400);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0x1000);
-    CHECK(current_freelist_entry->prev.value() == 0x800);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0x1400);
-    CHECK(current_freelist_entry->prev.value() == 0xc00);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0x1800);
-    CHECK(current_freelist_entry->prev.value() == 0x1000);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0x1c00);
-    CHECK(current_freelist_entry->prev.value() == 0x1400);
-    current_freelist_entry = allocator.get_freelist_entry(current_freelist_entry->next.value());
-    CHECK(current_freelist_entry->next.value() == 0x400);
-    CHECK(current_freelist_entry->prev.value() == 0x1800);
+TEST_CASE_METHOD(SubBlockAllocatorFixture,
+                 "SubBlockAllocator allocates and frees one block of each size",
+                 "[sub-block-allocator][unit]") {
+  auto* allocator_header = allocator.get_allocator_header();
+  for (int size = 6; size <= 10; ++size) {
+    auto offset = allocator.Alloc(uint16_t{1} << size);
+    REQUIRE(offset.has_value());
+    CHECK(*offset == uint16_t{1} << size);
+    if (size == 10)
+      CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 6);
+    else
+      CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 0);
   }
-
-  SECTION("Alloc and free one of each size") {
-    auto* allocator_header = allocator.get_allocator_header();
-    for (int size = 6; size <= 10; ++size) {
-      auto offset = allocator.Alloc(uint16_t{1} << size);
-      REQUIRE(offset.has_value());
-      CHECK(*offset == uint16_t{1} << size);
-      if (size == 10)
-        CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 6);
-      else
-        CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 0);
-    }
-    for (int size = 6; size <= 10; ++size) {
-      allocator.Free(uint16_t{1} << size, uint16_t{1} << size);
-      if (size == 10)
-        CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 7);
-      else
-        CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 1);
-    }
+  for (int size = 6; size <= 10; ++size) {
+    allocator.Free(uint16_t{1} << size, uint16_t{1} << size);
+    if (size == 10)
+      CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 7);
+    else
+      CHECK(allocator_header->free_list[size - 3].free_blocks_count.value() == 1);
   }
+}
 
-  SECTION("Coallese test") {
-    auto* allocator_header = allocator.get_allocator_header();
-    REQUIRE(*allocator.Alloc(8) == 0x40);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
-    REQUIRE(*allocator.Alloc(8) == 0x48);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
-    REQUIRE(*allocator.Alloc(8) == 0x50);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
-    REQUIRE(*allocator.Alloc(8) == 0x58);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
+TEST_CASE_METHOD(SubBlockAllocatorFixture,
+                 "SubBlockAllocator coalesces adjacent frees",
+                 "[sub-block-allocator][unit]") {
+  auto* allocator_header = allocator.get_allocator_header();
+  REQUIRE(*allocator.Alloc(8) == 0x40);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
+  REQUIRE(*allocator.Alloc(8) == 0x48);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
+  REQUIRE(*allocator.Alloc(8) == 0x50);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
+  REQUIRE(*allocator.Alloc(8) == 0x58);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
 
-    allocator.Free(0x48, 8);
-    allocator.Free(0x50, 8);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 2);
-    allocator.Free(0x40, 8);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[1].free_blocks_count.value() == 1);
-    allocator.Free(0x58, 8);
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[3].free_blocks_count.value() == 1);
-  }
+  allocator.Free(0x48, 8);
+  allocator.Free(0x50, 8);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 2);
+  allocator.Free(0x40, 8);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 1);
+  REQUIRE(allocator_header->free_list[1].free_blocks_count.value() == 1);
+  allocator.Free(0x58, 8);
+  REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
+  REQUIRE(allocator_header->free_list[3].free_blocks_count.value() == 1);
+}
 
-  SECTION("Fill heap") {
-    auto* allocator_header = allocator.get_allocator_header();
-    uint16_t current_offset = sizeof(MetadataBlockHeader) + sizeof(SubBlockAllocatorStruct) + sizeof(DummyExtraHeader);
-    size_t total_bytes = (1 << log2_size(BlockSize::Logical)) - current_offset;
-    for (size_t i = 0; i < (total_bytes >> 3); ++i) {
-      auto offset = allocator.Alloc(8);
-      REQUIRE(offset.has_value());
-      CHECK(*offset == current_offset);
-      current_offset += 8;
-    }
-    // Now should be full
-    for (int i = 0; i <= 7; ++i) {
-      CHECK(allocator_header->free_list[i].free_blocks_count.value() == 0);
-    }
-
+TEST_CASE_METHOD(SubBlockAllocatorFixture,
+                 "SubBlockAllocator fills and frees the entire block",
+                 "[sub-block-allocator][unit]") {
+  auto* allocator_header = allocator.get_allocator_header();
+  uint16_t current_offset = sizeof(MetadataBlockHeader) + sizeof(SubBlockAllocatorStruct) + sizeof(DummyExtraHeader);
+  size_t total_bytes = (1 << log2_size(BlockSize::Logical)) - current_offset;
+  for (size_t i = 0; i < (total_bytes >> 3); ++i) {
     auto offset = allocator.Alloc(8);
-    CHECK(!offset.has_value());
-
-    current_offset = sizeof(MetadataBlockHeader) + sizeof(SubBlockAllocatorStruct) + sizeof(DummyExtraHeader);
-    for (size_t i = 0; i < (total_bytes >> 3); ++i) {
-      allocator.Free(current_offset, 8);
-      current_offset += 8;
-    }
-
-    // Should have the intial space
-    REQUIRE(allocator_header->free_list[0].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[1].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[2].free_blocks_count.value() == 0);
-    REQUIRE(allocator_header->free_list[3].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[4].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[5].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[6].free_blocks_count.value() == 1);
-    REQUIRE(allocator_header->free_list[7].free_blocks_count.value() == 7);
+    REQUIRE(offset.has_value());
+    CHECK(*offset == current_offset);
+    current_offset += 8;
   }
+
+  for (int i = 0; i <= 7; ++i) {
+    CHECK(allocator_header->free_list[i].free_blocks_count.value() == 0);
+  }
+
+  auto offset = allocator.Alloc(8);
+  CHECK(!offset.has_value());
+
+  current_offset = sizeof(MetadataBlockHeader) + sizeof(SubBlockAllocatorStruct) + sizeof(DummyExtraHeader);
+  for (size_t i = 0; i < (total_bytes >> 3); ++i) {
+    allocator.Free(current_offset, 8);
+    current_offset += 8;
+  }
+
+  RequireInitialFreeListState(allocator);
 }

--- a/tests/tree_nodes_allocator_tests.cpp
+++ b/tests/tree_nodes_allocator_tests.cpp
@@ -9,8 +9,7 @@
 
 #include "tree_nodes_allocator.h"
 
-#include "utils/test_block.h"
-#include "utils/test_blocks_device.h"
+#include "utils/test_fixtures.h"
 
 namespace {
 
@@ -26,8 +25,6 @@ struct DummyEntry {
   uint32_be_t a, b, c, d;
 };
 
-}  // namespace
-
 using DummyAllocatorBlockArgs = TreeNodesAllocatorArgs<DummyExtraHeader, DummyExtraHeader, sizeof(DummyEntry)>;
 
 class DummyAllocatorBlock : public TreeNodesAllocator<DummyAllocatorBlockArgs> {
@@ -40,111 +37,122 @@ class DummyAllocatorBlock : public TreeNodesAllocator<DummyAllocatorBlockArgs> {
   const HeapFreelistEntry* get_freelist_entry(uint32_t index) const { return base::get_freelist_entry(index); }
 };
 
-TEST_CASE("TreeNodesAllocatorTests") {
-  auto test_device = std::make_shared<TestBlocksDevice>();
-  auto block = TestBlock::LoadMetadataBlock(test_device, 0);
+class TreeNodesAllocatorFixture : public MetadataBlockFixture {
+ public:
+  TreeNodesAllocatorFixture() { allocator.Init(); }
+
+  std::shared_ptr<TestBlock> block = LoadMetadataBlock(0);
   DummyAllocatorBlock allocator{block};
-  allocator.Init();
 
-  constexpr size_t total_bytes = (size_t{1} << log2_size(BlockSize::Logical)) - sizeof(MetadataBlockHeader) -
-                                 sizeof(DummyExtraHeader) - sizeof(DummyTreeHeader) - sizeof(HeapHeader);
-  constexpr size_t max_entries_count = total_bytes / 0x10;
-  constexpr size_t offset = sizeof(MetadataBlockHeader) + sizeof(DummyExtraHeader);
+  static constexpr size_t kTotalBytes = (size_t{1} << log2_size(BlockSize::Logical)) - sizeof(MetadataBlockHeader) -
+                                        sizeof(DummyExtraHeader) - sizeof(DummyTreeHeader) - sizeof(HeapHeader);
+  static constexpr size_t kMaxEntriesCount = kTotalBytes / 0x10;
+  static constexpr size_t kOffset = sizeof(MetadataBlockHeader) + sizeof(DummyExtraHeader);
+};
 
-  SECTION("Check initial heap state") {
-    auto* heap_header = allocator.get_heap_header();
-    REQUIRE(heap_header->freelist_head.value() == 0);
-    REQUIRE(heap_header->allocated_entries.value() == 0);
-    REQUIRE(heap_header->total_bytes.value() == total_bytes);
-    REQUIRE(heap_header->start_offset.value() == offset);
+}  // namespace
 
-    auto freelist_entry = allocator.get_freelist_entry(0);
-    REQUIRE(freelist_entry->count.value() == max_entries_count);
-    REQUIRE(freelist_entry->next.value() == max_entries_count);
-  }
+TEST_CASE_METHOD(TreeNodesAllocatorFixture,
+                 "TreeNodesAllocator initializes heap metadata",
+                 "[tree-nodes-allocator][white-box]") {
+  auto* heap_header = allocator.get_heap_header();
+  REQUIRE(heap_header->freelist_head.value() == 0);
+  REQUIRE(heap_header->allocated_entries.value() == 0);
+  REQUIRE(heap_header->total_bytes.value() == kTotalBytes);
+  REQUIRE(heap_header->start_offset.value() == kOffset);
 
-  SECTION("Alloc and free one") {
-    auto* entry = allocator.Alloc<DummyEntry>(1);
-    REQUIRE(entry == block->get_object<DummyEntry>(offset));
-    REQUIRE(allocator.to_offset(entry) == offset);
+  auto freelist_entry = allocator.get_freelist_entry(0);
+  REQUIRE(freelist_entry->count.value() == kMaxEntriesCount);
+  REQUIRE(freelist_entry->next.value() == kMaxEntriesCount);
+}
 
-    auto* heap_header = allocator.get_heap_header();
-    REQUIRE(heap_header->freelist_head.value() == 1);
-    REQUIRE(heap_header->allocated_entries.value() == 1);
-    REQUIRE(heap_header->total_bytes.value() == total_bytes);
-    REQUIRE(heap_header->start_offset.value() == offset);
+TEST_CASE_METHOD(TreeNodesAllocatorFixture,
+                 "TreeNodesAllocator allocates and frees one entry",
+                 "[tree-nodes-allocator][unit]") {
+  auto* entry = allocator.Alloc<DummyEntry>(1);
+  REQUIRE(entry == block->get_object<DummyEntry>(kOffset));
+  REQUIRE(allocator.to_offset(entry) == kOffset);
 
-    auto freelist_entry1 = allocator.get_freelist_entry(1);
-    REQUIRE(freelist_entry1->count.value() == max_entries_count - 1);
-    REQUIRE(freelist_entry1->next.value() == max_entries_count);
+  auto* heap_header = allocator.get_heap_header();
+  REQUIRE(heap_header->freelist_head.value() == 1);
+  REQUIRE(heap_header->allocated_entries.value() == 1);
+  REQUIRE(heap_header->total_bytes.value() == kTotalBytes);
+  REQUIRE(heap_header->start_offset.value() == kOffset);
 
-    allocator.Free(entry, 1);
-    REQUIRE(heap_header->freelist_head.value() == 0);
-    REQUIRE(heap_header->allocated_entries.value() == 0);
+  auto freelist_entry1 = allocator.get_freelist_entry(1);
+  REQUIRE(freelist_entry1->count.value() == kMaxEntriesCount - 1);
+  REQUIRE(freelist_entry1->next.value() == kMaxEntriesCount);
 
-    auto freelist_entry0 = allocator.get_freelist_entry(0);
-    REQUIRE(freelist_entry0->count.value() == max_entries_count);
-    REQUIRE(freelist_entry0->next.value() == max_entries_count);
-  }
+  allocator.Free(entry, 1);
+  REQUIRE(heap_header->freelist_head.value() == 0);
+  REQUIRE(heap_header->allocated_entries.value() == 0);
 
-  SECTION("Alloc and free multiple") {
-    auto* entry1 = allocator.Alloc<DummyEntry>(1);
-    REQUIRE(allocator.to_offset(entry1) == offset);
-    auto* entry2 = allocator.Alloc<DummyEntry>(2);
-    REQUIRE(entry2 == entry1 + 1);
-    auto* entry3 = allocator.Alloc<DummyEntry>(1);
-    REQUIRE(entry3 == entry2 + 2);
+  auto freelist_entry0 = allocator.get_freelist_entry(0);
+  REQUIRE(freelist_entry0->count.value() == kMaxEntriesCount);
+  REQUIRE(freelist_entry0->next.value() == kMaxEntriesCount);
+}
 
-    auto* heap_header = allocator.get_heap_header();
-    REQUIRE(heap_header->freelist_head.value() == 4);
-    REQUIRE(heap_header->allocated_entries.value() == 4);
-    REQUIRE(heap_header->total_bytes.value() == total_bytes);
-    REQUIRE(heap_header->start_offset.value() == offset);
-    auto freelist_entry4 = allocator.get_freelist_entry(4);
-    REQUIRE(freelist_entry4->count.value() == max_entries_count - 4);
-    REQUIRE(freelist_entry4->next.value() == max_entries_count);
+TEST_CASE_METHOD(TreeNodesAllocatorFixture,
+                 "TreeNodesAllocator coalesces multiple freed entries",
+                 "[tree-nodes-allocator][unit]") {
+  auto* entry1 = allocator.Alloc<DummyEntry>(1);
+  REQUIRE(allocator.to_offset(entry1) == kOffset);
+  auto* entry2 = allocator.Alloc<DummyEntry>(2);
+  REQUIRE(entry2 == entry1 + 1);
+  auto* entry3 = allocator.Alloc<DummyEntry>(1);
+  REQUIRE(entry3 == entry2 + 2);
 
-    allocator.Free(entry2, 2);
-    REQUIRE(heap_header->freelist_head.value() == 1);
-    REQUIRE(heap_header->allocated_entries.value() == 2);
-    auto freelist_entry1 = allocator.get_freelist_entry(1);
-    REQUIRE(freelist_entry1->count.value() == 2);
-    REQUIRE(freelist_entry1->next.value() == 4);
-    REQUIRE(freelist_entry4->count.value() == max_entries_count - 4);
-    REQUIRE(freelist_entry4->next.value() == max_entries_count);
+  auto* heap_header = allocator.get_heap_header();
+  REQUIRE(heap_header->freelist_head.value() == 4);
+  REQUIRE(heap_header->allocated_entries.value() == 4);
+  REQUIRE(heap_header->total_bytes.value() == kTotalBytes);
+  REQUIRE(heap_header->start_offset.value() == kOffset);
+  auto freelist_entry4 = allocator.get_freelist_entry(4);
+  REQUIRE(freelist_entry4->count.value() == kMaxEntriesCount - 4);
+  REQUIRE(freelist_entry4->next.value() == kMaxEntriesCount);
 
-    allocator.Free(entry1, 1);
-    REQUIRE(heap_header->freelist_head.value() == 0);
-    REQUIRE(heap_header->allocated_entries.value() == 1);
-    auto freelist_entry0 = allocator.get_freelist_entry(0);
-    REQUIRE(freelist_entry0->count.value() == 3);
-    REQUIRE(freelist_entry0->next.value() == 4);
-    REQUIRE(freelist_entry4->count.value() == max_entries_count - 4);
-    REQUIRE(freelist_entry4->next.value() == max_entries_count);
+  allocator.Free(entry2, 2);
+  REQUIRE(heap_header->freelist_head.value() == 1);
+  REQUIRE(heap_header->allocated_entries.value() == 2);
+  auto freelist_entry1 = allocator.get_freelist_entry(1);
+  REQUIRE(freelist_entry1->count.value() == 2);
+  REQUIRE(freelist_entry1->next.value() == 4);
+  REQUIRE(freelist_entry4->count.value() == kMaxEntriesCount - 4);
+  REQUIRE(freelist_entry4->next.value() == kMaxEntriesCount);
 
-    allocator.Free(entry3, 1);
-    REQUIRE(heap_header->freelist_head.value() == 0);
-    REQUIRE(heap_header->allocated_entries.value() == 0);
-    REQUIRE(freelist_entry0->count.value() == max_entries_count);
-    REQUIRE(freelist_entry0->next.value() == max_entries_count);
-  }
+  allocator.Free(entry1, 1);
+  REQUIRE(heap_header->freelist_head.value() == 0);
+  REQUIRE(heap_header->allocated_entries.value() == 1);
+  auto freelist_entry0 = allocator.get_freelist_entry(0);
+  REQUIRE(freelist_entry0->count.value() == 3);
+  REQUIRE(freelist_entry0->next.value() == 4);
+  REQUIRE(freelist_entry4->count.value() == kMaxEntriesCount - 4);
+  REQUIRE(freelist_entry4->next.value() == kMaxEntriesCount);
 
-  SECTION("Fill heap") {
-    auto* entry = allocator.Alloc<DummyEntry>(max_entries_count);
-    REQUIRE(allocator.to_offset(entry) == offset);
-    auto* entry2 = allocator.Alloc<DummyEntry>(1);
-    REQUIRE(entry2 == nullptr);
-    auto* heap_header = allocator.get_heap_header();
-    REQUIRE(heap_header->freelist_head.value() == max_entries_count);
-    REQUIRE(heap_header->allocated_entries.value() == max_entries_count);
+  allocator.Free(entry3, 1);
+  REQUIRE(heap_header->freelist_head.value() == 0);
+  REQUIRE(heap_header->allocated_entries.value() == 0);
+  REQUIRE(freelist_entry0->count.value() == kMaxEntriesCount);
+  REQUIRE(freelist_entry0->next.value() == kMaxEntriesCount);
+}
 
-    allocator.Free(entry, max_entries_count);
-    REQUIRE(heap_header->freelist_head.value() == 0);
-    REQUIRE(heap_header->allocated_entries.value() == 0);
-  }
+TEST_CASE_METHOD(TreeNodesAllocatorFixture, "TreeNodesAllocator fills the heap", "[tree-nodes-allocator][unit]") {
+  auto* entry = allocator.Alloc<DummyEntry>(kMaxEntriesCount);
+  REQUIRE(allocator.to_offset(entry) == kOffset);
+  auto* entry2 = allocator.Alloc<DummyEntry>(1);
+  REQUIRE(entry2 == nullptr);
+  auto* heap_header = allocator.get_heap_header();
+  REQUIRE(heap_header->freelist_head.value() == kMaxEntriesCount);
+  REQUIRE(heap_header->allocated_entries.value() == kMaxEntriesCount);
 
-  SECTION("Alloc too much") {
-    auto* entry = allocator.Alloc<DummyEntry>(max_entries_count + 1);
-    REQUIRE(entry == nullptr);
-  }
+  allocator.Free(entry, kMaxEntriesCount);
+  REQUIRE(heap_header->freelist_head.value() == 0);
+  REQUIRE(heap_header->allocated_entries.value() == 0);
+}
+
+TEST_CASE_METHOD(TreeNodesAllocatorFixture,
+                 "TreeNodesAllocator rejects allocations larger than the heap",
+                 "[tree-nodes-allocator][unit]") {
+  auto* entry = allocator.Alloc<DummyEntry>(kMaxEntriesCount + 1);
+  REQUIRE(entry == nullptr);
 }

--- a/tests/utils/range_assertions.h
+++ b/tests/utils/range_assertions.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <ranges>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "structs.h"
+
+template <std::ranges::input_range Range, typename Projection>
+auto CollectRange(Range&& range, Projection projection) {
+  using Value = std::remove_cvref_t<std::invoke_result_t<Projection, std::ranges::range_reference_t<Range>>>;
+  std::vector<Value> values;
+  for (auto&& item : range) {
+    values.push_back(std::invoke(projection, item));
+  }
+  return values;
+}
+
+template <std::ranges::input_range Range>
+auto CollectKeys(Range&& range) {
+  return CollectRange(std::forward<Range>(range), [](const auto& item) -> uint32_t { return item.key(); });
+}
+
+template <std::ranges::input_range Range>
+auto CollectKeyValues(Range&& range) {
+  return CollectRange(std::forward<Range>(range),
+                      [](const auto& item) -> std::pair<uint32_t, uint32_t> { return {item.key(), item.value()}; });
+}
+
+template <std::ranges::input_range Range>
+auto CollectFreeExtents(Range&& range) {
+  return CollectRange(std::forward<Range>(range), [](const auto& item) -> std::tuple<uint32_t, nibble, size_t> {
+    return {item.key(), item.value(), item.bucket_index};
+  });
+}
+
+inline std::vector<uint32_t> SequentialKeys(uint32_t count, uint32_t start = 0, uint32_t step = 1) {
+  std::vector<uint32_t> keys;
+  keys.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    keys.push_back(start + i * step);
+  }
+  return keys;
+}
+
+inline std::vector<std::pair<uint32_t, uint32_t>> SequentialKeyValues(uint32_t count) {
+  std::vector<std::pair<uint32_t, uint32_t>> values;
+  values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values.emplace_back(i, i + 1);
+  }
+  return values;
+}
+
+inline std::vector<std::pair<uint32_t, nibble>> SequentialNibbleValues(uint32_t count) {
+  std::vector<std::pair<uint32_t, nibble>> values;
+  values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values.emplace_back(i, static_cast<nibble>(i % 16));
+  }
+  return values;
+}
+
+inline std::vector<std::tuple<uint32_t, nibble, size_t>> SequentialFreeExtents(uint32_t count, size_t bucket_index) {
+  std::vector<std::tuple<uint32_t, nibble, size_t>> values;
+  values.reserve(count);
+  for (uint32_t i = 0; i < count; ++i) {
+    values.emplace_back(i, static_cast<nibble>(i % 16), bucket_index);
+  }
+  return values;
+}
+
+template <typename Tree, typename KeyProjection>
+void RequireBidirectionalIteration(Tree& tree,
+                                   uint32_t expected_count,
+                                   KeyProjection key_projection,
+                                   uint32_t forward_steps = 40,
+                                   uint32_t backward_steps = 20) {
+  auto it = tree.begin();
+  uint32_t steps = 0;
+  while (it != tree.end()) {
+    REQUIRE(std::invoke(key_projection, *it) == steps);
+    ++it;
+    ++steps;
+  }
+  REQUIRE(steps == expected_count);
+  REQUIRE(it.is_end());
+
+  while (it != tree.begin()) {
+    --it;
+    --steps;
+    REQUIRE(std::invoke(key_projection, *it) == steps);
+  }
+  REQUIRE(steps == 0);
+  REQUIRE(it.is_begin());
+
+  for (uint32_t i = 0; i < forward_steps; ++i) {
+    ++it;
+    ++steps;
+    REQUIRE(std::invoke(key_projection, *it) == steps);
+  }
+  for (uint32_t i = 0; i < backward_steps; ++i) {
+    --it;
+    --steps;
+    REQUIRE(std::invoke(key_projection, *it) == steps);
+  }
+  REQUIRE(std::invoke(key_projection, *it) == forward_steps - backward_steps);
+}

--- a/tests/utils/test_fixtures.h
+++ b/tests/utils/test_fixtures.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "test_area.h"
+#include "test_block.h"
+#include "test_blocks_device.h"
+#include "test_free_blocks_allocator.h"
+
+class MetadataBlockFixture {
+ public:
+  std::shared_ptr<TestBlock> LoadMetadataBlock(uint32_t physical_block_number, bool new_block = true) {
+    return TestBlock::LoadMetadataBlock(test_device, physical_block_number, new_block);
+  }
+
+  std::shared_ptr<TestBlocksDevice> test_device = std::make_shared<TestBlocksDevice>();
+};
+
+class FreeBlocksAllocatorFixture : public MetadataBlockFixture {
+ public:
+  std::shared_ptr<TestBlock> allocator_block = LoadMetadataBlock(0);
+  TestFreeBlocksAllocator allocator{allocator_block, test_device};
+};
+
+class AreaAllocatorFixture : public MetadataBlockFixture {
+ public:
+  std::shared_ptr<TestBlock> area_block = LoadMetadataBlock(0);
+  std::shared_ptr<TestBlock> allocator_block = LoadMetadataBlock(1);
+  std::shared_ptr<TestArea> area = std::make_shared<TestArea>(std::move(area_block));
+  TestFreeBlocksAllocator allocator{allocator_block, test_device, area};
+};


### PR DESCRIPTION
## Summary

Refactors the test suite structure without changing production code.

- Split broad Catch2 `SECTION`-based test files into focused `TEST_CASE_METHOD` tests with descriptive names.
- Added shared test fixtures for common block/device/allocator setup.
- Added reusable range and iterator assertion helpers so large tree tests produce clearer, more maintainable checks.
- Grouped behavior test sources and support sources explicitly in the tests CMake file.
- Tagged tests by scope such as `[unit]`, `[integration]`, `[stress]`, `[iterator]`, and `[white-box]`.

## Impact

The behavior coverage is preserved, but failures are easier to identify from CTest/Catch output and repeated tree/allocator setup is centralized.

## Validation

- `cmake --build build/gcc14-tests --target wfslib_tests`
- `ctest --test-dir build/gcc14-tests --output-on-failure`

Result: 85/85 tests passed on the `origin/master`-based branch.