### PR TITLE
Update workflow to LLVM 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  LLVM_VERSION: 19
+  LLVM_VERSION: 22
   GCC_VERSION: 14
 
 jobs:

--- a/src/directory_tree_iterator.h
+++ b/src/directory_tree_iterator.h
@@ -162,8 +162,7 @@ class DirectoryTreeIterator {
                               return std::ranges::to<std::string>(parent.node.prefix()) + (*parent.iterator).key();
                             }) |
                             std::views::join;
-    return std::ranges::to<std::string>(parent_key_parts) +
-           std::ranges::to<std::string>(leaf_->get_node().prefix());
+    return std::ranges::to<std::string>(parent_key_parts) + std::ranges::to<std::string>(leaf_->get_node().prefix());
   };
 
   Block* block_;

--- a/src/directory_tree_iterator.h
+++ b/src/directory_tree_iterator.h
@@ -158,10 +158,11 @@ class DirectoryTreeIterator {
 
  private:
   std::string key() const {
-    return (parents_ | std::views::transform([](const auto& parent) {
-              return std::ranges::to<std::string>(parent.node.prefix()) + (*parent.iterator).key();
-            }) |
-            std::views::join | std::ranges::to<std::string>()) +
+    auto parent_key_parts = parents_ | std::views::transform([](const auto& parent) {
+                              return std::ranges::to<std::string>(parent.node.prefix()) + (*parent.iterator).key();
+                            }) |
+                            std::views::join;
+    return std::ranges::to<std::string>(parent_key_parts) +
            std::ranges::to<std::string>(leaf_->get_node().prefix());
   };
 

--- a/src/free_blocks_allocator.cpp
+++ b/src/free_blocks_allocator.cpp
@@ -481,8 +481,7 @@ std::optional<std::vector<FreeBlocksRangeInfo>> FreeBlocksAllocator::AllocAreaBl
   for (const auto& range : used_ranges)
     std::ranges::for_each(range.extents,
                           std::bind(&FreeBlocksAllocator::RemoveFreeBlocksExtent, this, std::placeholders::_1));
-  return std::ranges::to<std::vector>(
-      used_ranges | std::views::transform([](const auto& x) { return x.range; }));
+  return std::ranges::to<std::vector>(used_ranges | std::views::transform([](const auto& x) { return x.range; }));
 }
 
 std::shared_ptr<Block> FreeBlocksAllocator::LoadAllocatorBlock(uint32_t block_number, bool new_block) {

--- a/src/free_blocks_allocator.cpp
+++ b/src/free_blocks_allocator.cpp
@@ -481,7 +481,7 @@ std::optional<std::vector<FreeBlocksRangeInfo>> FreeBlocksAllocator::AllocAreaBl
   for (const auto& range : used_ranges)
     std::ranges::for_each(range.extents,
                           std::bind(&FreeBlocksAllocator::RemoveFreeBlocksExtent, this, std::placeholders::_1));
-  return std::ranges::to<std::vector<FreeBlocksRangeInfo>>(
+  return std::ranges::to<std::vector>(
       used_ranges | std::views::transform([](const auto& x) { return x.range; }));
 }
 

--- a/src/free_blocks_allocator.cpp
+++ b/src/free_blocks_allocator.cpp
@@ -481,7 +481,8 @@ std::optional<std::vector<FreeBlocksRangeInfo>> FreeBlocksAllocator::AllocAreaBl
   for (const auto& range : used_ranges)
     std::ranges::for_each(range.extents,
                           std::bind(&FreeBlocksAllocator::RemoveFreeBlocksExtent, this, std::placeholders::_1));
-  return used_ranges | std::views::transform([](const auto& x) { return x.range; }) | std::ranges::to<std::vector>();
+  return std::ranges::to<std::vector<FreeBlocksRangeInfo>>(
+      used_ranges | std::views::transform([](const auto& x) { return x.range; }));
 }
 
 std::shared_ptr<Block> FreeBlocksAllocator::LoadAllocatorBlock(uint32_t block_number, bool new_block) {

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -105,7 +105,7 @@ std::expected<std::vector<QuotaArea::QuotaFragment>, WfsError> QuotaArea::AllocA
     return std::unexpected(kNoSpace);
   auto to_quota_fragment = [](const auto& frag) { return QuotaFragment{frag.block_number, frag.blocks_count}; };
   auto quota_fragments = *res | std::views::transform(to_quota_fragment);
-  return std::ranges::to<std::vector<QuotaFragment>>(quota_fragments);
+  return std::ranges::to<std::vector>(quota_fragments);
 }
 
 bool QuotaArea::DeleteBlocks(uint32_t block_number, uint32_t blocks_count) {
@@ -157,7 +157,7 @@ void QuotaArea::Init(std::shared_ptr<Area> parent_area,
 
   auto free_blocks_allocator =
       std::make_unique<FreeBlocksAllocator>(shared_from_this(), std::move(free_blocks_allocator_block));
-  auto quota_free_blocks = std::ranges::to<std::vector<FreeBlocksRangeInfo>>(
+  auto quota_free_blocks = std::ranges::to<std::vector>(
       fragments | std::views::transform([&](const auto& frag) {
         return FreeBlocksRangeInfo{
             to_area_block_number(parent_area ? parent_area->to_physical_block_number(frag.block_number)

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -103,9 +103,10 @@ std::expected<std::vector<QuotaArea::QuotaFragment>, WfsError> QuotaArea::AllocA
   auto res = (*allocator)->AllocAreaBlocks(extents_count, BlockType::Cluster);
   if (!res)
     return std::unexpected(kNoSpace);
-  return *res |
-         std::views::transform([](const auto& frag) { return QuotaFragment{frag.block_number, frag.blocks_count}; }) |
-         std::ranges::to<std::vector>();
+  return std::ranges::to<std::vector<QuotaFragment>>(
+      *res | std::views::transform([](const auto& frag) {
+        return QuotaFragment{frag.block_number, frag.blocks_count};
+      }));
 }
 
 bool QuotaArea::DeleteBlocks(uint32_t block_number, uint32_t blocks_count) {
@@ -157,15 +158,14 @@ void QuotaArea::Init(std::shared_ptr<Area> parent_area,
 
   auto free_blocks_allocator =
       std::make_unique<FreeBlocksAllocator>(shared_from_this(), std::move(free_blocks_allocator_block));
-  auto quota_free_blocks =
+  auto quota_free_blocks = std::ranges::to<std::vector<FreeBlocksRangeInfo>>(
       fragments | std::views::transform([&](const auto& frag) {
         return FreeBlocksRangeInfo{
             to_area_block_number(parent_area ? parent_area->to_physical_block_number(frag.block_number)
                                              : frag.block_number),
             to_area_blocks_count(parent_area ? parent_area->to_physical_blocks_count(frag.blocks_count)
                                              : frag.blocks_count)};
-      }) |
-      std::ranges::to<std::vector>();
+      }));
 
   // Decrease reserved blocks from first block
   uint32_t reserved_blocks = kReservedAreaBlocks;

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -103,10 +103,9 @@ std::expected<std::vector<QuotaArea::QuotaFragment>, WfsError> QuotaArea::AllocA
   auto res = (*allocator)->AllocAreaBlocks(extents_count, BlockType::Cluster);
   if (!res)
     return std::unexpected(kNoSpace);
-  return std::ranges::to<std::vector<QuotaFragment>>(
-      *res | std::views::transform([](const auto& frag) {
-        return QuotaFragment{frag.block_number, frag.blocks_count};
-      }));
+  auto to_quota_fragment = [](const auto& frag) { return QuotaFragment{frag.block_number, frag.blocks_count}; };
+  auto quota_fragments = *res | std::views::transform(to_quota_fragment);
+  return std::ranges::to<std::vector<QuotaFragment>>(quota_fragments);
 }
 
 bool QuotaArea::DeleteBlocks(uint32_t block_number, uint32_t blocks_count) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
+  $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>
 )
 
 get_property(wfs_include_dirs TARGET wfslib PROPERTY INCLUDE_DIRECTORIES)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,9 @@ target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
 )
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+  $<$<AND:$<CXX_COMPILER_ID:Clang>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,22>>:CATCH_CONFIG_NO_COUNTER>
+)
 
 get_property(wfs_include_dirs TARGET wfslib PROPERTY INCLUDE_DIRECTORIES)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,7 +49,6 @@ target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
 )
-target_compile_definitions(${PROJECT_NAME} PRIVATE CATCH_CONFIG_NO_COUNTER)
 
 get_property(wfs_include_dirs TARGET wfslib PROPERTY INCLUDE_DIRECTORIES)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,8 +48,8 @@ target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_23)
 target_compile_options(${PROJECT_NAME} PRIVATE
   $<$<CXX_COMPILER_ID:MSVC>:/W4 /WX>
   $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror>
-  $<$<CXX_COMPILER_ID:Clang>:-Wno-c2y-extensions>
 )
+target_compile_definitions(${PROJECT_NAME} PRIVATE CATCH_CONFIG_NO_COUNTER)
 
 get_property(wfs_include_dirs TARGET wfslib PROPERTY INCLUDE_DIRECTORIES)
 

--- a/tests/directory_tree_tests.cpp
+++ b/tests/directory_tree_tests.cpp
@@ -73,10 +73,10 @@ std::vector<std::string> CartesianDirectoryKeys() {
   auto two_char_keys = std::views::cartesian_product(chars, chars) | std::views::transform(to_key);
   auto three_char_keys = std::views::cartesian_product(chars, chars, chars) | std::views::transform(to_key);
   auto four_char_keys = std::views::cartesian_product(chars, chars, chars, chars) | std::views::transform(to_key);
-  auto one_char = std::ranges::to<std::vector<std::string>>(one_char_keys);
-  auto two_chars = std::ranges::to<std::vector<std::string>>(two_char_keys);
-  auto three_chars = std::ranges::to<std::vector<std::string>>(three_char_keys);
-  auto four_chars = std::ranges::to<std::vector<std::string>>(four_char_keys);
+  auto one_char = std::ranges::to<std::vector>(one_char_keys);
+  auto two_chars = std::ranges::to<std::vector>(two_char_keys);
+  auto three_chars = std::ranges::to<std::vector>(three_char_keys);
+  auto four_chars = std::ranges::to<std::vector>(four_char_keys);
   auto keys = std::ranges::to<std::vector>(std::views::join(std::vector{one_char, two_chars, three_chars, four_chars}));
   std::ranges::sort(keys);
   return keys;

--- a/tests/directory_tree_tests.cpp
+++ b/tests/directory_tree_tests.cpp
@@ -68,18 +68,18 @@ class DirectoryTreeFixture : public MetadataBlockFixture {
 
 std::vector<std::string> CartesianDirectoryKeys() {
   constexpr std::array<char, 3> chars = {'a', 'b', 'c'};
-  auto one_char = std::views::cartesian_product(chars) |
-                  std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                  std::ranges::to<std::vector>();
-  auto two_chars = std::views::cartesian_product(chars, chars) |
-                   std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                   std::ranges::to<std::vector>();
-  auto three_chars = std::views::cartesian_product(chars, chars, chars) |
-                     std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                     std::ranges::to<std::vector>();
-  auto four_chars = std::views::cartesian_product(chars, chars, chars, chars) |
-                    std::views::transform([](auto tuple) { return tuple_to_string(tuple); }) |
-                    std::ranges::to<std::vector>();
+  auto one_char = std::ranges::to<std::vector<std::string>>(
+      std::views::cartesian_product(chars) |
+      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
+  auto two_chars = std::ranges::to<std::vector<std::string>>(
+      std::views::cartesian_product(chars, chars) |
+      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
+  auto three_chars = std::ranges::to<std::vector<std::string>>(
+      std::views::cartesian_product(chars, chars, chars) |
+      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
+  auto four_chars = std::ranges::to<std::vector<std::string>>(
+      std::views::cartesian_product(chars, chars, chars, chars) |
+      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
   auto keys = std::ranges::to<std::vector>(std::views::join(std::vector{one_char, two_chars, three_chars, four_chars}));
   std::ranges::sort(keys);
   return keys;

--- a/tests/directory_tree_tests.cpp
+++ b/tests/directory_tree_tests.cpp
@@ -68,18 +68,15 @@ class DirectoryTreeFixture : public MetadataBlockFixture {
 
 std::vector<std::string> CartesianDirectoryKeys() {
   constexpr std::array<char, 3> chars = {'a', 'b', 'c'};
-  auto one_char = std::ranges::to<std::vector<std::string>>(
-      std::views::cartesian_product(chars) |
-      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
-  auto two_chars = std::ranges::to<std::vector<std::string>>(
-      std::views::cartesian_product(chars, chars) |
-      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
-  auto three_chars = std::ranges::to<std::vector<std::string>>(
-      std::views::cartesian_product(chars, chars, chars) |
-      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
-  auto four_chars = std::ranges::to<std::vector<std::string>>(
-      std::views::cartesian_product(chars, chars, chars, chars) |
-      std::views::transform([](auto tuple) { return tuple_to_string(tuple); }));
+  auto to_key = [](auto tuple) { return tuple_to_string(tuple); };
+  auto one_char_keys = std::views::cartesian_product(chars) | std::views::transform(to_key);
+  auto two_char_keys = std::views::cartesian_product(chars, chars) | std::views::transform(to_key);
+  auto three_char_keys = std::views::cartesian_product(chars, chars, chars) | std::views::transform(to_key);
+  auto four_char_keys = std::views::cartesian_product(chars, chars, chars, chars) | std::views::transform(to_key);
+  auto one_char = std::ranges::to<std::vector<std::string>>(one_char_keys);
+  auto two_chars = std::ranges::to<std::vector<std::string>>(two_char_keys);
+  auto three_chars = std::ranges::to<std::vector<std::string>>(three_char_keys);
+  auto four_chars = std::ranges::to<std::vector<std::string>>(four_char_keys);
   auto keys = std::ranges::to<std::vector>(std::views::join(std::vector{one_char, two_chars, three_chars, four_chars}));
   std::ranges::sort(keys);
   return keys;

--- a/tests/ftree_tests.cpp
+++ b/tests/ftree_tests.cpp
@@ -20,10 +20,9 @@ namespace {
 class FTreeFixture : public MetadataBlockFixture {
  public:
   FTreeFixture() {
-    FTreesBlock{ftrees_block}.Init();
-    ftrees = std::ranges::iota_view(size_t{0}, kSizeBuckets.size()) |
-             std::views::transform([this](size_t i) -> FTree { return FTree{ftrees_block, i}; }) |
-             std::ranges::to<std::vector>();
+    ftrees = std::ranges::to<std::vector<FTree>>(
+        std::ranges::iota_view(size_t{0}, kSizeBuckets.size()) |
+        std::views::transform([this](size_t i) -> FTree { return FTree{ftrees_block, i}; }));
   }
 
   std::shared_ptr<TestBlock> ftrees_block = LoadMetadataBlock(0);

--- a/tests/ftree_tests.cpp
+++ b/tests/ftree_tests.cpp
@@ -20,9 +20,11 @@ namespace {
 class FTreeFixture : public MetadataBlockFixture {
  public:
   FTreeFixture() {
-    ftrees = std::ranges::to<std::vector<FTree>>(
-        std::ranges::iota_view(size_t{0}, kSizeBuckets.size()) |
-        std::views::transform([this](size_t i) -> FTree { return FTree{ftrees_block, i}; }));
+    FTreesBlock{ftrees_block}.Init();
+    ftrees.reserve(kSizeBuckets.size());
+    for (size_t i = 0; i < kSizeBuckets.size(); ++i) {
+      ftrees.emplace_back(ftrees_block, i);
+    }
   }
 
   std::shared_ptr<TestBlock> ftrees_block = LoadMetadataBlock(0);


### PR DESCRIPTION
## Summary
- Update the CI workflow LLVM version from 19 to 22.
- Configure Catch2 tests with `CATCH_CONFIG_NO_COUNTER` to avoid the Clang 22 `__COUNTER__` diagnostic tracked in catchorg/Catch2#3076.
- Replace piped `range | std::ranges::to(...)` conversions that fail with Clang 22 and libstdc++ 14 with direct conversions or simple loops.

## Validation
- `Clang Format` run 50: success
- `Build` run 532: success across the full matrix