### PR TITLE
Implement inline file resizing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(${PROJECT_NAME}
     src/file_device.cpp
     src/file_layout.cpp
     src/file_layout_accessor.cpp
+    src/file_resizer.cpp
     src/free_blocks_allocator.cpp
     src/free_blocks_tree_iterator.cpp
     src/free_blocks_tree.cpp

--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -31,10 +31,10 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(std::string_view name) const;
   std::expected<std::shared_ptr<File>, WfsError> GetFile(std::string_view name) const;
 
-  size_t size() const { return map_.size(); }
+  size_t size() const { return map_->size(); }
 
-  iterator begin() const { return {map_.begin()}; }
-  iterator end() const { return {map_.end()}; }
+  iterator begin() const { return {map_->begin(), map_}; }
+  iterator end() const { return {map_->end(), map_}; }
 
   iterator find(std::string_view key) const;
 
@@ -46,5 +46,5 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   std::shared_ptr<QuotaArea> quota_;
   std::shared_ptr<Block> block_;
 
-  DirectoryMap map_;
+  std::shared_ptr<DirectoryMap> map_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -15,13 +15,21 @@
 #include "structs.h"
 
 class QuotaArea;
+class DirectoryMap;
 
 class Entry {
  public:
   using MetadataRef = Block::DataRef<EntryMetadata>;
+  struct MetadataHandle {
+    explicit MetadataHandle(MetadataRef metadata) : metadata(std::move(metadata)) {}
+    MetadataRef metadata;
+  };
+  using MetadataHandleRef = std::shared_ptr<MetadataHandle>;
 
-  Entry(std::string name, MetadataRef block);
+  Entry(std::string name, MetadataHandleRef metadata);
   virtual ~Entry();
+
+  static MetadataHandleRef CreateMetadataHandle(MetadataRef metadata);
 
   std::string_view name() const { return name_; }
   bool is_directory() const { return !metadata()->is_link() && metadata()->is_directory(); }
@@ -37,14 +45,16 @@ class Entry {
 
   static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
                                                               std::string name,
-                                                              MetadataRef metadata_ref);
+                                                              MetadataHandleRef metadata,
+                                                              std::shared_ptr<DirectoryMap> directory_map,
+                                                              std::string directory_key);
 
  protected:
   // TODO: Metadata copy as it can change?
-  EntryMetadata* mutable_metadata() { return metadata_.get_mutable(); }
-  const EntryMetadata* metadata() const { return metadata_.get(); }
-  const std::shared_ptr<Block>& metadata_block() const { return metadata_.block; }
+  EntryMetadata* mutable_metadata() { return metadata_->metadata.get_mutable(); }
+  const EntryMetadata* metadata() const { return metadata_->metadata.get(); }
+  const std::shared_ptr<Block>& metadata_block() const { return metadata_->metadata.block; }
 
   std::string name_;
-  MetadataRef metadata_;
+  MetadataHandleRef metadata_;
 };

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -11,8 +11,11 @@
 #include <boost/iostreams/positioning.hpp>
 #include <boost/iostreams/stream.hpp>
 #include <memory>
+#include <string>
 #include "entry.h"
 
+class DirectoryMap;
+class FileResizer;
 class QuotaArea;
 
 class File : public Entry, public std::enable_shared_from_this<File> {
@@ -25,8 +28,11 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota)
-      : Entry(std::move(name), std::move(metadata)), quota_(std::move(quota)) {}
+  File(std::string name,
+       MetadataHandleRef metadata,
+       std::shared_ptr<QuotaArea> quota,
+       std::shared_ptr<DirectoryMap> directory_map,
+       std::string directory_key);
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;
@@ -55,10 +61,16 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   typedef boost::iostreams::stream<file_device> stream;
 
  private:
+  friend class FileResizer;
+
   std::shared_ptr<QuotaArea> quota() const { return quota_; }
+  void OverwriteMetadata(const EntryMetadata* metadata);
+  void ReallocateMetadata(const EntryMetadata* metadata);
 
   // TODO: We may have cyclic reference here if we do cache in area.
   std::shared_ptr<QuotaArea> quota_;
+  std::shared_ptr<DirectoryMap> directory_map_;
+  std::string directory_key_;
 
   static std::shared_ptr<LayoutAccessor> CreateLayoutAccessor(std::shared_ptr<File> file);
 };

