### PR TITLE
Disable fail-fast in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
         compiler: [msvc, gcc, llvm]


### PR DESCRIPTION
## Summary
- Set `strategy.fail-fast: false` for the build matrix.
- Keep remaining matrix jobs running after one job fails, while still allowing the overall workflow to fail when any job fails.

## Validation
- `git diff --check`