### PR TITLE
Add directory metadata reallocation

### DIFF
--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -62,6 +62,25 @@ Block::DataRef<EntryMetadata> DirectoryMap::alloc_metadata(iterator it, size_t l
   }
 }
 
+Block::DataRef<EntryMetadata> DirectoryMap::realloc_metadata(iterator it, size_t log2_size) {
+  auto name = (*it).name;
+  auto old_metadata = (*it).metadata;
+  auto old_log2_size = old_metadata->metadata_log2_size.value();
+  assert(old_log2_size != log2_size);
+
+  auto old_size = static_cast<uint16_t>(1 << old_log2_size);
+  auto new_metadata = alloc_metadata(it, log2_size);
+
+  auto updated_it = find(name);
+  assert(!updated_it.is_end());
+  assert(updated_it.leaf().node.block() == new_metadata.block);
+  auto old_offset = (*updated_it.leaf().iterator).value();
+  (*updated_it.leaf().iterator).set_value(static_cast<uint16_t>(new_metadata.offset));
+  updated_it.leaf().node.Free(old_offset, old_size);
+
+  return new_metadata;
+}
+
 DirectoryMap::iterator DirectoryMap::find(std::string_view key) const {
   auto current_block = root_block_;
   std::vector<iterator::parent_node_info> parents;
@@ -164,6 +183,29 @@ bool DirectoryMap::erase(std::string_view name) {
     }
     parents.pop_back();
   }
+}
+
+std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_metadata(std::string_view name,
+                                                                                      const EntryMetadata* metadata) {
+  auto new_log2_size = metadata->metadata_log2_size.value();
+  assert(new_log2_size >= 6 && new_log2_size <= SubBlockAllocatorBase::MAX_BLOCK_SIZE);
+
+  auto it = find(name);
+  if (it.is_end())
+    return std::unexpected(WfsError::kEntryNotFound);
+
+  auto old_metadata = (*it).metadata;
+  auto old_log2_size = old_metadata->metadata_log2_size.value();
+  auto new_size = static_cast<uint16_t>(1 << new_log2_size);
+  if (old_log2_size == new_log2_size) {
+    if (old_metadata.get() != metadata)
+      std::memcpy(old_metadata.get_mutable(), metadata, new_size);
+    return old_metadata;
+  }
+
+  auto new_metadata = realloc_metadata(it, new_log2_size);
+  std::memcpy(new_metadata.get_mutable(), metadata, new_size);
+  return new_metadata;
 }
 
 template <DirectoryTreeImpl TreeType>

--- a/src/directory_map.h
+++ b/src/directory_map.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "directory_map_iterator.h"
+#include "errors.h"
 
 template <typename T>
 concept DirectoryTreeImpl = std::same_as<T, DirectoryLeafTree> || std::same_as<T, DirectoryParentTree>;
@@ -27,6 +28,8 @@ class DirectoryMap {
 
   bool insert(std::string_view name, const EntryMetadata* metadata);
   bool erase(std::string_view name);
+  std::expected<Block::DataRef<EntryMetadata>, WfsError> replace_metadata(std::string_view name,
+                                                                          const EntryMetadata* metadata);
 
   void Init();
 
@@ -34,6 +37,7 @@ class DirectoryMap {
   template <DirectoryTreeImpl TreeType>
   bool split_tree(std::vector<iterator::parent_node_info>& parents, TreeType& tree, std::string_view for_key);
   Block::DataRef<EntryMetadata> alloc_metadata(iterator it, size_t log2_size);
+  Block::DataRef<EntryMetadata> realloc_metadata(iterator it, size_t log2_size);
 
   size_t CalcSizeOfDirectoryBlock(std::shared_ptr<Block> block) const;
 

--- a/tests/directory_map_tests.cpp
+++ b/tests/directory_map_tests.cpp
@@ -72,6 +72,28 @@ void RequireEntriesInOrder(const DirectoryMap& dir_tree, uint32_t entries_count,
   }
 }
 
+size_t MetadataSize(uint8_t log2_size) {
+  return size_t{1} << log2_size;
+}
+
+void FillMetadataBytes(EntryMetadata* metadata, size_t start, size_t end, std::byte value) {
+  auto* bytes = reinterpret_cast<std::byte*>(metadata);
+  std::fill(bytes + start, bytes + end, value);
+}
+
+void FillMetadataPayload(EntryMetadata* metadata, uint8_t log2_size, std::byte value) {
+  FillMetadataBytes(metadata, sizeof(EntryMetadata), MetadataSize(log2_size), value);
+}
+
+void FillMetadataPayload(Block::DataRef<EntryMetadata> metadata, uint8_t log2_size, std::byte value) {
+  FillMetadataPayload(metadata.get_mutable(), log2_size, value);
+}
+
+bool MetadataPayloadEquals(Block::DataRef<EntryMetadata> metadata, size_t start, size_t end, std::byte value) {
+  auto* bytes = reinterpret_cast<const std::byte*>(metadata.get());
+  return std::all_of(bytes + start, bytes + end, [value](std::byte byte) { return byte == value; });
+}
+
 constexpr int kDirectoryMapStressEntries = 100000;
 
 }  // namespace