--- a/include/wfslib/link.h
+++ b/include/wfslib/link.h
@@ -15,7 +15,7 @@ class QuotaArea;
 
 class Link : public Entry, public std::enable_shared_from_this<Link> {
  public:
-  Link(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota)
+  Link(std::string name, MetadataHandleRef metadata, std::shared_ptr<QuotaArea> quota)
       : Entry(std::move(name), std::move(metadata)), quota_(std::move(quota)) {}
 
  private:

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -16,10 +16,10 @@ Directory::Directory(std::string name,
                      MetadataRef metadata,
                      std::shared_ptr<QuotaArea> quota,
                      std::shared_ptr<Block> block)
-    : Entry(std::move(name), std::move(metadata)),
+    : Entry(std::move(name), Entry::CreateMetadataHandle(std::move(metadata))),
       quota_(std::move(quota)),
       block_(std::move(block)),
-      map_{quota_, block_} {}
+      map_{std::make_shared<DirectoryMap>(quota_, block_)} {}
 
 std::expected<std::shared_ptr<Entry>, WfsError> Directory::GetEntry(std::string_view name) const {
   try {
@@ -59,5 +59,5 @@ Directory::iterator Directory::find(std::string_view key) const {
   std::string lowercase_key{key};
   // to lowercase
   std::ranges::transform(lowercase_key, lowercase_key.begin(), [](char c) { return std::tolower(c); });
-  return {map_.find(lowercase_key)};
+  return {map_->find(lowercase_key), map_};
 }

--- a/src/directory_iterator.cpp
+++ b/src/directory_iterator.cpp
@@ -7,14 +7,20 @@
 
 #include "directory_iterator.h"
 
+#include "directory_map.h"
 #include "entry.h"
 
-DirectoryIterator::DirectoryIterator(DirectoryMapIterator base) : base_(base) {}
+DirectoryIterator::DirectoryIterator(DirectoryMapIterator base, std::shared_ptr<DirectoryMap> map)
+    : base_(base), map_(std::move(map)) {}
 
 DirectoryIterator::reference DirectoryIterator::operator*() const {
   auto val = *base_;
-  auto name = val.metadata.get()->GetCaseSensitiveName(val.name);
-  return {name, Entry::Load(base_.quota(), name, val.metadata)};
+  auto metadata = map_->metadata_handle(val.name);
+  if (!metadata.has_value())
+    return {val.name, std::unexpected(metadata.error())};
+
+  auto name = (*metadata)->metadata.get()->GetCaseSensitiveName(val.name);
+  return {name, Entry::Load(base_.quota(), name, *metadata, map_, val.name)};
 }
 
 DirectoryIterator& DirectoryIterator::operator++() {

--- a/src/directory_iterator.h
+++ b/src/directory_iterator.h
@@ -7,10 +7,13 @@
 
 #pragma once
 
+#include <memory>
+
 #include "directory_map_iterator.h"
 #include "errors.h"
 
 class QuotaArea;
+class DirectoryMap;
 class Entry;
 
 struct DiretoryEntry {
@@ -29,7 +32,7 @@ class DirectoryIterator {
   using reference = ref_type;
 
   DirectoryIterator() = default;
-  DirectoryIterator(DirectoryMapIterator base);
+  DirectoryIterator(DirectoryMapIterator base, std::shared_ptr<DirectoryMap> map);
 
   reference operator*() const;
 
@@ -48,4 +51,5 @@ class DirectoryIterator {
 
  private:
   DirectoryMapIterator base_;
+  std::shared_ptr<DirectoryMap> map_;
 };

--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -96,6 +96,25 @@ DirectoryMap::iterator DirectoryMap::find(std::string_view key) const {
   return {quota_, std::move(parents), std::move(leaf)};
 }
 
+std::expected<Entry::MetadataHandleRef, WfsError> DirectoryMap::metadata_handle(std::string_view name) const {
+  auto it = find(name);
+  if (it.is_end())
+    return std::unexpected(WfsError::kEntryNotFound);
+
+  const auto metadata = (*it).metadata;
+  auto key = std::ranges::to<std::string>(name);
+  auto [handle_it, inserted] = metadata_handles_.try_emplace(key);
+  (void)inserted;
+  if (auto handle = handle_it->second.lock()) {
+    handle->metadata = metadata;
+    return handle;
+  }
+
+  auto handle = Entry::CreateMetadataHandle(metadata);
+  handle_it->second = handle;
+  return handle;
+}
+
 size_t DirectoryMap::CalcSizeOfDirectoryBlock(std::shared_ptr<Block> block) const {
   if (block->get_object<MetadataBlockHeader>(0)->block_flags.value() &
       MetadataBlockHeader::Flags::DIRECTORY_LEAF_TREE) {
@@ -138,6 +157,7 @@ bool DirectoryMap::erase(std::string_view name) {
     return false;
   }
   auto parents = it.parents();
+  metadata_handles_.erase(std::ranges::to<std::string>(name));
   // Free the entry metadata first
   it.leaf().node.Free((*it.leaf().iterator).value(),
                       static_cast<uint16_t>(1 << (*it).metadata->metadata_log2_size.value()));
@@ -200,12 +220,25 @@ std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_met
   if (old_log2_size == new_log2_size) {
     if (old_metadata.get() != metadata)
       std::memcpy(old_metadata.get_mutable(), metadata, new_size);
+    update_metadata_handle(name, old_metadata);
     return old_metadata;
   }
 
   auto new_metadata = realloc_metadata(it, new_log2_size);
   std::memcpy(new_metadata.get_mutable(), metadata, new_size);
+  update_metadata_handle(name, new_metadata);
   return new_metadata;
+}
+
+void DirectoryMap::update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const {
+  auto handle_it = metadata_handles_.find(name);
+  if (handle_it == metadata_handles_.end())
+    return;
+  if (auto handle = handle_it->second.lock()) {
+    handle->metadata = std::move(metadata);
+  } else {
+    metadata_handles_.erase(handle_it);
+  }
 }
 
 template <DirectoryTreeImpl TreeType>
@@ -258,6 +291,7 @@ bool DirectoryMap::split_tree(std::vector<iterator::parent_node_info>& parents,
 }
 
 void DirectoryMap::Init() {
+  metadata_handles_.clear();
   DirectoryLeafTree root_tree{root_block_};
   root_tree.Init(/*is_root=*/true);
 }

--- a/src/directory_map.h
+++ b/src/directory_map.h
@@ -7,7 +7,12 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+#include <string>
+
 #include "directory_map_iterator.h"
+#include "entry.h"
 #include "errors.h"
 
 template <typename T>
@@ -25,6 +30,7 @@ class DirectoryMap {
   iterator end() const;
 
   iterator find(std::string_view key) const;
+  std::expected<Entry::MetadataHandleRef, WfsError> metadata_handle(std::string_view name) const;
 
   bool insert(std::string_view name, const EntryMetadata* metadata);
   bool erase(std::string_view name);
@@ -38,9 +44,11 @@ class DirectoryMap {
   bool split_tree(std::vector<iterator::parent_node_info>& parents, TreeType& tree, std::string_view for_key);
   Block::DataRef<EntryMetadata> alloc_metadata(iterator it, size_t log2_size);
   Block::DataRef<EntryMetadata> realloc_metadata(iterator it, size_t log2_size);
+  void update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const;
 
   size_t CalcSizeOfDirectoryBlock(std::shared_ptr<Block> block) const;
 
   std::shared_ptr<QuotaArea> quota_;
   std::shared_ptr<Block> root_block_;
+  mutable std::map<std::string, std::weak_ptr<Entry::MetadataHandle>, std::less<>> metadata_handles_;
 };

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -12,18 +12,24 @@
 #include "link.h"
 #include "quota_area.h"
 
-Entry::Entry(std::string name, MetadataRef metadata) : name_(std::move(name)), metadata_(std::move(metadata)) {}
+Entry::Entry(std::string name, MetadataHandleRef metadata) : name_(std::move(name)), metadata_(std::move(metadata)) {}
 
 Entry::~Entry() = default;
+
+Entry::MetadataHandleRef Entry::CreateMetadataHandle(MetadataRef metadata) {
+  return std::make_shared<MetadataHandle>(std::move(metadata));
+}
 
 // static
 std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
                                                             std::string name,
-                                                            MetadataRef metadata_ref) {
-  auto* metadata = metadata_ref.get();
+                                                            MetadataHandleRef metadata_handle,
+                                                            std::shared_ptr<DirectoryMap> directory_map,
+                                                            std::string directory_key) {
+  auto* metadata = metadata_handle->metadata.get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
-    return std::make_shared<Link>(std::move(name), std::move(metadata_ref), std::move(quota));
+    return std::make_shared<Link>(std::move(name), std::move(metadata_handle), std::move(quota));
   } else if (metadata->is_directory()) {
     if (metadata->flags.value() & metadata->Flags::QUOTA) {
       // The directory is quota, aka new area
@@ -34,13 +40,14 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
       auto new_quota = quota->LoadQuotaArea(metadata->directory_block_number.value(), block_size);
       if (!new_quota.has_value())
         return std::unexpected(new_quota.error());
-      return (*new_quota)->LoadRootDirectory(std::move(name), std::move(metadata_ref));
+      return (*new_quota)->LoadRootDirectory(std::move(name), metadata_handle->metadata);
     } else {
-      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(name), std::move(metadata_ref));
+      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(name), metadata_handle->metadata);
     }
   } else {
     // IsFile()
-    return std::make_shared<File>(std::move(name), std::move(metadata_ref), std::move(quota));
+    return std::make_shared<File>(std::move(name), std::move(metadata_handle), std::move(quota),
+                                  std::move(directory_map), std::move(directory_key));
   }
 }
 

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -8,9 +8,27 @@
 #include "file.h"
 
 #include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <utility>
 
 #include "block.h"
+#include "directory_map.h"
+#include "errors.h"
 #include "file_layout_accessor.h"
+#include "file_resizer.h"
+
+File::File(std::string name,
+           MetadataHandleRef metadata,
+           std::shared_ptr<QuotaArea> quota,
+           std::shared_ptr<DirectoryMap> directory_map,
+           std::string directory_key)
+    : Entry(std::move(name), std::move(metadata)),
+      quota_(std::move(quota)),
+      directory_map_(std::move(directory_map)),
+      directory_key_(std::move(directory_key)) {
+  assert(directory_map_);
+}
 
 uint32_t File::Size() const {
   return metadata()->file_size.value();
@@ -25,12 +43,19 @@ bool File::IsEncrypted() const {
 }
 
 void File::Resize(size_t new_size) {
-  // TODO: implment it, write now change up to size_on_disk without ever chaning size_on_disk
-  new_size = std::min(new_size, static_cast<size_t>(metadata_.get()->size_on_disk.value()));
-  size_t old_size = metadata_.get()->file_size.value();
-  if (new_size != old_size) {
-    CreateLayoutAccessor(shared_from_this())->Resize(new_size);
-  }
+  FileResizer::Resize(*this, new_size);
+}
+
+void File::OverwriteMetadata(const EntryMetadata* new_metadata) {
+  auto* current_metadata = mutable_metadata();
+  assert(new_metadata->metadata_log2_size.value() == current_metadata->metadata_log2_size.value());
+  if (new_metadata != current_metadata)
+    std::memcpy(current_metadata, new_metadata, size_t{1} << new_metadata->metadata_log2_size.value());
+}
+
+void File::ReallocateMetadata(const EntryMetadata* new_metadata) {
+  assert(new_metadata->metadata_log2_size.value() != metadata()->metadata_log2_size.value());
+  metadata_->metadata = throw_if_error(directory_map_->replace_metadata(directory_key_, new_metadata));
 }
 
 File::file_device::file_device(const std::shared_ptr<File>& file)

--- a/src/file_resizer.cpp
+++ b/src/file_resizer.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "file_resizer.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstring>
+#include <limits>
+#include <stdexcept>
+#include <vector>
+
+#include "errors.h"
+#include "file.h"
+#include "file_layout.h"
+#include "file_layout_accessor.h"
+
+namespace {
+uint32_t CheckedFileSize(size_t size, uint8_t block_size_log2) {
+  if (size > FileLayout::MaxFileSize(block_size_log2))
+    throw WfsException(WfsError::kFileTooLarge);
+  assert(size <= std::numeric_limits<uint32_t>::max());
+  return static_cast<uint32_t>(size);
+}
+
+}  // namespace
+
+void FileResizer::ResizeExternalWithinCurrentAllocation(File& file, size_t new_size) {
+  const auto old_size = file.metadata()->file_size.value();
+  new_size = std::min(new_size, static_cast<size_t>(file.metadata()->size_on_disk.value()));
+  if (new_size != old_size)
+    File::CreateLayoutAccessor(file.shared_from_this())->Resize(new_size);
+}
+
+void FileResizer::ResizeInline(File& file, const FileLayout& layout) {
+  assert(layout.category == FileLayoutCategory::Inline);
+
+  const auto old_size = file.metadata()->file_size.value();
+  const auto bytes_to_preserve = std::min(old_size, layout.file_size);
+
+  std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+  auto* updated_metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+
+  std::memcpy(updated_metadata, file.metadata(), file.metadata()->size());
+  updated_metadata->file_size = layout.file_size;
+  updated_metadata->size_on_disk = layout.size_on_disk;
+  updated_metadata->metadata_log2_size = layout.metadata_log2_size;
+  updated_metadata->size_category = FileLayout::CategoryValue(layout.category);
+
+  std::copy_n(reinterpret_cast<const std::byte*>(file.metadata()) + file.metadata()->size(), bytes_to_preserve,
+              reinterpret_cast<std::byte*>(updated_metadata) + updated_metadata->size());
+  if (updated_metadata->metadata_log2_size.value() == file.metadata()->metadata_log2_size.value())
+    file.OverwriteMetadata(updated_metadata);
+  else
+    file.ReallocateMetadata(updated_metadata);
+}
+
+void FileResizer::Resize(File& file, size_t new_size) {
+  const auto old_size = file.metadata()->file_size.value();
+  if (new_size == old_size)
+    return;
+
+  const auto current_category = FileLayout::CategoryFromValue(file.metadata()->size_category.value());
+  if (current_category != FileLayoutCategory::Inline) {
+    ResizeExternalWithinCurrentAllocation(file, new_size);
+    return;
+  }
+
+  const auto file_size = CheckedFileSize(new_size, file.quota()->block_size_log2());
+  const auto layout = FileLayout::Calculate(file_size, file.metadata()->filename_length.value(),
+                                            file.quota()->block_size_log2(), FileLayoutMode::MinimumForGrow);
+  if (layout.category != FileLayoutCategory::Inline)
+    throw std::logic_error("File resize across layout categories is not implemented");
+
+  ResizeInline(file, layout);
+}

--- a/src/file_resizer.h
+++ b/src/file_resizer.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+class File;
+struct FileLayout;
+
+class FileResizer {
+ public:
+  static void Resize(File& file, size_t new_size);
+
+ private:
+  static void ResizeExternalWithinCurrentAllocation(File& file, size_t new_size);
+  static void ResizeInline(File& file, const FileLayout& layout);
+};

--- a/src/recovery.cpp
+++ b/src/recovery.cpp
@@ -238,7 +238,7 @@ std::expected<std::shared_ptr<WfsDevice>, WfsError> Recovery::OpenUsrDirectoryWi
     throw std::logic_error("Failed to find /usr/save/system");
   }
   std::shared_ptr<const Area> sub_area;
-  for (const auto& [name, metadata] : system_save_dir->map_) {
+  for (const auto& [name, metadata] : *system_save_dir->map_) {
     // this is probably a corrupted quota, let's check
     if (!metadata.get()->is_quota())
       continue;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(WFSLIB_BEHAVIOR_TEST_SOURCES
   eptree_tests.cpp
   file_layout_accessor_tests.cpp
   file_layout_tests.cpp
+  file_resize_tests.cpp
   free_blocks_allocator_tests.cpp
   free_blocks_tree_bucket_tests.cpp
   free_blocks_tree_tests.cpp

--- a/tests/file_layout_accessor_tests.cpp
+++ b/tests/file_layout_accessor_tests.cpp
@@ -19,10 +19,12 @@
 #include <vector>
 
 #include <wfslib/device.h>
+#include <wfslib/directory.h>
 #include <wfslib/file.h>
 #include <wfslib/wfs_device.h>
 
 #include "block.h"
+#include "directory_map.h"
 #include "file_layout.h"
 #include "quota_area.h"
 #include "structs.h"
@@ -46,12 +48,15 @@ class FileLayoutAccessorFixture : public MetadataBlockFixture {
  public:
   std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
   std::shared_ptr<QuotaArea> quota = wfs_device->GetRootArea();
+  std::shared_ptr<Block> root_block = *quota->AllocMetadataBlock();
+  DirectoryMap directory_map{quota, root_block};
+  std::shared_ptr<Directory> directory = std::make_shared<Directory>("", Entry::MetadataRef{}, quota, root_block);
+
+  FileLayoutAccessorFixture() { directory_map.Init(); }
 
   TestFile CreateFile(std::string_view name, const FileLayout& layout) {
-    auto metadata_block = *quota->AllocMetadataBlock();
-    auto* metadata = metadata_block->get_mutable_object<EntryMetadata>(0);
-    std::fill(reinterpret_cast<std::byte*>(metadata),
-              reinterpret_cast<std::byte*>(metadata) + (size_t{1} << layout.metadata_log2_size), std::byte{0});
+    std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
     metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
     metadata->file_size = layout.file_size;
     metadata->size_on_disk = layout.size_on_disk;
@@ -59,8 +64,13 @@ class FileLayoutAccessorFixture : public MetadataBlockFixture {
     metadata->size_category = FileLayout::CategoryValue(layout.category);
     metadata->filename_length = static_cast<uint8_t>(name.size());
 
-    auto file = std::make_shared<File>(std::string{name}, Entry::MetadataRef{metadata_block, 0}, quota);
-    return {std::move(file), std::move(metadata_block), metadata};
+    REQUIRE(directory_map.insert(name, metadata));
+    auto file = directory->GetFile(name);
+    REQUIRE(file.has_value());
+    auto it = directory->find(name);
+    REQUIRE(!it.is_end());
+    auto metadata_ref = (*it.base()).metadata;
+    return {*file, metadata_ref.block, metadata_ref.get_mutable()};
   }
 
   TestFile CreateFile(std::string_view name, uint32_t file_size) {

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <ios>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#include <wfslib/directory.h>
+#include <wfslib/file.h>
+#include <wfslib/wfs_device.h>
+
+#include "directory_map.h"
+#include "errors.h"
+#include "file_layout.h"
+#include "quota_area.h"
+#include "structs.h"
+
+#include "utils/test_fixtures.h"
+
+namespace {
+constexpr std::string_view kTestFilename = "file";
+
+class FileResizeFixture : public MetadataBlockFixture {
+ public:
+  FileResizeFixture() { directory_map.Init(); }
+
+  std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
+  std::shared_ptr<QuotaArea> quota = wfs_device->GetRootArea();
+  std::shared_ptr<Block> root_block = *quota->AllocMetadataBlock();
+  DirectoryMap directory_map{quota, root_block};
+  std::shared_ptr<Directory> directory = std::make_shared<Directory>("", Entry::MetadataRef{}, quota, root_block);
+
+  std::shared_ptr<File> InsertInlineFile(std::string_view name, std::span<const std::byte> payload) {
+    const auto layout = FileLayout::Calculate(static_cast<uint32_t>(payload.size()), static_cast<uint8_t>(name.size()),
+                                              quota->block_size_log2(), FileLayoutMode::MinimumForGrow);
+    REQUIRE(layout.category == FileLayoutCategory::Inline);
+
+    std::vector<std::byte> metadata_bytes(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_bytes.data());
+    metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+    metadata->file_size = layout.file_size;
+    metadata->size_on_disk = layout.size_on_disk;
+    metadata->metadata_log2_size = layout.metadata_log2_size;
+    metadata->size_category = FileLayout::CategoryValue(layout.category);
+    metadata->filename_length = static_cast<uint8_t>(name.size());
+    std::ranges::copy(payload, reinterpret_cast<std::byte*>(metadata) + metadata->size());
+
+    REQUIRE(directory_map.insert(name, metadata));
+    auto file = directory->GetFile(name);
+    REQUIRE(file.has_value());
+    return *file;
+  }
+
+  Entry::MetadataRef FindMetadata(std::string_view name) {
+    auto it = directory->find(name);
+    REQUIRE(!it.is_end());
+    return (*it.base()).metadata;
+  }
+};
+
+std::vector<std::byte> Bytes(std::initializer_list<uint8_t> values) {
+  return values | std::views::transform([](uint8_t value) { return std::byte{value}; }) |
+         std::ranges::to<std::vector>();
+}
+
+std::vector<std::byte> ReadFile(const std::shared_ptr<File>& file, size_t size) {
+  std::vector<std::byte> output(size);
+  if (output.empty())
+    return output;
+
+  File::file_device device(file);
+  const auto read = device.read(reinterpret_cast<char*>(output.data()), static_cast<std::streamsize>(output.size()));
+  REQUIRE(read == static_cast<std::streamsize>(output.size()));
+  return output;
+}
+
+void WriteFile(const std::shared_ptr<File>& file, std::span<const std::byte> input, size_t offset) {
+  File::file_device device(file);
+  if (offset != 0)
+    device.seek(static_cast<boost::iostreams::stream_offset>(offset), std::ios_base::beg);
+  const auto wrote =
+      device.write(reinterpret_cast<const char*>(input.data()), static_cast<std::streamsize>(input.size()));
+  REQUIRE(wrote == static_cast<std::streamsize>(input.size()));
+}
+
+}  // namespace
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows inline data and zero fills the new range", "[file][resize]") {
+  const auto initial = Bytes({0x11, 0x22, 0x33, 0x44});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(12);
+
+  CHECK(file->Size() == 12);
+  CHECK(file->SizeOnDisk() == 12);
+  auto expected = initial;
+  expected.resize(12, std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks inline data", "[file][resize]") {
+  const auto initial = Bytes({0x10, 0x20, 0x30, 0x40, 0x50});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(3);
+
+  CHECK(file->Size() == 3);
+  CHECK(file->SizeOnDisk() == 3);
+  CHECK(ReadFile(file, 3) == Bytes({0x10, 0x20, 0x30}));
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize reallocates inline metadata and supports writing after growth",
+                 "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x5a});
+  auto file = InsertInlineFile(kTestFilename, initial);
+  auto original_metadata = FindMetadata(kTestFilename);
+
+  file->Resize(small_inline_capacity + 1);
+
+  auto updated_metadata = FindMetadata(kTestFilename);
+  CHECK(updated_metadata->metadata_log2_size.value() == 7);
+  CHECK(updated_metadata != original_metadata);
+  CHECK(file->Size() == small_inline_capacity + 1);
+  CHECK(file->SizeOnDisk() == small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK(ReadFile(file, expected.size()) == expected);
+
+  constexpr std::array replacement{std::byte{0xbe}};
+  WriteFile(file, replacement, small_inline_capacity);
+  expected.back() = replacement.front();
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize refreshes another handle after inline metadata reallocation",
+                 "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x2a});
+  auto first_file = InsertInlineFile(kTestFilename, initial);
+  auto second_file = directory->GetFile(kTestFilename);
+  REQUIRE(second_file.has_value());
+
+  first_file->Resize(small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK((*second_file)->Size() == expected.size());
+  CHECK(ReadFile(*second_file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize can reallocate inline metadata after the parent directory handle is gone",
+                 "[file][resize]") {
+  const auto small_inline_capacity =
+      (size_t{1} << 6) - FileLayout::BaseMetadataSize(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(small_inline_capacity, std::byte{0x63});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  directory.reset();
+  file->Resize(small_inline_capacity + 1);
+
+  auto expected = initial;
+  expected.push_back(std::byte{0});
+  CHECK(file->Size() == expected.size());
+  CHECK(ReadFile(file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline data to zero", "[file][resize]") {
+  const auto initial = Bytes({0x6b, 0x6c, 0x6d});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  file->Resize(0);
+
+  auto metadata = FindMetadata(kTestFilename);
+  CHECK(metadata->metadata_log2_size.value() == 6);
+  CHECK(file->Size() == 0);
+  CHECK(file->SizeOnDisk() == 0);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize rejects category transitions for now", "[file][resize]") {
+  const auto inline_capacity = FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size()));
+  std::vector<std::byte> initial(inline_capacity, std::byte{0x7c});
+  auto file = InsertInlineFile(kTestFilename, initial);
+
+  CHECK_THROWS_AS(file->Resize(inline_capacity + 1), std::logic_error);
+
+  CHECK(file->Size() == inline_capacity);
+  CHECK(file->SizeOnDisk() == inline_capacity);
+  CHECK(ReadFile(file, initial.size()) == initial);
+}


### PR DESCRIPTION
Implements PR 5 inline/category-0 resize on top of the revert branch.

What changed:
- Adds FileResizer as the owner of resize policy, with File::Resize delegating to it.
- Adds DirectoryMap-backed shared metadata handles so multiple File objects for the same entry observe metadata relocation without repeated directory lookups.
- Requires File objects to come from directory-owned metadata; tests now load files through Directory/DirectoryMap instead of constructing loose File instances.
- Supports inline grow, shrink, zero-fill, metadata log2 reallocation, and writes after inline growth.
- Keeps external-category resize at the previous within-size_on_disk behavior for now, and throws std::logic_error for category transitions.


Validation:
- cmake --build --preset debug-tests

- ctest --preset run-debug-tests --output-on-failure (108/108 passed)


Note: this PR is stacked on #133. After #133 merges, retarget this PR to master.











