### PR TITLE
Implement inline file resize

### DIFF
--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -31,10 +31,10 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(std::string_view name) const;
   std::expected<std::shared_ptr<File>, WfsError> GetFile(std::string_view name) const;
 
-  size_t size() const { return map_.size(); }
+  size_t size() const { return map_->size(); }
 
-  iterator begin() const { return {map_.begin()}; }
-  iterator end() const { return {map_.end()}; }
+  iterator begin() const { return {map_->begin(), map_}; }
+  iterator end() const { return {map_->end(), map_}; }
 
   iterator find(std::string_view key) const;
 
@@ -46,5 +46,5 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   std::shared_ptr<QuotaArea> quota_;
   std::shared_ptr<Block> block_;
 
-  DirectoryMap map_;
+  std::shared_ptr<DirectoryMap> map_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <expected>
+#include <functional>
 #include <memory>
 #include <string>
 
@@ -19,6 +20,7 @@ class QuotaArea;
 class Entry {
  public:
   using MetadataRef = Block::DataRef<EntryMetadata>;
+  using MetadataUpdater = std::function<std::expected<MetadataRef, WfsError>(const EntryMetadata*)>;
 
   Entry(std::string name, MetadataRef block);
   virtual ~Entry();
@@ -37,7 +39,8 @@ class Entry {
 
   static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
                                                               std::string name,
-                                                              MetadataRef metadata_ref);
+                                                              MetadataRef metadata_ref,
+                                                              MetadataUpdater metadata_updater = {});
 
  protected:
   // TODO: Metadata copy as it can change?

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -21,6 +21,7 @@ class Entry {
  public:
   using MetadataRef = Block::DataRef<EntryMetadata>;
   using MetadataUpdater = std::function<std::expected<MetadataRef, WfsError>(const EntryMetadata*)>;
+  using MetadataRefresher = std::function<std::expected<MetadataRef, WfsError>()>;
 
   Entry(std::string name, MetadataRef block);
   virtual ~Entry();
@@ -40,7 +41,8 @@ class Entry {
   static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
                                                               std::string name,
                                                               MetadataRef metadata_ref,
-                                                              MetadataUpdater metadata_updater = {});
+                                                              MetadataUpdater metadata_updater = {},
+                                                              MetadataRefresher metadata_refresher = {});
 
  protected:
   // TODO: Metadata copy as it can change?

--- a/include/wfslib/errors.h
+++ b/include/wfslib/errors.h
@@ -24,6 +24,7 @@ enum WfsError {
   kInvalidWfsVersion,
   kNoSpace,
   kFileTooLarge,
+  kUnsupportedFileResize,
 };
 
 class WfsException : public std::exception {

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -11,9 +11,11 @@
 #include <boost/iostreams/positioning.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <memory>
+#include <utility>
 #include "entry.h"
 
 class QuotaArea;
+struct FileLayout;
 
 class File : public Entry, public std::enable_shared_from_this<File> {
   class LayoutAccessor;
@@ -25,8 +27,10 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota)
-      : Entry(std::move(name), std::move(metadata)), quota_(std::move(quota)) {}
+  File(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota, MetadataUpdater metadata_updater = {})
+      : Entry(std::move(name), std::move(metadata)),
+        quota_(std::move(quota)),
+        metadata_updater_(std::move(metadata_updater)) {}
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;
@@ -56,9 +60,12 @@ class File : public Entry, public std::enable_shared_from_this<File> {
 
  private:
   std::shared_ptr<QuotaArea> quota() const { return quota_; }
+  void ReplaceMetadata(const EntryMetadata* metadata);
+  void ResizeInline(const FileLayout& layout);
 
   // TODO: We may have cyclic reference here if we do cache in area.
   std::shared_ptr<QuotaArea> quota_;
+  MetadataUpdater metadata_updater_;
 
   static std::shared_ptr<LayoutAccessor> CreateLayoutAccessor(std::shared_ptr<File> file);
 };

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -27,10 +27,15 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota, MetadataUpdater metadata_updater = {})
+  File(std::string name,
+       MetadataRef metadata,
+       std::shared_ptr<QuotaArea> quota,
+       MetadataUpdater metadata_updater = {},
+       MetadataRefresher metadata_refresher = {})
       : Entry(std::move(name), std::move(metadata)),
         quota_(std::move(quota)),
