### PR TITLE
Implement same-category external file resize

### DIFF
--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -80,6 +80,9 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   }
   void ReplaceMetadata(const EntryMetadata* metadata);
   void ResizeInline(const FileLayout& layout);
+  void ResizeExternal(const FileLayout& layout);
+  void ResizeExternalDataBlocks(uint32_t old_file_size, uint32_t new_file_size, const FileLayout& layout);
+  void FlushAndDetachExternalDataBlocks(const FileLayout& layout);
 
   // TODO: We may have cyclic reference here if we do cache in area.
   std::shared_ptr<QuotaArea> quota_;

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -115,12 +115,16 @@ std::expected<std::shared_ptr<Block>, WfsError> Block::LoadDataBlock(std::shared
                                                                      bool check_hash) {
   auto cached_block = device->GetFromCache(physical_block_number);
   if (cached_block) {
-    assert(cached_block->physical_block_number() == physical_block_number);
-    assert(cached_block->block_size() == block_size);
-    assert(cached_block->block_type() == block_type);
-    assert(cached_block->size() == data_size);
-    assert(cached_block->encrypted() == encrypted);
-    return cached_block;
+    if (!load_data) {
+      cached_block->Detach();
+    } else {
+      assert(cached_block->physical_block_number() == physical_block_number);
+      assert(cached_block->block_size() == block_size);
+      assert(cached_block->block_type() == block_type);
+      assert(cached_block->size() == data_size);
+      assert(cached_block->encrypted() == encrypted);
+      return cached_block;
+    }
   }
   auto block = std::make_shared<Block>(device, physical_block_number, block_size, block_type, data_size, iv,
                                        std::move(data_hash), encrypted);

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -11,6 +11,7 @@
 #include <cassert>
 #include <cstring>
 #include <limits>
+#include <span>
 #include <vector>
 
 #include "block.h"
@@ -19,11 +20,210 @@
 #include "file_layout_accessor.h"
 
 namespace {
+struct ExternalDataBlockRef {
+  uint32_t block_number;
+  BlockType block_type;
+  size_t offset;
+  uint32_t size;
+  Block::HashRef hash;
+};
+
 uint32_t CheckedFileSize(size_t size, uint8_t block_size_log2) {
   if (size > FileLayout::MaxFileSize(block_size_log2))
     throw WfsException(WfsError::kFileTooLarge);
   assert(size <= std::numeric_limits<uint32_t>::max());
   return static_cast<uint32_t>(size);
+}
+
+FileLayout CurrentLayout(const EntryMetadata* metadata, uint8_t block_size_log2) {
+  const auto category = FileLayout::CategoryFromValue(metadata->size_category.value());
+  return {
+      .category = category,
+      .metadata_log2_size = metadata->metadata_log2_size.value(),
+      .file_size = metadata->file_size.value(),
+      .size_on_disk = metadata->size_on_disk.value(),
+      .data_units_count = FileLayout::DataUnitsCount(category, metadata->size_on_disk.value(), block_size_log2),
+  };
+}
+
+BlockType AllocationBlockType(FileLayoutCategory category) {
+  switch (category) {
+    case FileLayoutCategory::Blocks:
+      return BlockType::Single;
+    case FileLayoutCategory::LargeBlocks:
+      return BlockType::Large;
+    case FileLayoutCategory::Clusters:
+      return BlockType::Cluster;
+    case FileLayoutCategory::Inline:
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  throw std::invalid_argument("Unexpected external file layout category");
+}
+
+BlockType DataBlockType(FileLayoutCategory category) {
+  switch (category) {
+    case FileLayoutCategory::Blocks:
+      return BlockType::Single;
+    case FileLayoutCategory::LargeBlocks:
+    case FileLayoutCategory::Clusters:
+      return BlockType::Large;
+    case FileLayoutCategory::Inline:
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  throw std::invalid_argument("Unexpected external file layout category");
+}
+
+size_t DataBlockLog2Size(FileLayoutCategory category, uint8_t block_size_log2) {
+  return static_cast<size_t>(block_size_log2) + static_cast<size_t>(log2_size(DataBlockType(category)));
+}
+
+uint32_t AllocationBlocksCount(FileLayoutCategory category) {
+  return uint32_t{1} << log2_size(AllocationBlockType(category));
+}
+
+uint32_t DataSizeForBlock(uint32_t file_size, size_t block_offset, size_t log2_block_size) {
+  if (file_size <= block_offset)
+    return 0;
+  return static_cast<uint32_t>(std::min(size_t{1} << log2_block_size, static_cast<size_t>(file_size) - block_offset));
+}
+
+template <typename T>
+std::span<T> AlignedMetadataItems(EntryMetadata* metadata, size_t count) {
+  auto* metadata_bytes = reinterpret_cast<std::byte*>(metadata);
+  const auto metadata_size = sizeof(T) * count;
+  auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+  return {reinterpret_cast<T*>(end - metadata_size), count};
+}
+
+template <typename T>
+std::span<const T> AlignedMetadataItems(const EntryMetadata* metadata, size_t count) {
+  const auto* metadata_bytes = reinterpret_cast<const std::byte*>(metadata);
+  const auto metadata_size = sizeof(T) * count;
+  const auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+  return {reinterpret_cast<const T*>(end - metadata_size), count};
+}
+
+template <typename T>
+T& LogicalMetadataItem(std::span<T> items, size_t index) {
+  return items[items.size() - index - 1];
+}
+
+template <typename T>
+const T& LogicalMetadataItem(std::span<const T> items, size_t index) {
+  return items[items.size() - index - 1];
+}
+
+ExternalDataBlockRef GetExternalDataBlockRef(FileLayoutCategory category,
+                                             const EntryMetadata* metadata,
+                                             const std::shared_ptr<Block>& metadata_block,
+                                             uint8_t block_size_log2,
+                                             size_t block_offset,
+                                             uint32_t file_size) {
+  const auto data_block_type = DataBlockType(category);
+  const auto data_block_log2_size = DataBlockLog2Size(category, block_size_log2);
+  const auto data_block_size = DataSizeForBlock(file_size, block_offset, data_block_log2_size);
+
+  if (category == FileLayoutCategory::Blocks || category == FileLayoutCategory::LargeBlocks) {
+    const auto items_count = FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), block_size_log2);
+    const auto items = AlignedMetadataItems<DataBlockMetadata>(metadata, items_count);
+    const auto& item = LogicalMetadataItem(items, block_offset >> data_block_log2_size);
+    return {item.block_number.value(),
+            data_block_type,
+            block_offset,
+            data_block_size,
+            {metadata_block, metadata_block->to_offset(item.hash)}};
+  }
+
+  assert(category == FileLayoutCategory::Clusters);
+  const auto cluster_log2_size =
+      static_cast<size_t>(block_size_log2) + static_cast<size_t>(log2_size(BlockType::Cluster));
+  const auto items_count = FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), block_size_log2);
+  const auto items = AlignedMetadataItems<DataBlocksClusterMetadata>(metadata, items_count);
+  const auto cluster_index = block_offset >> cluster_log2_size;
+  const auto block_index_in_cluster = (block_offset - (cluster_index << cluster_log2_size)) >> data_block_log2_size;
+  const auto& item = LogicalMetadataItem(items, cluster_index);
+  return {item.block_number.value() + static_cast<uint32_t>(block_index_in_cluster << log2_size(BlockType::Large)),
+          data_block_type,
+          block_offset,
+          data_block_size,
+          {metadata_block, metadata_block->to_offset(item.hash[block_index_in_cluster])}};
+}
+
+void FreeAllocatedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                             FileLayoutCategory category,
+                             std::span<const uint32_t> block_numbers) {
+  for (const auto block_number : block_numbers) {
+    if (!quota->DeleteBlocks(block_number, AllocationBlocksCount(category)))
+      throw WfsException(WfsError::kFreeBlocksAllocatorCorrupted);
+  }
+}
+
+void CopyExternalMetadataItems(const EntryMetadata* old_metadata,
+                               EntryMetadata* new_metadata,
+                               const FileLayout& old_layout,
+                               const FileLayout& new_layout,
+                               std::span<const uint32_t> allocated_blocks) {
+  const auto preserved_count = std::min(old_layout.data_units_count, new_layout.data_units_count);
+
+  if (new_layout.category == FileLayoutCategory::Blocks || new_layout.category == FileLayoutCategory::LargeBlocks) {
+    const auto old_items = AlignedMetadataItems<DataBlockMetadata>(old_metadata, old_layout.data_units_count);
+    auto new_items = AlignedMetadataItems<DataBlockMetadata>(new_metadata, new_layout.data_units_count);
+    for (size_t i = 0; i < preserved_count; ++i)
+      LogicalMetadataItem(new_items, i) = LogicalMetadataItem(old_items, i);
+    for (size_t i = 0; i < allocated_blocks.size(); ++i)
+      LogicalMetadataItem(new_items, preserved_count + i).block_number = allocated_blocks[i];
+    return;
+  }
+
+  assert(new_layout.category == FileLayoutCategory::Clusters);
+  const auto old_items = AlignedMetadataItems<DataBlocksClusterMetadata>(old_metadata, old_layout.data_units_count);
+  auto new_items = AlignedMetadataItems<DataBlocksClusterMetadata>(new_metadata, new_layout.data_units_count);
+  for (size_t i = 0; i < preserved_count; ++i)
+    LogicalMetadataItem(new_items, i) = LogicalMetadataItem(old_items, i);
+  for (size_t i = 0; i < allocated_blocks.size(); ++i)
+    LogicalMetadataItem(new_items, preserved_count + i).block_number = allocated_blocks[i];
+}
+
+std::vector<uint32_t> RemovedAllocationBlocks(const EntryMetadata* old_metadata,
+                                              const FileLayout& old_layout,
+                                              const FileLayout& new_layout) {
+  std::vector<uint32_t> removed_blocks;
+  if (new_layout.data_units_count >= old_layout.data_units_count)
+    return removed_blocks;
+
+  removed_blocks.reserve(old_layout.data_units_count - new_layout.data_units_count);
+  if (old_layout.category == FileLayoutCategory::Blocks || old_layout.category == FileLayoutCategory::LargeBlocks) {
+    const auto old_items = AlignedMetadataItems<DataBlockMetadata>(old_metadata, old_layout.data_units_count);
+    for (size_t i = new_layout.data_units_count; i < old_layout.data_units_count; ++i)
+      removed_blocks.push_back(LogicalMetadataItem(old_items, i).block_number.value());
+    return removed_blocks;
+  }
+
+  assert(old_layout.category == FileLayoutCategory::Clusters);
+  const auto old_items = AlignedMetadataItems<DataBlocksClusterMetadata>(old_metadata, old_layout.data_units_count);
+  for (size_t i = new_layout.data_units_count; i < old_layout.data_units_count; ++i)
+    removed_blocks.push_back(LogicalMetadataItem(old_items, i).block_number.value());
+  return removed_blocks;
+}
+
+void DetachAllocatedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                               FileLayoutCategory category,
+                               std::span<const uint32_t> block_numbers) {
+  const auto data_block_type = DataBlockType(category);
+  const auto data_blocks_count = AllocationBlocksCount(category) >> log2_size(data_block_type);
+  const auto data_block_step = uint32_t{1} << log2_size(data_block_type);
+  const auto data_block_size =
+      static_cast<uint32_t>(quota->block_size() << static_cast<size_t>(log2_size(data_block_type)));
+  for (const auto block_number : block_numbers) {
+    for (uint32_t i = 0; i < data_blocks_count; ++i) {
+      auto block = throw_if_error(
+          quota->LoadDataBlock(block_number + i * data_block_step, static_cast<BlockSize>(quota->block_size_log2()),
+                               data_block_type, data_block_size, {}, /*encrypted=*/false, /*new_block=*/true));
+      block->Detach();
+    }
+  }
 }
 }  // namespace
 