@@ -151,6 +173,132 @@ TEST_CASE_METHOD(DirectoryMapFixture,
     CHECK(entry.name == EntryName(i, 4));
     CHECK(entry.metadata.get()->flags.value() == i);
     CHECK(entry.metadata.get()->metadata_log2_size.value() == (i % 5) + 6);
+  }
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement reports missing entries",
+                 "[directory-map][unit]") {
+  TestEntryMetadata replacement(6);
+  auto result = dir_tree.replace_metadata("missing", replacement.data());
+  REQUIRE(!result.has_value());
+  CHECK(result.error() == WfsError::kEntryNotFound);
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement keeps same-size allocations",
+                 "[directory-map][unit]") {
+  TestEntryMetadata metadata(6);
+  metadata.data()->flags = 0x1234;
+  REQUIRE(dir_tree.insert("a", metadata.data()));
+
+  auto entry = dir_tree.find("a");
+  REQUIRE(!entry.is_end());
+  auto original_metadata = (*entry).metadata;
+
+  TestEntryMetadata replacement(6);
+  replacement.data()->flags = 0x5678;
+  auto result = dir_tree.replace_metadata("a", replacement.data());
+
+  REQUIRE(result.has_value());
+  CHECK(result->block == original_metadata.block);
+  CHECK(result->offset == original_metadata.offset);
+  CHECK(result->get()->flags.value() == 0x5678);
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement grows metadata using prepared bytes",
+                 "[directory-map][unit]") {
+  TestEntryMetadata metadata(6);
+  metadata.data()->flags = 0x2345;
+  REQUIRE(dir_tree.insert("a", metadata.data()));
+
+  auto original_entry = dir_tree.find("a");
+  REQUIRE(!original_entry.is_end());
+  FillMetadataPayload((*original_entry).metadata, 6, std::byte{0x5a});
+
+  TestEntryMetadata replacement(8);
+  replacement.data()->flags = 0x6789;
+  FillMetadataBytes(replacement.data(), MetadataSize(8) - 16, MetadataSize(8), std::byte{0x6b});
+  auto result = dir_tree.replace_metadata("a", replacement.data());
+
+  REQUIRE(result.has_value());
+  auto entry = dir_tree.find("a");
+  REQUIRE(!entry.is_end());
+  CHECK((*entry).metadata.block == result->block);
+  CHECK((*entry).metadata.offset == result->offset);
+  CHECK(result->get()->flags.value() == 0x6789);
+  CHECK(result->get()->metadata_log2_size.value() == 8);
+  CHECK(MetadataPayloadEquals(*result, sizeof(EntryMetadata), MetadataSize(6), std::byte{0}));
+  CHECK(MetadataPayloadEquals(*result, MetadataSize(8) - 16, MetadataSize(8), std::byte{0x6b}));
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement shrinks metadata and frees space",
+                 "[directory-map][unit]") {
+  SubBlockAllocator<DirectoryTreeHeader> allocator{root_block};
+  TestEntryMetadata metadata(8);
+  metadata.data()->flags = 0x3456;
+  REQUIRE(dir_tree.insert("a", metadata.data()));
+  auto free_after_insert = allocator.GetFreeBytes();
+
+  TestEntryMetadata replacement(6);
+  replacement.data()->flags = 0x4567;
+  auto result = dir_tree.replace_metadata("a", replacement.data());
+
+  REQUIRE(result.has_value());
+  CHECK(allocator.GetFreeBytes() > free_after_insert);
+  CHECK(result->get()->flags.value() == 0x4567);
+  CHECK(result->get()->metadata_log2_size.value() == 6);
+  REQUIRE(dir_tree.erase("a"));
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement handles a forced leaf split",
+                 "[directory-map][white-box]") {
+  auto free_blocks = (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count();
+  InsertFixedSizeEntries(dir_tree, 80);
+
+  auto target = EntryName(40);
+
+  SubBlockAllocator<DirectoryTreeHeader> allocator{root_block};
+  while (allocator.Alloc(8)) {
+  }
+
+  TestEntryMetadata replacement(8);
+  replacement.data()->flags = 40;
+  FillMetadataBytes(replacement.data(), MetadataSize(8) - 16, MetadataSize(8), std::byte{0x6b});
+  auto result = dir_tree.replace_metadata(target, replacement.data());
+
+  REQUIRE(result.has_value());
+  CHECK(result->get()->flags.value() == 40);
+  CHECK(result->get()->metadata_log2_size.value() == 8);
+  CHECK(MetadataPayloadEquals(*result, MetadataSize(8) - 16, MetadataSize(8), std::byte{0x6b}));
+  RequireEntriesInOrder(dir_tree, 80);
+  for (uint32_t i = 0; i < 80; ++i) {
+    REQUIRE(dir_tree.erase(EntryName(i)));
+  }
+  CHECK(free_blocks == (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement works in a multi-level tree",
+                 "[directory-map][integration]") {
+  constexpr uint32_t kEntriesCount = 10000;
+  InsertFixedSizeEntries(dir_tree, kEntriesCount);
+
+  TestEntryMetadata replacement(8);
+  replacement.data()->flags = 5678;
+  auto result = dir_tree.replace_metadata(EntryName(5678), replacement.data());
+
+  REQUIRE(result.has_value());
+  CHECK(result->get()->flags.value() == 5678);
+  CHECK(result->get()->metadata_log2_size.value() == 8);
+  REQUIRE(dir_tree.size() == kEntriesCount);
+  for (auto index : {uint32_t{0}, uint32_t{5678}, kEntriesCount - 1}) {
+    auto entry = dir_tree.find(EntryName(index));
+    REQUIRE(!entry.is_end());
+    CHECK((*entry).metadata.get()->flags.value() == index);
   }
 }
 


### PR DESCRIPTION
Adds a DirectoryMap primitive for replacing an entry's prepared metadata allocation. If the replacement size changes, it allocates the new slot, writes the provided metadata bytes, updates the directory entry offset, and then frees the old slot. The tests cover missing entries, same-size replacement, grow/shrink replacement, forced leaf splits, and multi-level directory trees.