-        metadata_updater_(std::move(metadata_updater)) {}
+        metadata_updater_(std::move(metadata_updater)),
+        metadata_refresher_(std::move(metadata_refresher)) {}
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;
@@ -60,12 +65,26 @@ class File : public Entry, public std::enable_shared_from_this<File> {
 
  private:
   std::shared_ptr<QuotaArea> quota() const { return quota_; }
+  void RefreshMetadata() const;
+  EntryMetadata* mutable_metadata() {
+    RefreshMetadata();
+    return Entry::mutable_metadata();
+  }
+  const EntryMetadata* metadata() const {
+    RefreshMetadata();
+    return Entry::metadata();
+  }
+  const std::shared_ptr<Block>& metadata_block() const {
+    RefreshMetadata();
+    return Entry::metadata_block();
+  }
   void ReplaceMetadata(const EntryMetadata* metadata);
   void ResizeInline(const FileLayout& layout);
 
   // TODO: We may have cyclic reference here if we do cache in area.
   std::shared_ptr<QuotaArea> quota_;
   MetadataUpdater metadata_updater_;
+  MetadataRefresher metadata_refresher_;
 
   static std::shared_ptr<LayoutAccessor> CreateLayoutAccessor(std::shared_ptr<File> file);
 };

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -19,7 +19,7 @@ Directory::Directory(std::string name,
     : Entry(std::move(name), std::move(metadata)),
       quota_(std::move(quota)),
       block_(std::move(block)),
-      map_{quota_, block_} {}
+      map_{std::make_shared<DirectoryMap>(quota_, block_)} {}
 
 std::expected<std::shared_ptr<Entry>, WfsError> Directory::GetEntry(std::string_view name) const {
   try {
@@ -59,5 +59,5 @@ Directory::iterator Directory::find(std::string_view key) const {
   std::string lowercase_key{key};
   // to lowercase
   std::ranges::transform(lowercase_key, lowercase_key.begin(), [](char c) { return std::tolower(c); });
-  return {map_.find(lowercase_key)};
+  return {map_->find(lowercase_key), map_};
 }

--- a/src/directory_iterator.cpp
+++ b/src/directory_iterator.cpp
@@ -17,14 +17,24 @@ DirectoryIterator::reference DirectoryIterator::operator*() const {
   auto val = *base_;
   auto name = val.metadata.get()->GetCaseSensitiveName(val.name);
   Entry::MetadataUpdater metadata_updater;
+  Entry::MetadataRefresher metadata_refresher;
   if (map_) {
-    auto map = map_;
-    auto map_name = val.name;
-    metadata_updater = [map = std::move(map), map_name = std::move(map_name)](const EntryMetadata* metadata) {
-      return map->replace_metadata(map_name, metadata);
+    auto updater_map = map_;
+    auto updater_name = val.name;
+    metadata_updater = [map = std::move(updater_map), map_name = std::move(updater_name)](
+                           const EntryMetadata* metadata) { return map->replace_metadata(map_name, metadata); };
+    auto refresher_map = map_;
+    auto refresher_name = val.name;
+    metadata_refresher = [map = std::move(refresher_map),
+                          map_name = std::move(refresher_name)]() -> std::expected<Entry::MetadataRef, WfsError> {
+      auto it = map->find(map_name);
+      if (it.is_end())
+        return std::unexpected(WfsError::kEntryNotFound);
+      return (*it).metadata;
     };
   }
-  return {name, Entry::Load(base_.quota(), name, val.metadata, std::move(metadata_updater))};
+  return {name,
+          Entry::Load(base_.quota(), name, val.metadata, std::move(metadata_updater), std::move(metadata_refresher))};
 }
 
 DirectoryIterator& DirectoryIterator::operator++() {

--- a/src/directory_iterator.cpp
+++ b/src/directory_iterator.cpp
@@ -7,14 +7,24 @@
 
 #include "directory_iterator.h"
 
+#include "directory_map.h"
 #include "entry.h"
 
-DirectoryIterator::DirectoryIterator(DirectoryMapIterator base) : base_(base) {}
+DirectoryIterator::DirectoryIterator(DirectoryMapIterator base, std::shared_ptr<DirectoryMap> map)
+    : base_(base), map_(std::move(map)) {}
 
 DirectoryIterator::reference DirectoryIterator::operator*() const {
   auto val = *base_;
   auto name = val.metadata.get()->GetCaseSensitiveName(val.name);
-  return {name, Entry::Load(base_.quota(), name, val.metadata)};
+  Entry::MetadataUpdater metadata_updater;
+  if (map_) {
+    auto map = map_;
+    auto map_name = val.name;
+    metadata_updater = [map = std::move(map), map_name = std::move(map_name)](const EntryMetadata* metadata) {
+      return map->replace_metadata(map_name, metadata);
+    };
+  }
+  return {name, Entry::Load(base_.quota(), name, val.metadata, std::move(metadata_updater))};
 }
 
 DirectoryIterator& DirectoryIterator::operator++() {

--- a/src/directory_iterator.h
+++ b/src/directory_iterator.h
@@ -10,6 +10,9 @@
 #include "directory_map_iterator.h"
 #include "errors.h"
 
+#include <memory>
+
+class DirectoryMap;
 class QuotaArea;
 class Entry;
 
@@ -29,7 +32,7 @@ class DirectoryIterator {
   using reference = ref_type;
 
   DirectoryIterator() = default;
-  DirectoryIterator(DirectoryMapIterator base);
+  DirectoryIterator(DirectoryMapIterator base, std::shared_ptr<DirectoryMap> map);
 
   reference operator*() const;
 
@@ -48,4 +51,5 @@ class DirectoryIterator {
 
  private:
   DirectoryMapIterator base_;
+  std::shared_ptr<DirectoryMap> map_;
 };

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -19,7 +19,8 @@ Entry::~Entry() = default;
 // static
 std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
                                                             std::string name,
-                                                            MetadataRef metadata_ref) {
+                                                            MetadataRef metadata_ref,
+                                                            MetadataUpdater metadata_updater) {
   auto* metadata = metadata_ref.get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
@@ -40,7 +41,8 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
     }
   } else {
     // IsFile()
-    return std::make_shared<File>(std::move(name), std::move(metadata_ref), std::move(quota));
+    return std::make_shared<File>(std::move(name), std::move(metadata_ref), std::move(quota),
+                                  std::move(metadata_updater));
   }
 }
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -20,7 +20,8 @@ Entry::~Entry() = default;
 std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
                                                             std::string name,
                                                             MetadataRef metadata_ref,
-                                                            MetadataUpdater metadata_updater) {
+                                                            MetadataUpdater metadata_updater,
+                                                            MetadataRefresher metadata_refresher) {
   auto* metadata = metadata_ref.get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
@@ -42,7 +43,7 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
   } else {
     // IsFile()
     return std::make_shared<File>(std::move(name), std::move(metadata_ref), std::move(quota),
-                                  std::move(metadata_updater));
+                                  std::move(metadata_updater), std::move(metadata_refresher));
   }
 }
 

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -35,6 +35,8 @@ char const* WfsException::what() const noexcept {
       return "Not enough free space";
     case WfsError::kFileTooLarge:
       return "File too large";
+    case WfsError::kUnsupportedFileResize:
+      return "Unsupported file resize";
   }
   return "";
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -62,13 +62,21 @@ void File::Resize(size_t new_size) {
   ResizeInline(layout);
 }
 
+void File::RefreshMetadata() const {
+  if (metadata_refresher_)
+    const_cast<File*>(this)->metadata_ = throw_if_error(metadata_refresher_());
+}
+
 void File::ReplaceMetadata(const EntryMetadata* metadata) {
   if (metadata_updater_) {
     metadata_ = throw_if_error(metadata_updater_(metadata));
     return;
   }
 
-  assert(metadata->metadata_log2_size.value() == metadata_->metadata_log2_size.value());
+  if (metadata->metadata_log2_size.value() != metadata_->metadata_log2_size.value()) {
+    assert(false);
+    throw WfsException(WfsError::kUnsupportedFileResize);
+  }
   if (metadata != metadata_.get())
     std::memcpy(metadata_.get_mutable(), metadata, size_t{1} << metadata->metadata_log2_size.value());
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -8,9 +8,24 @@
 #include "file.h"
 
 #include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <limits>
+#include <vector>
 
 #include "block.h"
+#include "errors.h"
+#include "file_layout.h"
 #include "file_layout_accessor.h"
+
+namespace {
+uint32_t CheckedFileSize(size_t size, uint8_t block_size_log2) {
+  if (size > FileLayout::MaxFileSize(block_size_log2))
+    throw WfsException(WfsError::kFileTooLarge);
+  assert(size <= std::numeric_limits<uint32_t>::max());
+  return static_cast<uint32_t>(size);
+}
+}  // namespace
 
 uint32_t File::Size() const {
   return metadata()->file_size.value();
@@ -25,12 +40,56 @@ bool File::IsEncrypted() const {
 }
 
 void File::Resize(size_t new_size) {
-  // TODO: implment it, write now change up to size_on_disk without ever chaning size_on_disk
-  new_size = std::min(new_size, static_cast<size_t>(metadata_.get()->size_on_disk.value()));
-  size_t old_size = metadata_.get()->file_size.value();
-  if (new_size != old_size) {
-    CreateLayoutAccessor(shared_from_this())->Resize(new_size);
+  size_t old_size = metadata()->file_size.value();
+  if (new_size == old_size)
+    return;
+
+  const auto current_category = FileLayout::CategoryFromValue(metadata()->size_category.value());
+  if (current_category != FileLayoutCategory::Inline) {
+    // External block allocation is introduced in later resize stages. Preserve the old logical-only behavior for now.
+    new_size = std::min(new_size, static_cast<size_t>(metadata()->size_on_disk.value()));
+    if (new_size != old_size)
+      CreateLayoutAccessor(shared_from_this())->Resize(new_size);
+    return;
   }
+
+  const auto file_size = CheckedFileSize(new_size, quota()->block_size_log2());
+  const auto layout = FileLayout::Calculate(file_size, metadata()->filename_length.value(), quota()->block_size_log2(),
+                                            FileLayoutMode::MinimumForGrow);
+  if (layout.category != FileLayoutCategory::Inline)
+    throw WfsException(WfsError::kUnsupportedFileResize);
+
+  ResizeInline(layout);
+}
+
+void File::ReplaceMetadata(const EntryMetadata* metadata) {
+  if (metadata_updater_) {
+    metadata_ = throw_if_error(metadata_updater_(metadata));
+    return;
+  }
+
+  assert(metadata->metadata_log2_size.value() == metadata_->metadata_log2_size.value());
+  if (metadata != metadata_.get())
+    std::memcpy(metadata_.get_mutable(), metadata, size_t{1} << metadata->metadata_log2_size.value());
+}
+
+void File::ResizeInline(const FileLayout& layout) {
+  assert(layout.category == FileLayoutCategory::Inline);
+
+  const auto old_size = metadata()->file_size.value();
+  const auto bytes_to_preserve = std::min(old_size, layout.file_size);
+  std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+  auto* updated_metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+
+  std::memcpy(updated_metadata, metadata(), metadata()->size());
+  updated_metadata->file_size = layout.file_size;
+  updated_metadata->size_on_disk = layout.size_on_disk;
+  updated_metadata->metadata_log2_size = layout.metadata_log2_size;
+  updated_metadata->size_category = FileLayout::CategoryValue(layout.category);
+
+  std::copy_n(reinterpret_cast<const std::byte*>(metadata()) + metadata()->size(), bytes_to_preserve,
+              reinterpret_cast<std::byte*>(updated_metadata) + updated_metadata->size());
+  ReplaceMetadata(updated_metadata);
 }
 
 File::file_device::file_device(const std::shared_ptr<File>& file)

--- a/src/recovery.cpp
+++ b/src/recovery.cpp
@@ -238,7 +238,7 @@ std::expected<std::shared_ptr<WfsDevice>, WfsError> Recovery::OpenUsrDirectoryWi
     throw std::logic_error("Failed to find /usr/save/system");
   }
   std::shared_ptr<const Area> sub_area;
-  for (const auto& [name, metadata] : system_save_dir->map_) {
+  for (const auto& [name, metadata] : *system_save_dir->map_) {
     // this is probably a corrupted quota, let's check
     if (!metadata.get()->is_quota())
       continue;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(WFSLIB_BEHAVIOR_TEST_SOURCES
   eptree_tests.cpp
   file_layout_accessor_tests.cpp
   file_layout_tests.cpp
+  file_resize_tests.cpp
   free_blocks_allocator_tests.cpp
   free_blocks_tree_bucket_tests.cpp
   free_blocks_tree_tests.cpp

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -11,12 +11,12 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <format>
 #include <initializer_list>
 #include <ios>
 #include <memory>
 #include <ranges>
 #include <span>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -88,7 +88,10 @@ class FileResizeFixture : public MetadataBlockFixture {
 };
 
 std::string EntryName(uint32_t index) {
-  return std::format("{:05}", index);
+  auto name = std::to_string(index);
+  if (name.size() < 5)
+    name.insert(name.begin(), 5 - name.size(), '0');
+  return name;
 }
 
 std::vector<std::byte> Bytes(std::initializer_list<uint8_t> values) {
@@ -175,6 +178,29 @@ TEST_CASE_METHOD(FileResizeFixture,
   WriteFile(file, replacement, small_inline_capacity);
   expected.back() = replacement.front();
   CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize keeps existing file handles valid after inline metadata reallocation",
+                 "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x2a});
+  auto first_file = InsertInlineFile(kTestFilename, initial);
+  auto second_file = directory->GetFile(kTestFilename);
+  REQUIRE(second_file.has_value());
+
+  first_file->Resize(small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK((*second_file)->Size() == expected.size());
+  CHECK(ReadFile(*second_file, expected.size()) == expected);
+
+  constexpr std::array replacement{std::byte{0xf0}};
+  WriteFile(*second_file, replacement, small_inline_capacity);
+  expected.back() = replacement.front();
+  CHECK(ReadFile(first_file, expected.size()) == expected);
 }
 
 TEST_CASE_METHOD(FileResizeFixture,

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <format>
+#include <initializer_list>
+#include <ios>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include <wfslib/directory.h>
+#include <wfslib/file.h>
+#include <wfslib/wfs_device.h>
+
+#include "directory_map.h"
+#include "errors.h"
+#include "file_layout.h"
+#include "quota_area.h"
+#include "structs.h"
+#include "sub_block_allocator.h"
+
+#include "utils/test_fixtures.h"
+
+namespace {
+constexpr std::string_view kTestFilename = "file";
+
+class FileResizeFixture : public MetadataBlockFixture {
+ public:
+  FileResizeFixture() { directory_map.Init(); }
+
+  std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
+  std::shared_ptr<QuotaArea> quota = wfs_device->GetRootArea();
+  std::shared_ptr<Block> root_block = *quota->AllocMetadataBlock();
+  DirectoryMap directory_map{quota, root_block};
+  std::shared_ptr<Directory> directory = std::make_shared<Directory>("", Entry::MetadataRef{}, quota, root_block);
+
+  std::shared_ptr<File> InsertInlineFile(std::string_view name, std::span<const std::byte> payload) {
+    auto layout = FileLayout::Calculate(static_cast<uint32_t>(payload.size()), static_cast<uint8_t>(name.size()),
+                                        quota->block_size_log2(), FileLayoutMode::MinimumForGrow);
+    REQUIRE(layout.category == FileLayoutCategory::Inline);
+
+    std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+    metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+    metadata->file_size = layout.file_size;
+    metadata->size_on_disk = layout.size_on_disk;
+    metadata->metadata_log2_size = layout.metadata_log2_size;
+    metadata->size_category = FileLayout::CategoryValue(layout.category);
+    metadata->filename_length = static_cast<uint8_t>(name.size());
+    std::ranges::copy(payload, reinterpret_cast<std::byte*>(metadata) + metadata->size());
+
+    REQUIRE(directory_map.insert(name, metadata));
+    auto file = directory->GetFile(name);
+    REQUIRE(file.has_value());
+    return *file;
+  }
+
+  void InsertEmptyInlineFileMetadata(std::string_view name) {
+    auto layout = FileLayout::Calculate(0, static_cast<uint8_t>(name.size()), quota->block_size_log2(),
+                                        FileLayoutMode::MinimumForGrow);
+    std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+    metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+    metadata->metadata_log2_size = layout.metadata_log2_size;
+    metadata->size_category = FileLayout::CategoryValue(layout.category);
+    metadata->filename_length = static_cast<uint8_t>(name.size());
+
+    REQUIRE(directory_map.insert(name, metadata));
+  }
+
+  Entry::MetadataRef FindMetadata(std::string_view name) {
+    auto it = directory->find(name);
+    REQUIRE(!it.is_end());
+    return (*it.base()).metadata;
+  }
+};
+
+std::string EntryName(uint32_t index) {
+  return std::format("{:05}", index);
+}
+
+std::vector<std::byte> Bytes(std::initializer_list<uint8_t> values) {
+  return values | std::views::transform([](uint8_t value) { return std::byte{value}; }) |
+         std::ranges::to<std::vector>();
+}
+
+std::vector<std::byte> ReadFile(const std::shared_ptr<File>& file, size_t size) {
+  std::vector<std::byte> output(size);
+  if (output.empty())
+    return output;
+
+  File::file_device device(file);
+  const auto read = device.read(reinterpret_cast<char*>(output.data()), static_cast<std::streamsize>(output.size()));
+  REQUIRE(read == static_cast<std::streamsize>(output.size()));
+  return output;
+}
+
+void WriteFile(const std::shared_ptr<File>& file, std::span<const std::byte> input, size_t offset) {
+  File::file_device device(file);
+  if (offset != 0)
+    device.seek(static_cast<boost::iostreams::stream_offset>(offset), std::ios_base::beg);
+  const auto wrote =
+      device.write(reinterpret_cast<const char*>(input.data()), static_cast<std::streamsize>(input.size()));
+  REQUIRE(wrote == static_cast<std::streamsize>(input.size()));
+}
+
+void RequireResizeError(const std::shared_ptr<File>& file, size_t new_size, WfsError error) {
+  try {
+    file->Resize(new_size);
+    FAIL("Expected File::Resize to throw");
+  } catch (const WfsException& e) {
+    CHECK(e.error() == error);
+  }
+}
+}  // namespace
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows inline data and zero fills the new range", "[file][resize]") {
+  const auto initial = Bytes({0x11, 0x22, 0x33, 0x44});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(12);
+
+  CHECK(file->Size() == 12);
+  CHECK(file->SizeOnDisk() == 12);
+  auto expected = initial;
+  expected.resize(12, std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks inline data", "[file][resize]") {
+  const auto initial = Bytes({0x10, 0x20, 0x30, 0x40, 0x50});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(3);
+
+  CHECK(file->Size() == 3);
+  CHECK(file->SizeOnDisk() == 3);
+  CHECK(ReadFile(file, 3) == Bytes({0x10, 0x20, 0x30}));
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize reallocates inline metadata and supports writing after growth",
+                 "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x5a});
+  auto file = InsertInlineFile(kTestFilename, initial);
+  auto original_metadata = FindMetadata(kTestFilename);
+
+  file->Resize(small_inline_capacity + 1);
+
+  auto updated_metadata = FindMetadata(kTestFilename);
+  CHECK(updated_metadata->metadata_log2_size.value() == 7);
+  CHECK(updated_metadata != original_metadata);
+  CHECK(file->Size() == small_inline_capacity + 1);
+  CHECK(file->SizeOnDisk() == small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  constexpr std::array replacement{std::byte{0xbe}};
+  WriteFile(file, replacement, small_inline_capacity);
+  expected.back() = replacement.front();
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize keeps directory lookup valid when inline metadata reallocation splits a leaf",
+                 "[file][resize]") {
+  constexpr uint32_t kEntriesCount = 80;
+  constexpr uint32_t kTargetIndex = 40;
+  const auto target = EntryName(kTargetIndex);
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(target.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x4d});
+
+  for (uint32_t i = 0; i < kEntriesCount; ++i) {
+    if (i == kTargetIndex) {
+      InsertInlineFile(target, initial);
+    } else {
+      InsertEmptyInlineFileMetadata(EntryName(i));
+    }
+  }
+
+  SubBlockAllocator<DirectoryTreeHeader> allocator{root_block};
+  while (allocator.Alloc(8)) {
+  }
+
+  auto file = directory->GetFile(target);
+  REQUIRE(file.has_value());
+  (*file)->Resize(small_inline_capacity + 1);
+
+  auto loaded_again = directory->GetFile(target);
+  REQUIRE(loaded_again.has_value());
+  CHECK((*loaded_again)->Size() == small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK(ReadFile(*loaded_again, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline data to zero", "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity + 1, std::byte{0x6b});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(0);
+
+  auto metadata = FindMetadata(kTestFilename);
+  CHECK(metadata->metadata_log2_size.value() == 6);
+  CHECK(file->Size() == 0);
+  CHECK(file->SizeOnDisk() == 0);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize rejects category transitions for now", "[file][resize]") {
+  const auto inline_capacity = FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(inline_capacity, std::byte{0x7c});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  RequireResizeError(file, inline_capacity + 1, WfsError::kUnsupportedFileResize);
+
+  CHECK(file->Size() == inline_capacity);
+  CHECK(file->SizeOnDisk() == inline_capacity);
+  CHECK(ReadFile(file, initial.size()) == initial);
+}


### PR DESCRIPTION
This PR implements physical resize support for inline category 0 files. File resize now recalculates the inline layout, preserves existing bytes, zero-fills newly exposed inline data, updates file size and size-on-disk, and uses directory metadata replacement when inline metadata has to move. Category transitions and external block allocation remain blocked for later resize stages.