@@ -45,8 +245,8 @@ void File::Resize(size_t new_size) {
     return;
 
   const auto current_category = FileLayout::CategoryFromValue(metadata()->size_category.value());
-  if (current_category != FileLayoutCategory::Inline) {
-    // External block allocation is introduced in later resize stages. Preserve the old logical-only behavior for now.
+  if (current_category == FileLayoutCategory::ClusterMetadataBlocks) {
+    // Category 4 allocation is introduced in a later resize stage. Preserve the old logical-only behavior for now.
     new_size = std::min(new_size, static_cast<size_t>(metadata()->size_on_disk.value()));
     if (new_size != old_size)
       CreateLayoutAccessor(shared_from_this())->Resize(new_size);
@@ -54,6 +254,15 @@ void File::Resize(size_t new_size) {
   }
 
   const auto file_size = CheckedFileSize(new_size, quota()->block_size_log2());
+  if (current_category != FileLayoutCategory::Inline) {
+    if (!FileLayout::CategoryCanStore(current_category, file_size, metadata()->filename_length.value(),
+                                      quota()->block_size_log2()))
+      throw WfsException(WfsError::kUnsupportedFileResize);
+    ResizeExternal(FileLayout::CalculateForCategory(file_size, metadata()->filename_length.value(),
+                                                    quota()->block_size_log2(), current_category));
+    return;
+  }
+
   const auto layout = FileLayout::Calculate(file_size, metadata()->filename_length.value(), quota()->block_size_log2(),
                                             FileLayoutMode::MinimumForGrow);
   if (layout.category != FileLayoutCategory::Inline)
@@ -73,10 +282,7 @@ void File::ReplaceMetadata(const EntryMetadata* metadata) {
     return;
   }
 
-  if (metadata->metadata_log2_size.value() != metadata_->metadata_log2_size.value()) {
-    assert(false);
-    throw WfsException(WfsError::kUnsupportedFileResize);
-  }
+  assert(metadata->metadata_log2_size.value() == metadata_->metadata_log2_size.value());
   if (metadata != metadata_.get())
     std::memcpy(metadata_.get_mutable(), metadata, size_t{1} << metadata->metadata_log2_size.value());
 }
@@ -98,6 +304,104 @@ void File::ResizeInline(const FileLayout& layout) {
   std::copy_n(reinterpret_cast<const std::byte*>(metadata()) + metadata()->size(), bytes_to_preserve,
               reinterpret_cast<std::byte*>(updated_metadata) + updated_metadata->size());
   ReplaceMetadata(updated_metadata);
+}
+
+void File::ResizeExternal(const FileLayout& layout) {
+  assert(layout.category == FileLayout::CategoryFromValue(metadata()->size_category.value()));
+  assert(layout.category == FileLayoutCategory::Blocks || layout.category == FileLayoutCategory::LargeBlocks ||
+         layout.category == FileLayoutCategory::Clusters);
+
+  const auto old_layout = CurrentLayout(metadata(), quota()->block_size_log2());
+  const auto metadata_realigns = old_layout.metadata_log2_size != layout.metadata_log2_size ||
+                                 old_layout.data_units_count != layout.data_units_count;
+  if (metadata_realigns)
+    FlushAndDetachExternalDataBlocks(old_layout);
+
+  std::vector<uint32_t> allocated_blocks;
+  if (layout.data_units_count > old_layout.data_units_count) {
+    allocated_blocks = throw_if_error(quota()->AllocDataBlocks(layout.data_units_count - old_layout.data_units_count,
+                                                               AllocationBlockType(layout.category)));
+  }
+
+  const auto removed_blocks = RemovedAllocationBlocks(metadata(), old_layout, layout);
+
+  std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+  auto* updated_metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+  std::memcpy(updated_metadata, metadata(), metadata()->size());
+  updated_metadata->file_size = layout.file_size;
+  updated_metadata->size_on_disk = layout.size_on_disk;
+  updated_metadata->metadata_log2_size = layout.metadata_log2_size;
+  updated_metadata->size_category = FileLayout::CategoryValue(layout.category);
+  CopyExternalMetadataItems(metadata(), updated_metadata, old_layout, layout, allocated_blocks);
+
+  try {
+    ReplaceMetadata(updated_metadata);
+  } catch (...) {
+    FreeAllocatedDataBlocks(quota(), layout.category, allocated_blocks);
+    throw;
+  }
+
+  ResizeExternalDataBlocks(old_layout.file_size, layout.file_size, layout);
+  DetachAllocatedDataBlocks(quota(), old_layout.category, removed_blocks);
+  FreeAllocatedDataBlocks(quota(), old_layout.category, removed_blocks);
+}
+
+void File::ResizeExternalDataBlocks(uint32_t old_file_size, uint32_t new_file_size, const FileLayout& layout) {
+  if (old_file_size == new_file_size)
+    return;
+
+  const auto data_block_log2_size = DataBlockLog2Size(layout.category, quota()->block_size_log2());
+  const auto data_block_size = size_t{1} << data_block_log2_size;
+
+  if (new_file_size < old_file_size) {
+    if (new_file_size == 0)
+      return;
+    const auto block_offset = floor_pow2(static_cast<size_t>(new_file_size - 1), data_block_log2_size);
+    auto ref = GetExternalDataBlockRef(layout.category, metadata(), metadata_block(), quota()->block_size_log2(),
+                                       block_offset, old_file_size);
+    assert(ref.size > 0);
+    auto block =
+        throw_if_error(quota()->LoadDataBlock(ref.block_number, static_cast<BlockSize>(quota()->block_size_log2()),
+                                              ref.block_type, ref.size, std::move(ref.hash), IsEncrypted()));
+    block->Resize(DataSizeForBlock(new_file_size, block_offset, data_block_log2_size));
+    return;
+  }
+
+  for (auto block_offset = floor_pow2(static_cast<size_t>(old_file_size), data_block_log2_size);
+       block_offset < new_file_size; block_offset += data_block_size) {
+    const auto old_data_size = DataSizeForBlock(old_file_size, block_offset, data_block_log2_size);
+    const auto new_data_size = DataSizeForBlock(new_file_size, block_offset, data_block_log2_size);
+    if (new_data_size == 0)
+      continue;
+
+    auto ref = GetExternalDataBlockRef(layout.category, metadata(), metadata_block(), quota()->block_size_log2(),
+                                       block_offset, old_data_size == 0 ? new_file_size : old_file_size);
+    auto block = throw_if_error(
+        quota()->LoadDataBlock(ref.block_number, static_cast<BlockSize>(quota()->block_size_log2()), ref.block_type,
+                               old_data_size == 0 ? new_data_size : old_data_size, std::move(ref.hash), IsEncrypted(),
+                               /*new_block=*/old_data_size == 0));
+    if (old_data_size == 0) {
+      std::ranges::fill(block->mutable_data(), std::byte{0});
+    } else if (new_data_size != old_data_size) {
+      block->Resize(new_data_size);
+    }
+  }
+}
+
+void File::FlushAndDetachExternalDataBlocks(const FileLayout& layout) {
+  const auto data_block_log2_size = DataBlockLog2Size(layout.category, quota()->block_size_log2());
+  const auto data_block_size = size_t{1} << data_block_log2_size;
+  for (size_t block_offset = 0; block_offset < layout.file_size; block_offset += data_block_size) {
+    auto ref = GetExternalDataBlockRef(layout.category, metadata(), metadata_block(), quota()->block_size_log2(),
+                                       block_offset, layout.file_size);
+    if (ref.size == 0)
+      continue;
+    auto block =
+        throw_if_error(quota()->LoadDataBlock(ref.block_number, static_cast<BlockSize>(quota()->block_size_log2()),
+                                              ref.block_type, ref.size, std::move(ref.hash), IsEncrypted()));
+    block->Flush();
+    block->Detach();
+  }
 }
 
 File::file_device::file_device(const std::shared_ptr<File>& file)

--- a/src/file_layout.cpp
+++ b/src/file_layout.cpp
@@ -214,6 +214,33 @@ uint32_t FileLayout::MaxFileSize(uint8_t block_size_log2) {
   return static_cast<uint32_t>(std::min(max_by_size_on_disk, max_by_cluster_metadata_blocks));
 }
 
+bool FileLayout::CategoryCanStore(FileLayoutCategory category,
+                                  uint32_t file_size,
+                                  uint8_t filename_length,
+                                  uint8_t block_size_log2) {
+  if (file_size > FileLayout::MaxFileSize(block_size_log2))
+    throw WfsException(WfsError::kFileTooLarge);
+
+  const auto single_block_size = pow2<uint32_t>(block_size_log2);
+  const auto large_block_size = pow2<uint32_t>(DataBlockLog2Size(block_size_log2, BlockType::Large));
+  const auto cluster_size = pow2<uint32_t>(DataBlockLog2Size(block_size_log2, BlockType::Cluster));
+
+  switch (category) {
+    case FileLayoutCategory::Inline:
+      return file_size <= FileLayout::InlineCapacity(filename_length);
+    case FileLayoutCategory::Blocks:
+      return file_size > FileLayout::InlineCapacity(filename_length) &&
+             file_size <= kBlocksMaxCount * single_block_size;
+    case FileLayoutCategory::LargeBlocks:
+      return file_size > single_block_size && file_size <= kLargeBlocksMaxCount * large_block_size;
+    case FileLayoutCategory::Clusters:
+      return file_size > large_block_size && file_size <= kClustersMaxCount * cluster_size;
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      return file_size >= cluster_size;
+  }
+  throw std::invalid_argument("Unexpected file layout category");
+}
+
 FileLayout FileLayout::Calculate(uint32_t file_size,
                                  uint8_t filename_length,
                                  uint8_t block_size_log2,
@@ -221,5 +248,14 @@ FileLayout FileLayout::Calculate(uint32_t file_size,
   const auto category = mode == FileLayoutMode::MinimumForGrow
                             ? MinimumCategory(file_size, filename_length, block_size_log2)
                             : MaximumCategory(file_size, filename_length, block_size_log2);
+  return BuildLayout(file_size, filename_length, block_size_log2, category);
+}
+
+FileLayout FileLayout::CalculateForCategory(uint32_t file_size,
+                                            uint8_t filename_length,
+                                            uint8_t block_size_log2,
+                                            FileLayoutCategory category) {
+  if (!FileLayout::CategoryCanStore(category, file_size, filename_length, block_size_log2))
+    throw std::invalid_argument("File layout category cannot store file size");
   return BuildLayout(file_size, filename_length, block_size_log2, category);
 }

--- a/src/file_layout.h
+++ b/src/file_layout.h
@@ -39,9 +39,17 @@ struct FileLayout {
   static uint32_t ClustersPerClusterMetadataBlock(uint8_t block_size_log2);
   static uint32_t ClusterMetadataBlocksCount(uint32_t clusters_count, uint8_t block_size_log2);
   static uint32_t MaxFileSize(uint8_t block_size_log2);
+  static bool CategoryCanStore(FileLayoutCategory category,
+                               uint32_t file_size,
+                               uint8_t filename_length,
+                               uint8_t block_size_log2);
 
   static FileLayout Calculate(uint32_t file_size,
                               uint8_t filename_length,
                               uint8_t block_size_log2,
                               FileLayoutMode mode);
+  static FileLayout CalculateForCategory(uint32_t file_size,
+                                         uint8_t filename_length,
+                                         uint8_t block_size_log2,
+                                         FileLayoutCategory category);
 };

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -10,6 +10,7 @@
 #include <numeric>
 #include <ranges>
 
+#include "blocks_device.h"
 #include "directory.h"
 #include "free_blocks_allocator.h"
 #include "utils.h"
@@ -92,6 +93,15 @@ std::expected<std::vector<uint32_t>, WfsError> QuotaArea::AllocDataBlocks(uint32
   auto res = (*allocator)->AllocBlocks(count, type, false);
   if (!res)
     return std::unexpected(kNoSpace);
+  const auto cache_step =
+      type == BlockType::Cluster ? uint32_t{1} << log2_size(BlockType::Large) : uint32_t{1} << log2_size(type);
+  const auto blocks_count = uint32_t{1} << log2_size(type);
+  for (const auto block_number : *res) {
+    for (uint32_t offset = 0; offset < blocks_count; offset += cache_step) {
+      if (auto cached_block = wfs_device()->device()->GetFromCache(to_physical_block_number(block_number + offset)))
+        cached_block->Detach();
+    }
+  }
   return *res;
 }
 

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -16,10 +16,12 @@
 #include <memory>
 #include <ranges>
 #include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
 
+#include <wfslib/device.h>
 #include <wfslib/directory.h>
 #include <wfslib/file.h>
 #include <wfslib/wfs_device.h>
@@ -27,9 +29,11 @@
 #include "directory_map.h"
 #include "errors.h"
 #include "file_layout.h"
+#include "free_blocks_allocator.h"
 #include "quota_area.h"
 #include "structs.h"
 #include "sub_block_allocator.h"
+#include "utils.h"
 
 #include "utils/test_fixtures.h"
 
@@ -85,6 +89,135 @@ class FileResizeFixture : public MetadataBlockFixture {
     REQUIRE(!it.is_end());
     return (*it.base()).metadata;
   }
+
+  std::shared_ptr<File> InsertExternalFile(FileLayoutCategory category,
+                                           std::string_view name,
+                                           std::span<const std::byte> payload) {
+    auto layout = FileLayout::CalculateForCategory(
+        static_cast<uint32_t>(payload.size()), static_cast<uint8_t>(name.size()), quota->block_size_log2(), category);
+    REQUIRE(layout.category == category);
+
+    std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+    metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+    metadata->file_size = layout.file_size;
+    metadata->size_on_disk = layout.size_on_disk;
+    metadata->metadata_log2_size = layout.metadata_log2_size;
+    metadata->size_category = FileLayout::CategoryValue(layout.category);
+    metadata->filename_length = static_cast<uint8_t>(name.size());
+
+    auto allocation_type = AllocationBlockType(category);
+    auto block_numbers = *quota->AllocDataBlocks(layout.data_units_count, allocation_type);
+    SetExternalMetadataBlocks(metadata, layout, block_numbers);
+    StorePayload(layout, metadata, block_numbers, payload);
+
+    REQUIRE(directory_map.insert(name, metadata));
+    auto file = directory->GetFile(name);
+    REQUIRE(file.has_value());
+    return *file;
+  }
+
+  uint32_t FreeBlocksCount() {
+    auto allocator = quota->GetFreeBlocksAllocator();
+    REQUIRE(allocator.has_value());
+    return (*allocator)->free_blocks_count();
+  }
+
+ private:
+  static BlockType AllocationBlockType(FileLayoutCategory category) {
+    switch (category) {
+      case FileLayoutCategory::Blocks:
+        return BlockType::Single;
+      case FileLayoutCategory::LargeBlocks:
+        return BlockType::Large;
+      case FileLayoutCategory::Clusters:
+        return BlockType::Cluster;
+      case FileLayoutCategory::Inline:
+      case FileLayoutCategory::ClusterMetadataBlocks:
+        break;
+    }
+    throw std::invalid_argument("Unexpected test file layout category");
+  }
+
+  static BlockType DataBlockType(FileLayoutCategory category) {
+    return category == FileLayoutCategory::Blocks ? BlockType::Single : BlockType::Large;
+  }
+
+  static size_t DataBlockLog2Size(FileLayoutCategory category, uint8_t block_size_log2) {
+    return static_cast<size_t>(block_size_log2) + static_cast<size_t>(log2_size(DataBlockType(category)));
+  }
+
+  template <typename T>
+  static std::span<T> AlignedMetadataItems(EntryMetadata* metadata, size_t count) {
+    auto* metadata_bytes = reinterpret_cast<std::byte*>(metadata);
+    const auto metadata_size = sizeof(T) * count;
+    auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+    return {reinterpret_cast<T*>(end - metadata_size), count};
+  }
+
+  template <typename T>
+  static T& LogicalMetadataItem(std::span<T> items, size_t index) {
+    return items[items.size() - index - 1];
+  }
+
+  static uint32_t DataSizeForBlock(size_t file_size, size_t block_offset, size_t log2_block_size) {
+    if (file_size <= block_offset)
+      return 0;
+    return static_cast<uint32_t>(std::min(size_t{1} << log2_block_size, file_size - block_offset));
+  }
+
+  void SetExternalMetadataBlocks(EntryMetadata* metadata,
+                                 const FileLayout& layout,
+                                 std::span<const uint32_t> block_numbers) {
+    REQUIRE(layout.data_units_count == block_numbers.size());
+    if (layout.category == FileLayoutCategory::Blocks || layout.category == FileLayoutCategory::LargeBlocks) {
+      auto items = AlignedMetadataItems<DataBlockMetadata>(metadata, layout.data_units_count);
+      for (size_t i = 0; i < block_numbers.size(); ++i)
+        LogicalMetadataItem(items, i).block_number = block_numbers[i];
+      return;
+    }
+
+    REQUIRE(layout.category == FileLayoutCategory::Clusters);
+    auto items = AlignedMetadataItems<DataBlocksClusterMetadata>(metadata, layout.data_units_count);
+    for (size_t i = 0; i < block_numbers.size(); ++i)
+      LogicalMetadataItem(items, i).block_number = block_numbers[i];
+  }
+
+  uint32_t DataBlockNumber(const FileLayout& layout, std::span<const uint32_t> allocation_blocks, size_t block_offset) {
+    if (layout.category == FileLayoutCategory::Blocks || layout.category == FileLayoutCategory::LargeBlocks) {
+      return allocation_blocks[block_offset >> DataBlockLog2Size(layout.category, quota->block_size_log2())];
+    }
+
+    REQUIRE(layout.category == FileLayoutCategory::Clusters);
+    const auto cluster_log2_size =
+        static_cast<size_t>(quota->block_size_log2()) + static_cast<size_t>(log2_size(BlockType::Cluster));
+    const auto large_block_log2_size = DataBlockLog2Size(layout.category, quota->block_size_log2());
+    const auto cluster_index = block_offset >> cluster_log2_size;
+    const auto block_index_in_cluster = (block_offset - (cluster_index << cluster_log2_size)) >> large_block_log2_size;
+    return allocation_blocks[cluster_index] +
+           static_cast<uint32_t>(block_index_in_cluster << log2_size(BlockType::Large));
+  }
+
+  void StoreDataBlock(uint32_t area_block_number, std::span<const std::byte> data) {
+    std::vector<std::byte> aligned_data(
+        div_ceil(data.size(), test_device->device()->SectorSize()) * test_device->device()->SectorSize(), std::byte{0});
+    std::ranges::copy(data, aligned_data.begin());
+    test_device->blocks_[quota->to_physical_block_number(area_block_number)] = std::move(aligned_data);
+  }
+
+  void StorePayload(const FileLayout& layout,
+                    EntryMetadata* metadata,
+                    std::span<const uint32_t> allocation_blocks,
+                    std::span<const std::byte> payload) {
+    (void)metadata;
+    const auto data_block_log2_size = DataBlockLog2Size(layout.category, quota->block_size_log2());
+    const auto data_block_size = size_t{1} << data_block_log2_size;
+    for (size_t block_offset = 0; block_offset < payload.size(); block_offset += data_block_size) {
+      const auto data_size = DataSizeForBlock(payload.size(), block_offset, data_block_log2_size);
+      StoreDataBlock(DataBlockNumber(layout, allocation_blocks, block_offset),
+                     payload.subspan(block_offset, data_size));
+    }
+  }
 };
 
 std::string EntryName(uint32_t index) {
@@ -126,6 +259,13 @@ void RequireResizeError(const std::shared_ptr<File>& file, size_t new_size, WfsE
   } catch (const WfsException& e) {
     CHECK(e.error() == error);
   }
+}
+
+std::vector<std::byte> Pattern(size_t size, uint8_t seed) {
+  std::vector<std::byte> data(size);
+  for (size_t i = 0; i < data.size(); ++i)
+    data[i] = std::byte{static_cast<uint8_t>(seed + i)};
+  return data;
 }
 }  // namespace
 
@@ -261,5 +401,160 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize rejects category transitions fo
 
   CHECK(file->Size() == inline_capacity);
   CHECK(file->SizeOnDisk() == inline_capacity);
+  CHECK(ReadFile(file, initial.size()) == initial);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize grows category 1 by allocating another single block",
+                 "[file][resize]") {
+  const auto block_size = quota->block_size();
+  auto initial = Pattern(3 * block_size, 0x10);
+  auto file = InsertExternalFile(FileLayoutCategory::Blocks, kTestFilename, initial);
+  auto original_metadata = FindMetadata(kTestFilename);
+  const auto free_before = FreeBlocksCount();
+
+  file->Resize(3 * block_size + 1);
+
+  auto updated_metadata = FindMetadata(kTestFilename);
+  CHECK(updated_metadata != original_metadata);
+  CHECK(file->Size() == 3 * block_size + 1);
+  CHECK(file->SizeOnDisk() == 4 * block_size);
+  CHECK(updated_metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_before - 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  const auto replacement = Bytes({0xa1});
+  WriteFile(file, replacement, 3 * block_size);
+  std::ranges::copy(replacement, expected.begin() + 3 * block_size);
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize shrinks category 1 and frees removed single blocks",
+                 "[file][resize]") {
+  const auto block_size = quota->block_size();
+  auto initial = Pattern(4 * block_size + 17, 0x20);
+  auto file = InsertExternalFile(FileLayoutCategory::Blocks, kTestFilename, initial);
+  const auto free_before = FreeBlocksCount();
+
+  file->Resize(2 * block_size + 9);
+
+  CHECK(file->Size() == 2 * block_size + 9);
+  CHECK(file->SizeOnDisk() == 3 * block_size);
+  CHECK(FreeBlocksCount() == free_before + 2);
+
+  initial.resize(2 * block_size + 9);
+  CHECK(ReadFile(file, initial.size()) == initial);
+
+  const auto replacement = Bytes({0xb1, 0xb2, 0xb3, 0xb4});
+  WriteFile(file, replacement, 2 * block_size + 1);
+  std::ranges::copy(replacement, initial.begin() + 2 * block_size + 1);
+  CHECK(ReadFile(file, initial.size()) == initial);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows and shrinks category 2", "[file][resize]") {
+  const auto block_size = quota->block_size();
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  auto initial = Pattern(large_block_size + 23, 0x30);
+  auto file = InsertExternalFile(FileLayoutCategory::LargeBlocks, kTestFilename, initial);
+  const auto free_before_grow = FreeBlocksCount();
+
+  file->Resize(2 * large_block_size + 5);
+
+  CHECK(file->Size() == 2 * large_block_size + 5);
+  CHECK(file->SizeOnDisk() == 3 * large_block_size);
+  CHECK(FreeBlocksCount() == free_before_grow - (uint32_t{1} << log2_size(BlockType::Large)));
+  auto expected = initial;
+  expected.resize(2 * large_block_size + 5, std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+  const auto grow_replacement = Bytes({0xc1, 0xc2, 0xc3, 0xc4, 0xc5});
+  WriteFile(file, grow_replacement, 2 * large_block_size);
+  std::ranges::copy(grow_replacement, expected.begin() + 2 * large_block_size);
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  const auto free_before_shrink = FreeBlocksCount();
+  file->Resize(large_block_size + 11);
+
+  CHECK(file->Size() == large_block_size + 11);
+  CHECK(file->SizeOnDisk() == 2 * large_block_size);
+  CHECK(FreeBlocksCount() == free_before_shrink + (uint32_t{1} << log2_size(BlockType::Large)));
+  expected.resize(large_block_size + 11);
+  CHECK(ReadFile(file, expected.size()) == expected);
+  const auto shrink_replacement = Bytes({0xd1, 0xd2, 0xd3, 0xd4});
+  WriteFile(file, shrink_replacement, large_block_size + 3);
+  std::ranges::copy(shrink_replacement, expected.begin() + large_block_size + 3);
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows and shrinks category 3", "[file][resize]") {
+  const auto block_size = quota->block_size();
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  const auto cluster_size = block_size << log2_size(BlockType::Cluster);
+  auto initial = Pattern(large_block_size + 31, 0x40);
+  auto file = InsertExternalFile(FileLayoutCategory::Clusters, kTestFilename, initial);
+  const auto free_before_grow = FreeBlocksCount();
+
+  file->Resize(cluster_size + 13);
+
+  CHECK(file->Size() == cluster_size + 13);
+  CHECK(file->SizeOnDisk() == 2 * cluster_size);
+  CHECK(FreeBlocksCount() == free_before_grow - (uint32_t{1} << log2_size(BlockType::Cluster)));
+  auto expected = initial;
+  expected.resize(cluster_size + 13, std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+  const auto grow_replacement = Bytes({0xe1, 0xe2, 0xe3, 0xe4});
+  WriteFile(file, grow_replacement, cluster_size + 4);
+  std::ranges::copy(grow_replacement, expected.begin() + cluster_size + 4);
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  const auto free_before_shrink = FreeBlocksCount();
+  file->Resize(large_block_size + 19);
+
+  CHECK(file->Size() == large_block_size + 19);
+  CHECK(file->SizeOnDisk() == cluster_size);
+  CHECK(FreeBlocksCount() == free_before_shrink + (uint32_t{1} << log2_size(BlockType::Cluster)));
+  expected.resize(large_block_size + 19);
+  CHECK(ReadFile(file, expected.size()) == expected);
+  const auto shrink_replacement = Bytes({0xf1, 0xf2, 0xf3, 0xf4});
+  WriteFile(file, shrink_replacement, large_block_size + 7);
+  std::ranges::copy(shrink_replacement, expected.begin() + large_block_size + 7);
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize grows category 1 within the allocated block and zero fills",
+                 "[file][resize]") {
+  const auto inline_capacity = FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size()));
+  auto initial = Pattern(inline_capacity + 8, 0x50);
+  auto file = InsertExternalFile(FileLayoutCategory::Blocks, kTestFilename, initial);
+  const auto free_before = FreeBlocksCount();
+
+  file->Resize(initial.size() + 8);
+
+  CHECK(file->Size() == initial.size() + 8);
+  CHECK(file->SizeOnDisk() == quota->block_size());
+  CHECK(FreeBlocksCount() == free_before);
+  auto expected = initial;
+  expected.resize(initial.size() + 8, std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  const auto replacement = Bytes({0x91, 0x92, 0x93, 0x94});
+  WriteFile(file, replacement, initial.size() + 2);
+  std::ranges::copy(replacement, expected.begin() + initial.size() + 2);
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize rejects external category transitions for now", "[file][resize]") {
+  const auto block_size = quota->block_size();
+  auto initial = Pattern(5 * block_size, 0x60);
+  auto file = InsertExternalFile(FileLayoutCategory::Blocks, kTestFilename, initial);
+
+  RequireResizeError(file, 5 * block_size + 1, WfsError::kUnsupportedFileResize);
+
+  CHECK(file->Size() == 5 * block_size);
+  CHECK(file->SizeOnDisk() == 5 * block_size);
   CHECK(ReadFile(file, initial.size()) == initial);
 }


### PR DESCRIPTION
Implements same-category resize for external file layouts in categories 1, 2, and 3. The resize path now updates metadata through the existing replacement callback, allocates and frees data blocks as needed, preserves reversed end-aligned metadata lists, refreshes cached block state around metadata changes, and adds read/write coverage for growth and shrink flows.