### PR TITLE
Track directory entry metadata handles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(${PROJECT_NAME}
     src/block.cpp
     src/blocks_device.cpp
     src/device_encryption.cpp
+    src/directory_entry_cache.cpp
     src/directory_iterator.cpp
     src/directory_leaf_tree.cpp
     src/directory_map_iterator.cpp

--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -24,11 +24,7 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
  public:
   using iterator = DirectoryIterator;
 
-  // TODO: Replace name with tree iterator?
-  Directory(std::string name,
-            MetadataHandlePtr metadata,
-            std::shared_ptr<QuotaArea> quota,
-            std::shared_ptr<DirectoryMap> map);
+  Directory(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> map);
 
   std::expected<std::shared_ptr<Entry>, WfsError> GetEntry(std::string_view name) const;
   std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(std::string_view name) const;

--- a/include/wfslib/directory.h
+++ b/include/wfslib/directory.h
@@ -25,16 +25,19 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   using iterator = DirectoryIterator;
 
   // TODO: Replace name with tree iterator?
-  Directory(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota, std::shared_ptr<Block> block);
+  Directory(std::string name,
+            MetadataHandlePtr metadata,
+            std::shared_ptr<QuotaArea> quota,
+            std::shared_ptr<DirectoryMap> map);
 
   std::expected<std::shared_ptr<Entry>, WfsError> GetEntry(std::string_view name) const;
   std::expected<std::shared_ptr<Directory>, WfsError> GetDirectory(std::string_view name) const;
   std::expected<std::shared_ptr<File>, WfsError> GetFile(std::string_view name) const;
 
-  size_t size() const { return map_.size(); }
+  size_t size() const { return map_->size(); }
 
-  iterator begin() const { return {map_.begin()}; }
-  iterator end() const { return {map_.end()}; }
+  iterator begin() const { return {map_, map_->begin()}; }
+  iterator end() const { return {map_, map_->end()}; }
 
   iterator find(std::string_view key) const;
 
@@ -44,7 +47,6 @@ class Directory : public Entry, public std::enable_shared_from_this<Directory> {
   friend class Recovery;
 
   std::shared_ptr<QuotaArea> quota_;
-  std::shared_ptr<Block> block_;
 
-  DirectoryMap map_;
+  std::shared_ptr<DirectoryMap> map_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -70,6 +70,7 @@ class Entry::MetadataHandle {
 
   void Update(MetadataRef metadata);
   void Invalidate();
+  const MetadataRef& metadata_ref() const;
 
   std::optional<MetadataRef> metadata_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -17,6 +17,7 @@
 
 class QuotaArea;
 class DirectoryMap;
+class DirectoryEntryCache;
 
 class Entry {
  public:
@@ -65,7 +66,7 @@ class Entry::MetadataHandle {
   const std::shared_ptr<Block>& block() const;
 
  private:
-  friend class DirectoryMap;
+  friend class DirectoryEntryCache;
 
   void Update(MetadataRef metadata);
   void Invalidate();

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -22,13 +22,13 @@ class DirectoryEntryCache;
 class Entry {
  public:
   using MetadataRef = Block::DataRef<EntryMetadata>;
-  class MetadataHandle;
-  using MetadataHandlePtr = std::shared_ptr<MetadataHandle>;
+  class EntryHandle;
+  using EntryHandlePtr = std::shared_ptr<EntryHandle>;
 
-  Entry(std::string name, MetadataHandlePtr metadata, std::shared_ptr<DirectoryMap> directory_map);
+  Entry(EntryHandlePtr handle, std::shared_ptr<DirectoryMap> directory_map);
   virtual ~Entry();
 
-  std::string_view name() const { return name_; }
+  std::string_view name() const;
   bool is_directory() const { return !metadata()->is_link() && metadata()->is_directory(); }
   bool is_file() const { return !metadata()->is_link() && !metadata()->is_directory(); }
   bool is_link() const { return metadata()->is_link(); }
@@ -41,10 +41,9 @@ class Entry {
   uint32_t modification_time() const;
 
   static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
-                                                              std::string name,
-                                                              MetadataHandlePtr metadata,
+                                                              EntryHandlePtr handle,
                                                               std::shared_ptr<DirectoryMap> directory_map);
-  static MetadataHandlePtr CreateMetadataHandle(MetadataRef metadata);
+  static EntryHandlePtr CreateEntryHandle(std::string name, MetadataRef metadata);
 
  protected:
   // TODO: Metadata copy as it can change?
@@ -52,15 +51,15 @@ class Entry {
   const EntryMetadata* metadata() const;
   const std::shared_ptr<Block>& metadata_block() const;
 
-  std::string name_;
-  MetadataHandlePtr metadata_;
+  EntryHandlePtr handle_;
   std::shared_ptr<DirectoryMap> directory_map_;
 };
 
-class Entry::MetadataHandle {
+class Entry::EntryHandle {
  public:
-  explicit MetadataHandle(MetadataRef metadata);
+  EntryHandle(std::string name, MetadataRef metadata);
 
+  std::string_view name() const;
   const EntryMetadata* get() const;
   EntryMetadata* get_mutable() const;
   const std::shared_ptr<Block>& block() const;
@@ -68,9 +67,10 @@ class Entry::MetadataHandle {
  private:
   friend class DirectoryEntryCache;
 
-  void Update(MetadataRef metadata);
+  void Update(std::string name, MetadataRef metadata);
   void Invalidate();
   const MetadataRef& metadata_ref() const;
 
+  std::string name_;
   std::optional<MetadataRef> metadata_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -9,18 +9,22 @@
 
 #include <expected>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "block.h"
 #include "structs.h"
 
 class QuotaArea;
+class DirectoryMap;
 
 class Entry {
  public:
   using MetadataRef = Block::DataRef<EntryMetadata>;
+  class MetadataHandle;
+  using MetadataHandlePtr = std::shared_ptr<MetadataHandle>;
 
-  Entry(std::string name, MetadataRef block);
+  Entry(std::string name, MetadataHandlePtr metadata, std::shared_ptr<DirectoryMap> directory_map);
   virtual ~Entry();
 
   std::string_view name() const { return name_; }
@@ -37,14 +41,34 @@ class Entry {
 
   static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
                                                               std::string name,
-                                                              MetadataRef metadata_ref);
+                                                              MetadataHandlePtr metadata,
+                                                              std::shared_ptr<DirectoryMap> directory_map);
+  static MetadataHandlePtr CreateMetadataHandle(MetadataRef metadata);
 
  protected:
   // TODO: Metadata copy as it can change?
-  EntryMetadata* mutable_metadata() { return metadata_.get_mutable(); }
-  const EntryMetadata* metadata() const { return metadata_.get(); }
-  const std::shared_ptr<Block>& metadata_block() const { return metadata_.block; }
+  EntryMetadata* mutable_metadata();
+  const EntryMetadata* metadata() const;
+  const std::shared_ptr<Block>& metadata_block() const;
 
   std::string name_;
-  MetadataRef metadata_;
+  MetadataHandlePtr metadata_;
+  std::shared_ptr<DirectoryMap> directory_map_;
+};
+
+class Entry::MetadataHandle {
+ public:
+  explicit MetadataHandle(MetadataRef metadata);
+
+  const EntryMetadata* get() const;
+  EntryMetadata* get_mutable() const;
+  const std::shared_ptr<Block>& block() const;
+
+ private:
+  friend class DirectoryMap;
+
+  void Update(MetadataRef metadata);
+  void Invalidate();
+
+  std::optional<MetadataRef> metadata_;
 };

--- a/include/wfslib/entry.h
+++ b/include/wfslib/entry.h
@@ -25,10 +25,10 @@ class Entry {
   class EntryHandle;
   using EntryHandlePtr = std::shared_ptr<EntryHandle>;
 
-  Entry(EntryHandlePtr handle, std::shared_ptr<DirectoryMap> directory_map);
+  explicit Entry(EntryHandlePtr handle);
   virtual ~Entry();
 
-  std::string_view name() const;
+  std::string name() const;
   bool is_directory() const { return !metadata()->is_link() && metadata()->is_directory(); }
   bool is_file() const { return !metadata()->is_link() && !metadata()->is_directory(); }
   bool is_link() const { return metadata()->is_link(); }
@@ -40,26 +40,26 @@ class Entry {
   uint32_t creation_time() const;
   uint32_t modification_time() const;
 
-  static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota,
-                                                              EntryHandlePtr handle,
-                                                              std::shared_ptr<DirectoryMap> directory_map);
-  static EntryHandlePtr CreateEntryHandle(std::string name, MetadataRef metadata);
+  static std::expected<std::shared_ptr<Entry>, WfsError> Load(std::shared_ptr<QuotaArea> quota, EntryHandlePtr handle);
+  static EntryHandlePtr CreateEntryHandle(std::shared_ptr<DirectoryMap> directory_map,
+                                          std::string key,
+                                          MetadataRef metadata);
+  static EntryHandlePtr CreateSyntheticEntryHandle(std::string name, MetadataRef metadata);
 
  protected:
-  // TODO: Metadata copy as it can change?
   EntryMetadata* mutable_metadata();
   const EntryMetadata* metadata() const;
   const std::shared_ptr<Block>& metadata_block() const;
 
   EntryHandlePtr handle_;
-  std::shared_ptr<DirectoryMap> directory_map_;
 };
 
 class Entry::EntryHandle {
  public:
-  EntryHandle(std::string name, MetadataRef metadata);
+  EntryHandle(std::shared_ptr<DirectoryMap> directory_map, std::string key, MetadataRef metadata);
 
-  std::string_view name() const;
+  std::string_view key() const;
+  const std::shared_ptr<DirectoryMap>& directory_map() const;
   const EntryMetadata* get() const;
   EntryMetadata* get_mutable() const;
   const std::shared_ptr<Block>& block() const;
@@ -67,10 +67,11 @@ class Entry::EntryHandle {
  private:
   friend class DirectoryEntryCache;
 
-  void Update(std::string name, MetadataRef metadata);
+  void Update(std::string key, MetadataRef metadata);
   void Invalidate();
   const MetadataRef& metadata_ref() const;
 
-  std::string name_;
+  std::shared_ptr<DirectoryMap> directory_map_;
+  std::string key_;
   std::optional<MetadataRef> metadata_;
 };

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -25,11 +25,8 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(std::string name,
-       MetadataHandlePtr metadata,
-       std::shared_ptr<QuotaArea> quota,
-       std::shared_ptr<DirectoryMap> directory_map)
-      : Entry(std::move(name), std::move(metadata), std::move(directory_map)), quota_(std::move(quota)) {}
+  File(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> directory_map)
+      : Entry(std::move(handle), std::move(directory_map)), quota_(std::move(quota)) {}
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -25,8 +25,7 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> directory_map)
-      : Entry(std::move(handle), std::move(directory_map)), quota_(std::move(quota)) {}
+  File(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota) : Entry(std::move(handle)), quota_(std::move(quota)) {}
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -25,8 +25,11 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   class ClusterMetadataBlocksLayoutAccessor;
 
  public:
-  File(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota)
-      : Entry(std::move(name), std::move(metadata)), quota_(std::move(quota)) {}
+  File(std::string name,
+       MetadataHandlePtr metadata,
+       std::shared_ptr<QuotaArea> quota,
+       std::shared_ptr<DirectoryMap> directory_map)
+      : Entry(std::move(name), std::move(metadata), std::move(directory_map)), quota_(std::move(quota)) {}
 
   uint32_t Size() const;
   uint32_t SizeOnDisk() const;

--- a/include/wfslib/link.h
+++ b/include/wfslib/link.h
@@ -15,8 +15,7 @@ class QuotaArea;
 
 class Link : public Entry, public std::enable_shared_from_this<Link> {
  public:
-  Link(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> directory_map)
-      : Entry(std::move(handle), std::move(directory_map)), quota_(std::move(quota)) {}
+  Link(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota) : Entry(std::move(handle)), quota_(std::move(quota)) {}
 
  private:
   // TODO: We may have cyclic reference here if we do cache in area.

--- a/include/wfslib/link.h
+++ b/include/wfslib/link.h
@@ -15,11 +15,8 @@ class QuotaArea;
 
 class Link : public Entry, public std::enable_shared_from_this<Link> {
  public:
-  Link(std::string name,
-       MetadataHandlePtr metadata,
-       std::shared_ptr<QuotaArea> quota,
-       std::shared_ptr<DirectoryMap> directory_map)
-      : Entry(std::move(name), std::move(metadata), std::move(directory_map)), quota_(std::move(quota)) {}
+  Link(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> directory_map)
+      : Entry(std::move(handle), std::move(directory_map)), quota_(std::move(quota)) {}
 
  private:
   // TODO: We may have cyclic reference here if we do cache in area.

--- a/include/wfslib/link.h
+++ b/include/wfslib/link.h
@@ -15,8 +15,11 @@ class QuotaArea;
 
 class Link : public Entry, public std::enable_shared_from_this<Link> {
  public:
-  Link(std::string name, MetadataRef metadata, std::shared_ptr<QuotaArea> quota)
-      : Entry(std::move(name), std::move(metadata)), quota_(std::move(quota)) {}
+  Link(std::string name,
+       MetadataHandlePtr metadata,
+       std::shared_ptr<QuotaArea> quota,
+       std::shared_ptr<DirectoryMap> directory_map)
+      : Entry(std::move(name), std::move(metadata), std::move(directory_map)), quota_(std::move(quota)) {}
 
  private:
   // TODO: We may have cyclic reference here if we do cache in area.

--- a/include/wfslib/wfs_device.h
+++ b/include/wfslib/wfs_device.h
@@ -84,5 +84,6 @@ class WfsDevice : public std::enable_shared_from_this<WfsDevice> {
 
   std::shared_ptr<BlocksDevice> device_;
   std::shared_ptr<Block> root_block_;
+  // Keep weak to avoid a WfsDevice -> QuotaArea -> WfsDevice reference cycle.
   std::weak_ptr<QuotaArea> root_area_;
 };

--- a/include/wfslib/wfs_device.h
+++ b/include/wfslib/wfs_device.h
@@ -84,4 +84,5 @@ class WfsDevice : public std::enable_shared_from_this<WfsDevice> {
 
   std::shared_ptr<BlocksDevice> device_;
   std::shared_ptr<Block> root_block_;
+  std::weak_ptr<QuotaArea> root_area_;
 };

--- a/src/area.cpp
+++ b/src/area.cpp
@@ -11,8 +11,12 @@
 
 #include "wfs_device.h"
 
-Area::Area(std::shared_ptr<WfsDevice> wfs_device, std::shared_ptr<Block> header_block)
-    : wfs_device_(std::move(wfs_device)), header_block_(std::move(header_block)) {}
+Area::Area(std::shared_ptr<WfsDevice> wfs_device,
+           std::shared_ptr<Block> header_block,
+           std::shared_ptr<Area> parent_area)
+    : wfs_device_(std::move(wfs_device)),
+      header_block_(std::move(header_block)),
+      parent_area_(std::move(parent_area)) {}
 
 void Area::Init(std::shared_ptr<Area> parent_area, uint32_t blocks_count, BlockSize block_size) {
   std::random_device rand_device;

--- a/src/area.h
+++ b/src/area.h
@@ -16,7 +16,9 @@ class WfsDevice;
 
 class Area {
  public:
-  Area(std::shared_ptr<WfsDevice> wfs_device, std::shared_ptr<Block> header_block);
+  Area(std::shared_ptr<WfsDevice> wfs_device,
+       std::shared_ptr<Block> header_block,
+       std::shared_ptr<Area> parent_area = nullptr);
 
   // TODO Create transactions area
 
@@ -81,4 +83,5 @@ class Area {
  private:
   std::shared_ptr<WfsDevice> wfs_device_;
   std::shared_ptr<Block> header_block_;
+  std::shared_ptr<Area> parent_area_;
 };

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -13,7 +13,7 @@
 #include "quota_area.h"
 
 Directory::Directory(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> map)
-    : Entry(std::move(handle), map), quota_(std::move(quota)), map_(std::move(map)) {}
+    : Entry(std::move(handle)), quota_(std::move(quota)), map_(std::move(map)) {}
 
 std::expected<std::shared_ptr<Entry>, WfsError> Directory::GetEntry(std::string_view name) const {
   try {

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -13,13 +13,12 @@
 #include "quota_area.h"
 
 Directory::Directory(std::string name,
-                     MetadataRef metadata,
+                     MetadataHandlePtr metadata,
                      std::shared_ptr<QuotaArea> quota,
-                     std::shared_ptr<Block> block)
-    : Entry(std::move(name), std::move(metadata)),
+                     std::shared_ptr<DirectoryMap> map)
+    : Entry(std::move(name), std::move(metadata), map),
       quota_(std::move(quota)),
-      block_(std::move(block)),
-      map_{quota_, block_} {}
+      map_(std::move(map)) {}
 
 std::expected<std::shared_ptr<Entry>, WfsError> Directory::GetEntry(std::string_view name) const {
   try {
@@ -59,5 +58,5 @@ Directory::iterator Directory::find(std::string_view key) const {
   std::string lowercase_key{key};
   // to lowercase
   std::ranges::transform(lowercase_key, lowercase_key.begin(), [](char c) { return std::tolower(c); });
-  return {map_.find(lowercase_key)};
+  return {map_, map_->find(lowercase_key)};
 }

--- a/src/directory.cpp
+++ b/src/directory.cpp
@@ -12,13 +12,8 @@
 #include "file.h"
 #include "quota_area.h"
 
-Directory::Directory(std::string name,
-                     MetadataHandlePtr metadata,
-                     std::shared_ptr<QuotaArea> quota,
-                     std::shared_ptr<DirectoryMap> map)
-    : Entry(std::move(name), std::move(metadata), map),
-      quota_(std::move(quota)),
-      map_(std::move(map)) {}
+Directory::Directory(EntryHandlePtr handle, std::shared_ptr<QuotaArea> quota, std::shared_ptr<DirectoryMap> map)
+    : Entry(std::move(handle), map), quota_(std::move(quota)), map_(std::move(map)) {}
 
 std::expected<std::shared_ptr<Entry>, WfsError> Directory::GetEntry(std::string_view name) const {
   try {

--- a/src/directory_entry_cache.cpp
+++ b/src/directory_entry_cache.cpp
@@ -26,8 +26,8 @@ std::expected<std::shared_ptr<Entry>, WfsError> DirectoryEntryCache::Load(Direct
     entries_.erase(entry_it);
   }
 
-  auto handle = HandleFor(val.name, val.metadata);
-  auto entry = Entry::Load(std::move(quota), handle, directory_map.shared_from_this());
+  auto handle = HandleFor(directory_map.shared_from_this(), val.name, val.metadata);
+  auto entry = Entry::Load(std::move(quota), handle);
   if (entry.has_value())
     entries_[val.name] = *entry;
   return entry;
@@ -38,8 +38,8 @@ void DirectoryEntryCache::MetadataUpdated(std::string_view name, Block::DataRef<
   if (it == handles_.end())
     return;
   if (auto handle = it->second.lock()) {
-    auto real_name = metadata->GetCaseSensitiveName(name);
-    handle->Update(std::move(real_name), std::move(metadata));
+    auto key = std::string{name};
+    handle->Update(std::move(key), std::move(metadata));
   } else {
     handles_.erase(it);
   }
@@ -74,25 +74,24 @@ void DirectoryEntryCache::RefreshMetadataRefs(const DirectoryMap& directory_map)
       handle->Invalidate();
     } else {
       auto metadata = (*it).metadata;
-      auto real_name = metadata->GetCaseSensitiveName(name);
-      handle->Update(std::move(real_name), std::move(metadata));
+      handle->Update(name, std::move(metadata));
     }
   }
 }
 
-Entry::EntryHandlePtr DirectoryEntryCache::HandleFor(std::string_view key, Block::DataRef<EntryMetadata> metadata) {
+Entry::EntryHandlePtr DirectoryEntryCache::HandleFor(std::shared_ptr<DirectoryMap> directory_map,
+                                                     std::string_view key,
+                                                     Block::DataRef<EntryMetadata> metadata) {
   auto map_key = std::string{key};
   if (auto it = handles_.find(map_key); it != handles_.end()) {
     if (auto handle = it->second.lock()) {
-      auto name = metadata->GetCaseSensitiveName(key);
-      handle->Update(std::move(name), std::move(metadata));
+      handle->Update(map_key, std::move(metadata));
       return handle;
     }
     handles_.erase(it);
   }
 
-  auto name = metadata->GetCaseSensitiveName(key);
-  auto handle = Entry::CreateEntryHandle(std::move(name), std::move(metadata));
+  auto handle = Entry::CreateEntryHandle(directory_map, map_key, std::move(metadata));
   handles_.emplace(std::move(map_key), handle);
   return handle;
 }

--- a/src/directory_entry_cache.cpp
+++ b/src/directory_entry_cache.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "directory_entry_cache.h"
+
+#include <utility>
+#include <vector>
+
+#include "directory_map.h"
+#include "quota_area.h"
+
+std::expected<std::shared_ptr<Entry>, WfsError> DirectoryEntryCache::Load(DirectoryMap& directory_map,
+                                                                          DirectoryMapIterator it,
+                                                                          std::shared_ptr<QuotaArea> quota) {
+  if (it.is_end())
+    return std::unexpected(WfsError::kEntryNotFound);
+
+  auto val = *it;
+  if (auto entry_it = entries_.find(val.name); entry_it != entries_.end()) {
+    if (auto entry = entry_it->second.lock())
+      return entry;
+    entries_.erase(entry_it);
+  }
+
+  auto metadata = HandleFor(val.name, val.metadata);
+  auto name = metadata->get()->GetCaseSensitiveName(val.name);
+  auto entry = Entry::Load(std::move(quota), name, metadata, directory_map.shared_from_this());
+  if (entry.has_value())
+    entries_[val.name] = *entry;
+  return entry;
+}
+
+void DirectoryEntryCache::MetadataUpdated(std::string_view name, Block::DataRef<EntryMetadata> metadata) {
+  auto it = metadata_handles_.find(std::string{name});
+  if (it == metadata_handles_.end())
+    return;
+  if (auto handle = it->second.lock()) {
+    handle->Update(std::move(metadata));
+  } else {
+    metadata_handles_.erase(it);
+  }
+}
+
+void DirectoryEntryCache::EntryRemoved(std::string_view name) {
+  auto key = std::string{name};
+  entries_.erase(key);
+
+  auto it = metadata_handles_.find(key);
+  if (it == metadata_handles_.end())
+    return;
+  if (auto handle = it->second.lock())
+    handle->Invalidate();
+  metadata_handles_.erase(it);
+}
+
+void DirectoryEntryCache::RefreshMetadataRefs(const DirectoryMap& directory_map) {
+  std::vector<std::pair<std::string, Entry::MetadataHandlePtr>> live_handles;
+  for (auto it = metadata_handles_.begin(); it != metadata_handles_.end();) {
+    if (auto handle = it->second.lock()) {
+      live_handles.emplace_back(it->first, std::move(handle));
+      ++it;
+    } else {
+      it = metadata_handles_.erase(it);
+    }
+  }
+
+  for (auto& [name, handle] : live_handles) {
+    auto it = directory_map.find(name);
+    if (it.is_end()) {
+      handle->Invalidate();
+    } else {
+      handle->Update((*it).metadata);
+    }
+  }
+}
+
+Entry::MetadataHandlePtr DirectoryEntryCache::HandleFor(std::string_view name,
+                                                        Block::DataRef<EntryMetadata> metadata) {
+  auto key = std::string{name};
+  if (auto it = metadata_handles_.find(key); it != metadata_handles_.end()) {
+    if (auto handle = it->second.lock()) {
+      handle->Update(std::move(metadata));
+      return handle;
+    }
+    metadata_handles_.erase(it);
+  }
+
+  auto handle = Entry::CreateMetadataHandle(std::move(metadata));
+  metadata_handles_.emplace(std::move(key), handle);
+  return handle;
+}

--- a/src/directory_entry_cache.cpp
+++ b/src/directory_entry_cache.cpp
@@ -26,22 +26,22 @@ std::expected<std::shared_ptr<Entry>, WfsError> DirectoryEntryCache::Load(Direct
     entries_.erase(entry_it);
   }
 
-  auto metadata = HandleFor(val.name, val.metadata);
-  auto name = metadata->get()->GetCaseSensitiveName(val.name);
-  auto entry = Entry::Load(std::move(quota), name, metadata, directory_map.shared_from_this());
+  auto handle = HandleFor(val.name, val.metadata);
+  auto entry = Entry::Load(std::move(quota), handle, directory_map.shared_from_this());
   if (entry.has_value())
     entries_[val.name] = *entry;
   return entry;
 }
 
 void DirectoryEntryCache::MetadataUpdated(std::string_view name, Block::DataRef<EntryMetadata> metadata) {
-  auto it = metadata_handles_.find(std::string{name});
-  if (it == metadata_handles_.end())
+  auto it = handles_.find(std::string{name});
+  if (it == handles_.end())
     return;
   if (auto handle = it->second.lock()) {
-    handle->Update(std::move(metadata));
+    auto real_name = metadata->GetCaseSensitiveName(name);
+    handle->Update(std::move(real_name), std::move(metadata));
   } else {
-    metadata_handles_.erase(it);
+    handles_.erase(it);
   }
 }
 
@@ -49,22 +49,22 @@ void DirectoryEntryCache::EntryRemoved(std::string_view name) {
   auto key = std::string{name};
   entries_.erase(key);
 
-  auto it = metadata_handles_.find(key);
-  if (it == metadata_handles_.end())
+  auto it = handles_.find(key);
+  if (it == handles_.end())
     return;
   if (auto handle = it->second.lock())
     handle->Invalidate();
-  metadata_handles_.erase(it);
+  handles_.erase(it);
 }
 
 void DirectoryEntryCache::RefreshMetadataRefs(const DirectoryMap& directory_map) {
-  std::vector<std::pair<std::string, Entry::MetadataHandlePtr>> live_handles;
-  for (auto it = metadata_handles_.begin(); it != metadata_handles_.end();) {
+  std::vector<std::pair<std::string, Entry::EntryHandlePtr>> live_handles;
+  for (auto it = handles_.begin(); it != handles_.end();) {
     if (auto handle = it->second.lock()) {
       live_handles.emplace_back(it->first, std::move(handle));
       ++it;
     } else {
-      it = metadata_handles_.erase(it);
+      it = handles_.erase(it);
     }
   }
 
@@ -73,23 +73,26 @@ void DirectoryEntryCache::RefreshMetadataRefs(const DirectoryMap& directory_map)
     if (it.is_end()) {
       handle->Invalidate();
     } else {
-      handle->Update((*it).metadata);
+      auto metadata = (*it).metadata;
+      auto real_name = metadata->GetCaseSensitiveName(name);
+      handle->Update(std::move(real_name), std::move(metadata));
     }
   }
 }
 
-Entry::MetadataHandlePtr DirectoryEntryCache::HandleFor(std::string_view name,
-                                                        Block::DataRef<EntryMetadata> metadata) {
-  auto key = std::string{name};
-  if (auto it = metadata_handles_.find(key); it != metadata_handles_.end()) {
+Entry::EntryHandlePtr DirectoryEntryCache::HandleFor(std::string_view key, Block::DataRef<EntryMetadata> metadata) {
+  auto map_key = std::string{key};
+  if (auto it = handles_.find(map_key); it != handles_.end()) {
     if (auto handle = it->second.lock()) {
-      handle->Update(std::move(metadata));
+      auto name = metadata->GetCaseSensitiveName(key);
+      handle->Update(std::move(name), std::move(metadata));
       return handle;
     }
-    metadata_handles_.erase(it);
+    handles_.erase(it);
   }
 
-  auto handle = Entry::CreateMetadataHandle(std::move(metadata));
-  metadata_handles_.emplace(std::move(key), handle);
+  auto name = metadata->GetCaseSensitiveName(key);
+  auto handle = Entry::CreateEntryHandle(std::move(name), std::move(metadata));
+  handles_.emplace(std::move(map_key), handle);
   return handle;
 }

--- a/src/directory_entry_cache.h
+++ b/src/directory_entry_cache.h
@@ -29,8 +29,8 @@ class DirectoryEntryCache {
   void RefreshMetadataRefs(const DirectoryMap& directory_map);
 
  private:
-  Entry::MetadataHandlePtr HandleFor(std::string_view name, Block::DataRef<EntryMetadata> metadata);
+  Entry::EntryHandlePtr HandleFor(std::string_view key, Block::DataRef<EntryMetadata> metadata);
 
-  std::map<std::string, std::weak_ptr<Entry::MetadataHandle>> metadata_handles_;
+  std::map<std::string, std::weak_ptr<Entry::EntryHandle>> handles_;
   std::map<std::string, std::weak_ptr<Entry>> entries_;
 };

--- a/src/directory_entry_cache.h
+++ b/src/directory_entry_cache.h
@@ -29,7 +29,9 @@ class DirectoryEntryCache {
   void RefreshMetadataRefs(const DirectoryMap& directory_map);
 
  private:
-  Entry::EntryHandlePtr HandleFor(std::string_view key, Block::DataRef<EntryMetadata> metadata);
+  Entry::EntryHandlePtr HandleFor(std::shared_ptr<DirectoryMap> directory_map,
+                                  std::string_view key,
+                                  Block::DataRef<EntryMetadata> metadata);
 
   std::map<std::string, std::weak_ptr<Entry::EntryHandle>> handles_;
   std::map<std::string, std::weak_ptr<Entry>> entries_;

--- a/src/directory_entry_cache.h
+++ b/src/directory_entry_cache.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "directory_map_iterator.h"
+#include "entry.h"
+#include "errors.h"
+
+class DirectoryMap;
+class QuotaArea;
+
+class DirectoryEntryCache {
+ public:
+  std::expected<std::shared_ptr<Entry>, WfsError> Load(DirectoryMap& directory_map,
+                                                       DirectoryMapIterator it,
+                                                       std::shared_ptr<QuotaArea> quota);
+
+  void MetadataUpdated(std::string_view name, Block::DataRef<EntryMetadata> metadata);
+  void EntryRemoved(std::string_view name);
+  void RefreshMetadataRefs(const DirectoryMap& directory_map);
+
+ private:
+  Entry::MetadataHandlePtr HandleFor(std::string_view name, Block::DataRef<EntryMetadata> metadata);
+
+  std::map<std::string, std::weak_ptr<Entry::MetadataHandle>> metadata_handles_;
+  std::map<std::string, std::weak_ptr<Entry>> entries_;
+};

--- a/src/directory_iterator.cpp
+++ b/src/directory_iterator.cpp
@@ -7,14 +7,19 @@
 
 #include "directory_iterator.h"
 
+#include "directory_map.h"
 #include "entry.h"
 
-DirectoryIterator::DirectoryIterator(DirectoryMapIterator base) : base_(base) {}
+DirectoryIterator::DirectoryIterator(std::shared_ptr<DirectoryMap> map, DirectoryMapIterator base)
+    : map_(std::move(map)), base_(std::move(base)) {}
 
 DirectoryIterator::reference DirectoryIterator::operator*() const {
   auto val = *base_;
   auto name = val.metadata.get()->GetCaseSensitiveName(val.name);
-  return {name, Entry::Load(base_.quota(), name, val.metadata)};
+  auto entry = map_->LoadEntry(base_);
+  if (!entry.has_value())
+    return {name, std::unexpected(entry.error())};
+  return {std::move(name), std::move(*entry)};
 }
 
 DirectoryIterator& DirectoryIterator::operator++() {

--- a/src/directory_iterator.h
+++ b/src/directory_iterator.h
@@ -7,11 +7,14 @@
 
 #pragma once
 
+#include <memory>
+
 #include "directory_map_iterator.h"
 #include "errors.h"
 
 class QuotaArea;
 class Entry;
+class DirectoryMap;
 
 struct DiretoryEntry {
   std::string name;
@@ -29,7 +32,7 @@ class DirectoryIterator {
   using reference = ref_type;
 
   DirectoryIterator() = default;
-  DirectoryIterator(DirectoryMapIterator base);
+  DirectoryIterator(std::shared_ptr<DirectoryMap> map, DirectoryMapIterator base);
 
   reference operator*() const;
 
@@ -47,5 +50,6 @@ class DirectoryIterator {
   bool is_end() const { return base_.is_end(); }
 
  private:
+  std::shared_ptr<DirectoryMap> map_;
   DirectoryMapIterator base_;
 };

--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -47,6 +47,82 @@ DirectoryMap::iterator DirectoryMap::end() const {
   return {quota_, std::move(parents), std::move(leaf)};
 }
 
+std::expected<std::shared_ptr<Entry>, WfsError> DirectoryMap::LoadEntry(iterator it) {
+  if (it.is_end())
+    return std::unexpected(WfsError::kEntryNotFound);
+
+  auto val = *it;
+  if (auto entry_it = entries_.find(val.name); entry_it != entries_.end()) {
+    if (auto entry = entry_it->second.lock())
+      return entry;
+    entries_.erase(entry_it);
+  }
+
+  auto metadata = metadata_handle(val.name, val.metadata);
+  auto name = metadata->get()->GetCaseSensitiveName(val.name);
+  auto entry = Entry::Load(quota_, name, metadata, shared_from_this());
+  if (entry.has_value())
+    entries_[val.name] = *entry;
+  return entry;
+}
+
+Entry::MetadataHandlePtr DirectoryMap::metadata_handle(std::string_view name,
+                                                       Block::DataRef<EntryMetadata> metadata) const {
+  auto key = std::ranges::to<std::string>(name);
+  if (auto it = metadata_handles_.find(key); it != metadata_handles_.end()) {
+    if (auto handle = it->second.lock()) {
+      handle->Update(std::move(metadata));
+      return handle;
+    }
+    metadata_handles_.erase(it);
+  }
+
+  auto handle = Entry::CreateMetadataHandle(std::move(metadata));
+  metadata_handles_.emplace(std::move(key), handle);
+  return handle;
+}
+
+void DirectoryMap::update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const {
+  auto it = metadata_handles_.find(std::ranges::to<std::string>(name));
+  if (it == metadata_handles_.end())
+    return;
+  if (auto handle = it->second.lock()) {
+    handle->Update(std::move(metadata));
+  } else {
+    metadata_handles_.erase(it);
+  }
+}
+
+void DirectoryMap::invalidate_metadata_handle(std::string_view name) const {
+  auto it = metadata_handles_.find(std::ranges::to<std::string>(name));
+  if (it == metadata_handles_.end())
+    return;
+  if (auto handle = it->second.lock())
+    handle->Invalidate();
+  metadata_handles_.erase(it);
+}
+
+void DirectoryMap::refresh_live_metadata_handles() const {
+  std::vector<std::pair<std::string, Entry::MetadataHandlePtr>> live_handles;
+  for (auto it = metadata_handles_.begin(); it != metadata_handles_.end();) {
+    if (auto handle = it->second.lock()) {
+      live_handles.emplace_back(it->first, std::move(handle));
+      ++it;
+    } else {
+      it = metadata_handles_.erase(it);
+    }
+  }
+
+  for (auto& [name, handle] : live_handles) {
+    auto it = find(name);
+    if (it.is_end()) {
+      handle->Invalidate();
+    } else {
+      handle->Update((*it).metadata);
+    }
+  }
+}
+
 // Or maybe realloc?
 Block::DataRef<EntryMetadata> DirectoryMap::alloc_metadata(iterator it, size_t log2_size) {
   auto size = static_cast<uint16_t>(1 << log2_size);
@@ -137,11 +213,14 @@ bool DirectoryMap::erase(std::string_view name) {
     // Not in tree
     return false;
   }
+  auto key = (*it).name;
   auto parents = it.parents();
   // Free the entry metadata first
   it.leaf().node.Free((*it.leaf().iterator).value(),
                       static_cast<uint16_t>(1 << (*it).metadata->metadata_log2_size.value()));
   it.leaf().node.erase(it.leaf().iterator);
+  entries_.erase(key);
+  invalidate_metadata_handle(key);
   bool last_empty = it.leaf().node.empty();
   if (!last_empty)
     return true;
@@ -200,11 +279,13 @@ std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_met
   if (old_log2_size == new_log2_size) {
     if (old_metadata.get() != metadata)
       std::memcpy(old_metadata.get_mutable(), metadata, new_size);
+    update_metadata_handle(name, old_metadata);
     return old_metadata;
   }
 
   auto new_metadata = realloc_metadata(it, new_log2_size);
   std::memcpy(new_metadata.get_mutable(), metadata, new_size);
+  update_metadata_handle(name, new_metadata);
   return new_metadata;
 }
 
@@ -254,6 +335,9 @@ bool DirectoryMap::split_tree(std::vector<iterator::parent_node_info>& parents,
   assert(!parents.back().iterator.is_end());
 
   tree = std::ranges::lexicographical_compare(for_key, middle_key) ? new_left_tree : new_right_tree;
+  if constexpr (std::same_as<TreeType, DirectoryLeafTree>) {
+    refresh_live_metadata_handles();
+  }
   return true;
 }
 

--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -7,12 +7,31 @@
 
 #include "directory_map.h"
 
+#include <cassert>
 #include <cstring>
 #include <numeric>
 #include <utility>
 
 #include "quota_area.h"
 #include "structs.h"
+
+namespace {
+
+void assert_same_entry_identity(const EntryMetadata* old_metadata, const EntryMetadata* new_metadata) {
+  assert(old_metadata->is_link() == new_metadata->is_link());
+  assert(old_metadata->is_directory() == new_metadata->is_directory());
+  assert(old_metadata->is_quota() == new_metadata->is_quota());
+  assert(old_metadata->filename_length.value() == new_metadata->filename_length.value());
+
+  const auto case_bitmap_size = div_ceil(old_metadata->filename_length.value(), 8);
+  assert(std::memcmp(&old_metadata->case_bitmap, &new_metadata->case_bitmap, case_bitmap_size) == 0);
+
+  if (old_metadata->is_directory()) {
+    assert(old_metadata->directory_block_number.value() == new_metadata->directory_block_number.value());
+  }
+}
+
+}  // namespace
 
 DirectoryMap::DirectoryMap(std::shared_ptr<QuotaArea> quota, std::shared_ptr<Block> root_block)
     : quota_(std::move(quota)), root_block_(std::move(root_block)) {}
@@ -274,6 +293,8 @@ std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_met
     return std::unexpected(WfsError::kEntryNotFound);
 
   auto old_metadata = (*it).metadata;
+  assert_same_entry_identity(old_metadata.get(), metadata);
+
   auto old_log2_size = old_metadata->metadata_log2_size.value();
   auto new_size = static_cast<uint16_t>(1 << new_log2_size);
   if (old_log2_size == new_log2_size) {

--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -7,31 +7,12 @@
 
 #include "directory_map.h"
 
-#include <cassert>
 #include <cstring>
 #include <numeric>
 #include <utility>
 
 #include "quota_area.h"
 #include "structs.h"
-
-namespace {
-
-void assert_same_entry_identity(const EntryMetadata* old_metadata, const EntryMetadata* new_metadata) {
-  assert(old_metadata->is_link() == new_metadata->is_link());
-  assert(old_metadata->is_directory() == new_metadata->is_directory());
-  assert(old_metadata->is_quota() == new_metadata->is_quota());
-  assert(old_metadata->filename_length.value() == new_metadata->filename_length.value());
-
-  const auto case_bitmap_size = div_ceil(old_metadata->filename_length.value(), 8);
-  assert(std::memcmp(&old_metadata->case_bitmap, &new_metadata->case_bitmap, case_bitmap_size) == 0);
-
-  if (old_metadata->is_directory()) {
-    assert(old_metadata->directory_block_number.value() == new_metadata->directory_block_number.value());
-  }
-}
-
-}  // namespace
 
 DirectoryMap::DirectoryMap(std::shared_ptr<QuotaArea> quota, std::shared_ptr<Block> root_block)
     : quota_(std::move(quota)), root_block_(std::move(root_block)) {}
@@ -293,7 +274,8 @@ std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_met
     return std::unexpected(WfsError::kEntryNotFound);
 
   auto old_metadata = (*it).metadata;
-  assert_same_entry_identity(old_metadata.get(), metadata);
+  assert((old_metadata->flags.value() & (EntryMetadata::LINK | EntryMetadata::DIRECTORY | EntryMetadata::QUOTA)) ==
+         (metadata->flags.value() & (EntryMetadata::LINK | EntryMetadata::DIRECTORY | EntryMetadata::QUOTA)));
 
   auto old_log2_size = old_metadata->metadata_log2_size.value();
   auto new_size = static_cast<uint16_t>(1 << new_log2_size);

--- a/src/directory_map.cpp
+++ b/src/directory_map.cpp
@@ -48,79 +48,7 @@ DirectoryMap::iterator DirectoryMap::end() const {
 }
 
 std::expected<std::shared_ptr<Entry>, WfsError> DirectoryMap::LoadEntry(iterator it) {
-  if (it.is_end())
-    return std::unexpected(WfsError::kEntryNotFound);
-
-  auto val = *it;
-  if (auto entry_it = entries_.find(val.name); entry_it != entries_.end()) {
-    if (auto entry = entry_it->second.lock())
-      return entry;
-    entries_.erase(entry_it);
-  }
-
-  auto metadata = metadata_handle(val.name, val.metadata);
-  auto name = metadata->get()->GetCaseSensitiveName(val.name);
-  auto entry = Entry::Load(quota_, name, metadata, shared_from_this());
-  if (entry.has_value())
-    entries_[val.name] = *entry;
-  return entry;
-}
-
-Entry::MetadataHandlePtr DirectoryMap::metadata_handle(std::string_view name,
-                                                       Block::DataRef<EntryMetadata> metadata) const {
-  auto key = std::ranges::to<std::string>(name);
-  if (auto it = metadata_handles_.find(key); it != metadata_handles_.end()) {
-    if (auto handle = it->second.lock()) {
-      handle->Update(std::move(metadata));
-      return handle;
-    }
-    metadata_handles_.erase(it);
-  }
-
-  auto handle = Entry::CreateMetadataHandle(std::move(metadata));
-  metadata_handles_.emplace(std::move(key), handle);
-  return handle;
-}
-
-void DirectoryMap::update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const {
-  auto it = metadata_handles_.find(std::ranges::to<std::string>(name));
-  if (it == metadata_handles_.end())
-    return;
-  if (auto handle = it->second.lock()) {
-    handle->Update(std::move(metadata));
-  } else {
-    metadata_handles_.erase(it);
-  }
-}
-
-void DirectoryMap::invalidate_metadata_handle(std::string_view name) const {
-  auto it = metadata_handles_.find(std::ranges::to<std::string>(name));
-  if (it == metadata_handles_.end())
-    return;
-  if (auto handle = it->second.lock())
-    handle->Invalidate();
-  metadata_handles_.erase(it);
-}
-
-void DirectoryMap::refresh_live_metadata_handles() const {
-  std::vector<std::pair<std::string, Entry::MetadataHandlePtr>> live_handles;
-  for (auto it = metadata_handles_.begin(); it != metadata_handles_.end();) {
-    if (auto handle = it->second.lock()) {
-      live_handles.emplace_back(it->first, std::move(handle));
-      ++it;
-    } else {
-      it = metadata_handles_.erase(it);
-    }
-  }
-
-  for (auto& [name, handle] : live_handles) {
-    auto it = find(name);
-    if (it.is_end()) {
-      handle->Invalidate();
-    } else {
-      handle->Update((*it).metadata);
-    }
-  }
+  return entry_cache_.Load(*this, std::move(it), quota_);
 }
 
 // Or maybe realloc?
@@ -219,8 +147,7 @@ bool DirectoryMap::erase(std::string_view name) {
   it.leaf().node.Free((*it.leaf().iterator).value(),
                       static_cast<uint16_t>(1 << (*it).metadata->metadata_log2_size.value()));
   it.leaf().node.erase(it.leaf().iterator);
-  entries_.erase(key);
-  invalidate_metadata_handle(key);
+  entry_cache_.EntryRemoved(key);
   bool last_empty = it.leaf().node.empty();
   if (!last_empty)
     return true;
@@ -282,13 +209,13 @@ std::expected<Block::DataRef<EntryMetadata>, WfsError> DirectoryMap::replace_met
   if (old_log2_size == new_log2_size) {
     if (old_metadata.get() != metadata)
       std::memcpy(old_metadata.get_mutable(), metadata, new_size);
-    update_metadata_handle(name, old_metadata);
+    entry_cache_.MetadataUpdated(name, old_metadata);
     return old_metadata;
   }
 
   auto new_metadata = realloc_metadata(it, new_log2_size);
   std::memcpy(new_metadata.get_mutable(), metadata, new_size);
-  update_metadata_handle(name, new_metadata);
+  entry_cache_.MetadataUpdated(name, new_metadata);
   return new_metadata;
 }
 
@@ -339,7 +266,7 @@ bool DirectoryMap::split_tree(std::vector<iterator::parent_node_info>& parents,
 
   tree = std::ranges::lexicographical_compare(for_key, middle_key) ? new_left_tree : new_right_tree;
   if constexpr (std::same_as<TreeType, DirectoryLeafTree>) {
-    refresh_live_metadata_handles();
+    entry_cache_.RefreshMetadataRefs(*this);
   }
   return true;
 }

--- a/src/directory_map.h
+++ b/src/directory_map.h
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
 
+#include "directory_entry_cache.h"
 #include "directory_map_iterator.h"
-#include "entry.h"
 #include "errors.h"
 
 template <typename T>
@@ -43,15 +42,10 @@ class DirectoryMap : public std::enable_shared_from_this<DirectoryMap> {
   bool split_tree(std::vector<iterator::parent_node_info>& parents, TreeType& tree, std::string_view for_key);
   Block::DataRef<EntryMetadata> alloc_metadata(iterator it, size_t log2_size);
   Block::DataRef<EntryMetadata> realloc_metadata(iterator it, size_t log2_size);
-  Entry::MetadataHandlePtr metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const;
-  void update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const;
-  void invalidate_metadata_handle(std::string_view name) const;
-  void refresh_live_metadata_handles() const;
 
   size_t CalcSizeOfDirectoryBlock(std::shared_ptr<Block> block) const;
 
   std::shared_ptr<QuotaArea> quota_;
   std::shared_ptr<Block> root_block_;
-  mutable std::map<std::string, std::weak_ptr<Entry::MetadataHandle>> metadata_handles_;
-  mutable std::map<std::string, std::weak_ptr<Entry>> entries_;
+  DirectoryEntryCache entry_cache_;
 };

--- a/src/directory_map.h
+++ b/src/directory_map.h
@@ -7,13 +7,17 @@
 
 #pragma once
 
+#include <map>
+#include <memory>
+
 #include "directory_map_iterator.h"
+#include "entry.h"
 #include "errors.h"
 
 template <typename T>
 concept DirectoryTreeImpl = std::same_as<T, DirectoryLeafTree> || std::same_as<T, DirectoryParentTree>;
 
-class DirectoryMap {
+class DirectoryMap : public std::enable_shared_from_this<DirectoryMap> {
  public:
   using iterator = DirectoryMapIterator;
 
@@ -25,6 +29,7 @@ class DirectoryMap {
   iterator end() const;
 
   iterator find(std::string_view key) const;
+  std::expected<std::shared_ptr<Entry>, WfsError> LoadEntry(iterator it);
 
   bool insert(std::string_view name, const EntryMetadata* metadata);
   bool erase(std::string_view name);
@@ -38,9 +43,15 @@ class DirectoryMap {
   bool split_tree(std::vector<iterator::parent_node_info>& parents, TreeType& tree, std::string_view for_key);
   Block::DataRef<EntryMetadata> alloc_metadata(iterator it, size_t log2_size);
   Block::DataRef<EntryMetadata> realloc_metadata(iterator it, size_t log2_size);
+  Entry::MetadataHandlePtr metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const;
+  void update_metadata_handle(std::string_view name, Block::DataRef<EntryMetadata> metadata) const;
+  void invalidate_metadata_handle(std::string_view name) const;
+  void refresh_live_metadata_handles() const;
 
   size_t CalcSizeOfDirectoryBlock(std::shared_ptr<Block> block) const;
 
   std::shared_ptr<QuotaArea> quota_;
   std::shared_ptr<Block> root_block_;
+  mutable std::map<std::string, std::weak_ptr<Entry::MetadataHandle>> metadata_handles_;
+  mutable std::map<std::string, std::weak_ptr<Entry>> entries_;
 };

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -7,23 +7,40 @@
 
 #include "entry.h"
 
+#include <stdexcept>
+
 #include "directory.h"
 #include "file.h"
 #include "link.h"
 #include "quota_area.h"
 
-Entry::Entry(std::string name, MetadataRef metadata) : name_(std::move(name)), metadata_(std::move(metadata)) {}
+Entry::Entry(std::string name, MetadataHandlePtr metadata, std::shared_ptr<DirectoryMap> directory_map)
+    : name_(std::move(name)), metadata_(std::move(metadata)), directory_map_(std::move(directory_map)) {}
 
 Entry::~Entry() = default;
+
+EntryMetadata* Entry::mutable_metadata() {
+  return metadata_->get_mutable();
+}
+
+const EntryMetadata* Entry::metadata() const {
+  return metadata_->get();
+}
+
+const std::shared_ptr<Block>& Entry::metadata_block() const {
+  return metadata_->block();
+}
 
 // static
 std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
                                                             std::string name,
-                                                            MetadataRef metadata_ref) {
-  auto* metadata = metadata_ref.get();
+                                                            MetadataHandlePtr metadata_handle,
+                                                            std::shared_ptr<DirectoryMap> directory_map) {
+  auto* metadata = metadata_handle->get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
-    return std::make_shared<Link>(std::move(name), std::move(metadata_ref), std::move(quota));
+    return std::make_shared<Link>(std::move(name), std::move(metadata_handle), std::move(quota),
+                                  std::move(directory_map));
   } else if (metadata->is_directory()) {
     if (metadata->flags.value() & metadata->Flags::QUOTA) {
       // The directory is quota, aka new area
@@ -34,14 +51,20 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
       auto new_quota = quota->LoadQuotaArea(metadata->directory_block_number.value(), block_size);
       if (!new_quota.has_value())
         return std::unexpected(new_quota.error());
-      return (*new_quota)->LoadRootDirectory(std::move(name), std::move(metadata_ref));
+      return (*new_quota)->LoadRootDirectory(std::move(name), std::move(metadata_handle));
     } else {
-      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(name), std::move(metadata_ref));
+      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(name), std::move(metadata_handle));
     }
   } else {
     // IsFile()
-    return std::make_shared<File>(std::move(name), std::move(metadata_ref), std::move(quota));
+    return std::make_shared<File>(std::move(name), std::move(metadata_handle), std::move(quota),
+                                  std::move(directory_map));
   }
+}
+
+// static
+Entry::MetadataHandlePtr Entry::CreateMetadataHandle(MetadataRef metadata) {
+  return std::make_shared<MetadataHandle>(std::move(metadata));
 }
 
 uint32_t Entry::owner() const {
@@ -58,4 +81,32 @@ uint32_t Entry::creation_time() const {
 }
 uint32_t Entry::modification_time() const {
   return metadata()->mtime.value();
+}
+
+Entry::MetadataHandle::MetadataHandle(MetadataRef metadata) : metadata_(std::move(metadata)) {}
+
+const EntryMetadata* Entry::MetadataHandle::get() const {
+  if (!metadata_.has_value())
+    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
+  return metadata_->get();
+}
+
+EntryMetadata* Entry::MetadataHandle::get_mutable() const {
+  if (!metadata_.has_value())
+    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
+  return metadata_->get_mutable();
+}
+
+const std::shared_ptr<Block>& Entry::MetadataHandle::block() const {
+  if (!metadata_.has_value())
+    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
+  return metadata_->block;
+}
+
+void Entry::MetadataHandle::Update(MetadataRef metadata) {
+  metadata_ = std::move(metadata);
+}
+
+void Entry::MetadataHandle::Invalidate() {
+  metadata_.reset();
 }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -86,21 +86,15 @@ uint32_t Entry::modification_time() const {
 Entry::MetadataHandle::MetadataHandle(MetadataRef metadata) : metadata_(std::move(metadata)) {}
 
 const EntryMetadata* Entry::MetadataHandle::get() const {
-  if (!metadata_.has_value())
-    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
-  return metadata_->get();
+  return metadata_ref().get();
 }
 
 EntryMetadata* Entry::MetadataHandle::get_mutable() const {
-  if (!metadata_.has_value())
-    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
-  return metadata_->get_mutable();
+  return metadata_ref().get_mutable();
 }
 
 const std::shared_ptr<Block>& Entry::MetadataHandle::block() const {
-  if (!metadata_.has_value())
-    throw std::logic_error("Entry metadata handle is no longer attached to a directory entry");
-  return metadata_->block;
+  return metadata_ref().block;
 }
 
 void Entry::MetadataHandle::Update(MetadataRef metadata) {
@@ -109,4 +103,10 @@ void Entry::MetadataHandle::Update(MetadataRef metadata) {
 
 void Entry::MetadataHandle::Invalidate() {
   metadata_.reset();
+}
+
+const Entry::MetadataRef& Entry::MetadataHandle::metadata_ref() const {
+  if (!metadata_.has_value())
+    throw std::logic_error("Invalid entry metadata handle");
+  return *metadata_;
 }

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -14,13 +14,14 @@
 #include "link.h"
 #include "quota_area.h"
 
-Entry::Entry(EntryHandlePtr handle, std::shared_ptr<DirectoryMap> directory_map)
-    : handle_(std::move(handle)), directory_map_(std::move(directory_map)) {}
+Entry::Entry(EntryHandlePtr handle) : handle_(std::move(handle)) {}
 
 Entry::~Entry() = default;
 
-std::string_view Entry::name() const {
-  return handle_->name();
+std::string Entry::name() const {
+  if (!handle_->directory_map())
+    return std::string{handle_->key()};
+  return handle_->get()->GetCaseSensitiveName(handle_->key());
 }
 
 EntryMetadata* Entry::mutable_metadata() {
@@ -36,13 +37,11 @@ const std::shared_ptr<Block>& Entry::metadata_block() const {
 }
 
 // static
-std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
-                                                            EntryHandlePtr handle,
-                                                            std::shared_ptr<DirectoryMap> directory_map) {
+std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota, EntryHandlePtr handle) {
   auto* metadata = handle->get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
-    return std::make_shared<Link>(std::move(handle), std::move(quota), std::move(directory_map));
+    return std::make_shared<Link>(std::move(handle), std::move(quota));
   } else if (metadata->is_directory()) {
     if (metadata->flags.value() & metadata->Flags::QUOTA) {
       // The directory is quota, aka new area
@@ -59,13 +58,20 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
     }
   } else {
     // IsFile()
-    return std::make_shared<File>(std::move(handle), std::move(quota), std::move(directory_map));
+    return std::make_shared<File>(std::move(handle), std::move(quota));
   }
 }
 
 // static
-Entry::EntryHandlePtr Entry::CreateEntryHandle(std::string name, MetadataRef metadata) {
-  return std::make_shared<EntryHandle>(std::move(name), std::move(metadata));
+Entry::EntryHandlePtr Entry::CreateEntryHandle(std::shared_ptr<DirectoryMap> directory_map,
+                                               std::string key,
+                                               MetadataRef metadata) {
+  return std::make_shared<EntryHandle>(std::move(directory_map), std::move(key), std::move(metadata));
+}
+
+// static
+Entry::EntryHandlePtr Entry::CreateSyntheticEntryHandle(std::string name, MetadataRef metadata) {
+  return std::make_shared<EntryHandle>(nullptr, std::move(name), std::move(metadata));
 }
 
 uint32_t Entry::owner() const {
@@ -84,11 +90,15 @@ uint32_t Entry::modification_time() const {
   return metadata()->mtime.value();
 }
 
-Entry::EntryHandle::EntryHandle(std::string name, MetadataRef metadata)
-    : name_(std::move(name)), metadata_(std::move(metadata)) {}
+Entry::EntryHandle::EntryHandle(std::shared_ptr<DirectoryMap> directory_map, std::string key, MetadataRef metadata)
+    : directory_map_(std::move(directory_map)), key_(std::move(key)), metadata_(std::move(metadata)) {}
 
-std::string_view Entry::EntryHandle::name() const {
-  return name_;
+std::string_view Entry::EntryHandle::key() const {
+  return key_;
+}
+
+const std::shared_ptr<DirectoryMap>& Entry::EntryHandle::directory_map() const {
+  return directory_map_;
 }
 
 const EntryMetadata* Entry::EntryHandle::get() const {
@@ -103,8 +113,8 @@ const std::shared_ptr<Block>& Entry::EntryHandle::block() const {
   return metadata_ref().block;
 }
 
-void Entry::EntryHandle::Update(std::string name, MetadataRef metadata) {
-  name_ = std::move(name);
+void Entry::EntryHandle::Update(std::string key, MetadataRef metadata) {
+  key_ = std::move(key);
   metadata_ = std::move(metadata);
 }
 

--- a/src/entry.cpp
+++ b/src/entry.cpp
@@ -14,33 +14,35 @@
 #include "link.h"
 #include "quota_area.h"
 
-Entry::Entry(std::string name, MetadataHandlePtr metadata, std::shared_ptr<DirectoryMap> directory_map)
-    : name_(std::move(name)), metadata_(std::move(metadata)), directory_map_(std::move(directory_map)) {}
+Entry::Entry(EntryHandlePtr handle, std::shared_ptr<DirectoryMap> directory_map)
+    : handle_(std::move(handle)), directory_map_(std::move(directory_map)) {}
 
 Entry::~Entry() = default;
 
+std::string_view Entry::name() const {
+  return handle_->name();
+}
+
 EntryMetadata* Entry::mutable_metadata() {
-  return metadata_->get_mutable();
+  return handle_->get_mutable();
 }
 
 const EntryMetadata* Entry::metadata() const {
-  return metadata_->get();
+  return handle_->get();
 }
 
 const std::shared_ptr<Block>& Entry::metadata_block() const {
-  return metadata_->block();
+  return handle_->block();
 }
 
 // static
 std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<QuotaArea> quota,
-                                                            std::string name,
-                                                            MetadataHandlePtr metadata_handle,
+                                                            EntryHandlePtr handle,
                                                             std::shared_ptr<DirectoryMap> directory_map) {
-  auto* metadata = metadata_handle->get();
+  auto* metadata = handle->get();
   if (metadata->is_link()) {
     // TODO, I think that the link info is in the metadata metadata
-    return std::make_shared<Link>(std::move(name), std::move(metadata_handle), std::move(quota),
-                                  std::move(directory_map));
+    return std::make_shared<Link>(std::move(handle), std::move(quota), std::move(directory_map));
   } else if (metadata->is_directory()) {
     if (metadata->flags.value() & metadata->Flags::QUOTA) {
       // The directory is quota, aka new area
@@ -51,20 +53,19 @@ std::expected<std::shared_ptr<Entry>, WfsError> Entry::Load(std::shared_ptr<Quot
       auto new_quota = quota->LoadQuotaArea(metadata->directory_block_number.value(), block_size);
       if (!new_quota.has_value())
         return std::unexpected(new_quota.error());
-      return (*new_quota)->LoadRootDirectory(std::move(name), std::move(metadata_handle));
+      return (*new_quota)->LoadRootDirectory(std::move(handle));
     } else {
-      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(name), std::move(metadata_handle));
+      return quota->LoadDirectory(metadata->directory_block_number.value(), std::move(handle));
     }
   } else {
     // IsFile()
-    return std::make_shared<File>(std::move(name), std::move(metadata_handle), std::move(quota),
-                                  std::move(directory_map));
+    return std::make_shared<File>(std::move(handle), std::move(quota), std::move(directory_map));
   }
 }
 
 // static
-Entry::MetadataHandlePtr Entry::CreateMetadataHandle(MetadataRef metadata) {
-  return std::make_shared<MetadataHandle>(std::move(metadata));
+Entry::EntryHandlePtr Entry::CreateEntryHandle(std::string name, MetadataRef metadata) {
+  return std::make_shared<EntryHandle>(std::move(name), std::move(metadata));
 }
 
 uint32_t Entry::owner() const {
@@ -83,30 +84,36 @@ uint32_t Entry::modification_time() const {
   return metadata()->mtime.value();
 }
 
-Entry::MetadataHandle::MetadataHandle(MetadataRef metadata) : metadata_(std::move(metadata)) {}
+Entry::EntryHandle::EntryHandle(std::string name, MetadataRef metadata)
+    : name_(std::move(name)), metadata_(std::move(metadata)) {}
 
-const EntryMetadata* Entry::MetadataHandle::get() const {
+std::string_view Entry::EntryHandle::name() const {
+  return name_;
+}
+
+const EntryMetadata* Entry::EntryHandle::get() const {
   return metadata_ref().get();
 }
 
-EntryMetadata* Entry::MetadataHandle::get_mutable() const {
+EntryMetadata* Entry::EntryHandle::get_mutable() const {
   return metadata_ref().get_mutable();
 }
 
-const std::shared_ptr<Block>& Entry::MetadataHandle::block() const {
+const std::shared_ptr<Block>& Entry::EntryHandle::block() const {
   return metadata_ref().block;
 }
 
-void Entry::MetadataHandle::Update(MetadataRef metadata) {
+void Entry::EntryHandle::Update(std::string name, MetadataRef metadata) {
+  name_ = std::move(name);
   metadata_ = std::move(metadata);
 }
 
-void Entry::MetadataHandle::Invalidate() {
+void Entry::EntryHandle::Invalidate() {
   metadata_.reset();
 }
 
-const Entry::MetadataRef& Entry::MetadataHandle::metadata_ref() const {
+const Entry::MetadataRef& Entry::EntryHandle::metadata_ref() const {
   if (!metadata_.has_value())
-    throw std::logic_error("Invalid entry metadata handle");
+    throw std::logic_error("Invalid directory entry handle");
   return *metadata_;
 }

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -26,8 +26,8 @@ bool File::IsEncrypted() const {
 
 void File::Resize(size_t new_size) {
   // TODO: implment it, write now change up to size_on_disk without ever chaning size_on_disk
-  new_size = std::min(new_size, static_cast<size_t>(metadata_.get()->size_on_disk.value()));
-  size_t old_size = metadata_.get()->file_size.value();
+  new_size = std::min(new_size, static_cast<size_t>(metadata()->size_on_disk.value()));
+  size_t old_size = metadata()->file_size.value();
   if (new_size != old_size) {
     CreateLayoutAccessor(shared_from_this())->Resize(new_size);
   }

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -40,12 +40,11 @@ std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::Create(std::share
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadDirectory(uint32_t area_block_number,
-                                                                             std::string name,
-                                                                             Entry::MetadataHandlePtr metadata) {
+                                                                             Entry::EntryHandlePtr handle) {
   auto map = LoadDirectoryMap(area_block_number);
   if (!map.has_value())
     return std::unexpected(map.error());
-  return std::make_shared<Directory>(std::move(name), std::move(metadata), shared_from_this(), std::move(*map));
+  return std::make_shared<Directory>(std::move(handle), shared_from_this(), std::move(*map));
 }
 
 std::expected<std::shared_ptr<DirectoryMap>, WfsError> QuotaArea::LoadDirectoryMap(uint32_t area_block_number) {
@@ -63,19 +62,18 @@ std::expected<std::shared_ptr<DirectoryMap>, WfsError> QuotaArea::LoadDirectoryM
   return map;
 }
 
-std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadRootDirectory(std::string name,
-                                                                                 Entry::MetadataHandlePtr metadata) {
-  return LoadDirectory(header()->root_directory_block_number.value(), std::move(name), std::move(metadata));
+std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadRootDirectory(Entry::EntryHandlePtr handle) {
+  return LoadDirectory(header()->root_directory_block_number.value(), std::move(handle));
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory1() {
-  return LoadDirectory(header()->shadow_directory_block_number_1.value(), ".shadow_dir_1",
-                       Entry::CreateMetadataHandle({}));
+  return LoadDirectory(header()->shadow_directory_block_number_1.value(),
+                       Entry::CreateEntryHandle(".shadow_dir_1", {}));
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory2() {
-  return LoadDirectory(header()->shadow_directory_block_number_2.value(), ".shadow_dir_2",
-                       Entry::CreateMetadataHandle({}));
+  return LoadDirectory(header()->shadow_directory_block_number_2.value(),
+                       Entry::CreateEntryHandle(".shadow_dir_2", {}));
 }
 
 std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::LoadQuotaArea(uint32_t area_block_number,

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -16,8 +16,10 @@
 #include "utils.h"
 #include "wfs_device.h"
 
-QuotaArea::QuotaArea(std::shared_ptr<WfsDevice> wfs_device, std::shared_ptr<Block> header_block)
-    : Area(std::move(wfs_device), std::move(header_block)) {}
+QuotaArea::QuotaArea(std::shared_ptr<WfsDevice> wfs_device,
+                     std::shared_ptr<Block> header_block,
+                     std::shared_ptr<Area> parent_area)
+    : Area(std::move(wfs_device), std::move(header_block), std::move(parent_area)) {}
 
 // static
 std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::Create(std::shared_ptr<WfsDevice> wfs_device,
@@ -28,13 +30,14 @@ std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::Create(std::share
   // TODO: size
   std::shared_ptr<Block> block;
   if (parent_area) {
-    auto loaded_block = parent_area->LoadMetadataBlock(fragments[0].block_number);
+    auto loaded_block = parent_area->LoadMetadataBlock(fragments[0].block_number, /*new_block=*/true);
     if (!loaded_block.has_value())
       return std::unexpected(loaded_block.error());
+    block = std::move(*loaded_block);
   } else {
     block = wfs_device->root_block();
   }
-  auto quota = std::make_shared<QuotaArea>(wfs_device, std::move(block));
+  auto quota = std::make_shared<QuotaArea>(wfs_device, std::move(block), parent_area);
   quota->Init(parent_area, blocks_count, block_size, fragments);
   return quota;
 }
@@ -87,7 +90,7 @@ std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::LoadQuotaArea(uin
   auto area_metadata_block = LoadMetadataBlock(area_block_number, block_size);
   if (!area_metadata_block.has_value())
     return std::unexpected(WfsError::kAreaHeaderCorrupted);
-  auto quota = std::make_shared<QuotaArea>(wfs_device(), std::move(*area_metadata_block));
+  auto quota = std::make_shared<QuotaArea>(wfs_device(), std::move(*area_metadata_block), shared_from_this());
   quota_areas_.emplace(area_block_number, quota);
   return quota;
 }

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -11,6 +11,7 @@
 #include <ranges>
 
 #include "directory.h"
+#include "directory_map.h"
 #include "free_blocks_allocator.h"
 #include "utils.h"
 #include "wfs_device.h"
@@ -40,32 +41,57 @@ std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::Create(std::share
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadDirectory(uint32_t area_block_number,
                                                                              std::string name,
-                                                                             Entry::MetadataRef metadata) {
+                                                                             Entry::MetadataHandlePtr metadata) {
+  auto map = LoadDirectoryMap(area_block_number);
+  if (!map.has_value())
+    return std::unexpected(map.error());
+  return std::make_shared<Directory>(std::move(name), std::move(metadata), shared_from_this(), std::move(*map));
+}
+
+std::expected<std::shared_ptr<DirectoryMap>, WfsError> QuotaArea::LoadDirectoryMap(uint32_t area_block_number) {
+  if (auto it = directory_maps_.find(area_block_number); it != directory_maps_.end()) {
+    if (auto map = it->second.lock())
+      return map;
+    directory_maps_.erase(it);
+  }
+
   auto block = LoadMetadataBlock(area_block_number);
   if (!block.has_value())
     return std::unexpected(WfsError::kDirectoryCorrupted);
-  return std::make_shared<Directory>(std::move(name), std::move(metadata), shared_from_this(), std::move(*block));
+  auto map = std::make_shared<DirectoryMap>(shared_from_this(), std::move(*block));
+  directory_maps_.emplace(area_block_number, map);
+  return map;
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadRootDirectory(std::string name,
-                                                                                 Entry::MetadataRef metadata) {
+                                                                                 Entry::MetadataHandlePtr metadata) {
   return LoadDirectory(header()->root_directory_block_number.value(), std::move(name), std::move(metadata));
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory1() {
-  return LoadDirectory(header()->shadow_directory_block_number_1.value(), ".shadow_dir_1", {});
+  return LoadDirectory(header()->shadow_directory_block_number_1.value(), ".shadow_dir_1",
+                       Entry::CreateMetadataHandle({}));
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory2() {
-  return LoadDirectory(header()->shadow_directory_block_number_2.value(), ".shadow_dir_2", {});
+  return LoadDirectory(header()->shadow_directory_block_number_2.value(), ".shadow_dir_2",
+                       Entry::CreateMetadataHandle({}));
 }
 
 std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::LoadQuotaArea(uint32_t area_block_number,
                                                                              BlockSize block_size) {
+  if (auto it = quota_areas_.find(area_block_number); it != quota_areas_.end()) {
+    if (auto quota = it->second.lock())
+      return quota;
+    quota_areas_.erase(it);
+  }
+
   auto area_metadata_block = LoadMetadataBlock(area_block_number, block_size);
   if (!area_metadata_block.has_value())
     return std::unexpected(WfsError::kAreaHeaderCorrupted);
-  return std::make_shared<QuotaArea>(wfs_device(), std::move(*area_metadata_block));
+  auto quota = std::make_shared<QuotaArea>(wfs_device(), std::move(*area_metadata_block));
+  quota_areas_.emplace(area_block_number, quota);
+  return quota;
 }
 
 std::expected<std::shared_ptr<FreeBlocksAllocator>, WfsError> QuotaArea::GetFreeBlocksAllocator() {

--- a/src/quota_area.cpp
+++ b/src/quota_area.cpp
@@ -68,12 +68,12 @@ std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::LoadRootDirectory
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory1() {
   return LoadDirectory(header()->shadow_directory_block_number_1.value(),
-                       Entry::CreateEntryHandle(".shadow_dir_1", {}));
+                       Entry::CreateSyntheticEntryHandle(".shadow_dir_1", {}));
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> QuotaArea::GetShadowDirectory2() {
   return LoadDirectory(header()->shadow_directory_block_number_2.value(),
-                       Entry::CreateEntryHandle(".shadow_dir_2", {}));
+                       Entry::CreateSyntheticEntryHandle(".shadow_dir_2", {}));
 }
 
 std::expected<std::shared_ptr<QuotaArea>, WfsError> QuotaArea::LoadQuotaArea(uint32_t area_block_number,

--- a/src/quota_area.h
+++ b/src/quota_area.h
@@ -36,14 +36,12 @@ class QuotaArea : public Area, public std::enable_shared_from_this<QuotaArea> {
 
   std::expected<std::shared_ptr<QuotaArea>, WfsError> LoadQuotaArea(uint32_t area_block_number, BlockSize block_size);
 
-  std::expected<std::shared_ptr<Directory>, WfsError> LoadRootDirectory(std::string name,
-                                                                        Entry::MetadataHandlePtr metadata);
+  std::expected<std::shared_ptr<Directory>, WfsError> LoadRootDirectory(Entry::EntryHandlePtr handle);
   std::expected<std::shared_ptr<Directory>, WfsError> GetShadowDirectory1();
   std::expected<std::shared_ptr<Directory>, WfsError> GetShadowDirectory2();
 
   std::expected<std::shared_ptr<Directory>, WfsError> LoadDirectory(uint32_t area_block_number,
-                                                                    std::string name,
-                                                                    Entry::MetadataHandlePtr metadata);
+                                                                    Entry::EntryHandlePtr handle);
 
   std::expected<std::shared_ptr<Block>, WfsError> AllocMetadataBlock();
   std::expected<std::vector<uint32_t>, WfsError> AllocDataBlocks(uint32_t count, BlockType block_type);

--- a/src/quota_area.h
+++ b/src/quota_area.h
@@ -8,12 +8,14 @@
 #pragma once
 
 #include <expected>
+#include <map>
 
 #include "area.h"
 #include "entry.h"
 #include "errors.h"
 
 class Directory;
+class DirectoryMap;
 class FreeBlocksAllocator;
 
 class QuotaArea : public Area, public std::enable_shared_from_this<QuotaArea> {
@@ -34,13 +36,14 @@ class QuotaArea : public Area, public std::enable_shared_from_this<QuotaArea> {
 
   std::expected<std::shared_ptr<QuotaArea>, WfsError> LoadQuotaArea(uint32_t area_block_number, BlockSize block_size);
 
-  std::expected<std::shared_ptr<Directory>, WfsError> LoadRootDirectory(std::string name, Entry::MetadataRef metadata);
+  std::expected<std::shared_ptr<Directory>, WfsError> LoadRootDirectory(std::string name,
+                                                                        Entry::MetadataHandlePtr metadata);
   std::expected<std::shared_ptr<Directory>, WfsError> GetShadowDirectory1();
   std::expected<std::shared_ptr<Directory>, WfsError> GetShadowDirectory2();
 
   std::expected<std::shared_ptr<Directory>, WfsError> LoadDirectory(uint32_t area_block_number,
                                                                     std::string name,
-                                                                    Entry::MetadataRef metadata);
+                                                                    Entry::MetadataHandlePtr metadata);
 
   std::expected<std::shared_ptr<Block>, WfsError> AllocMetadataBlock();
   std::expected<std::vector<uint32_t>, WfsError> AllocDataBlocks(uint32_t count, BlockType block_type);
@@ -72,4 +75,8 @@ class QuotaArea : public Area, public std::enable_shared_from_this<QuotaArea> {
             uint32_t blocks_count,
             BlockSize block_size,
             const std::vector<QuotaFragment>& fragments);
+  std::expected<std::shared_ptr<DirectoryMap>, WfsError> LoadDirectoryMap(uint32_t area_block_number);
+
+  std::map<uint32_t, std::weak_ptr<QuotaArea>> quota_areas_;
+  std::map<uint32_t, std::weak_ptr<DirectoryMap>> directory_maps_;
 };

--- a/src/quota_area.h
+++ b/src/quota_area.h
@@ -25,7 +25,9 @@ class QuotaArea : public Area, public std::enable_shared_from_this<QuotaArea> {
     uint32_t blocks_count;
   };
 
-  QuotaArea(std::shared_ptr<WfsDevice> wfs_device, std::shared_ptr<Block> header_block);
+  QuotaArea(std::shared_ptr<WfsDevice> wfs_device,
+            std::shared_ptr<Block> header_block,
+            std::shared_ptr<Area> parent_area = nullptr);
 
   // If parent_area null it is root area
   static std::expected<std::shared_ptr<QuotaArea>, WfsError> Create(std::shared_ptr<WfsDevice> wfs_device,

--- a/src/recovery.cpp
+++ b/src/recovery.cpp
@@ -238,7 +238,7 @@ std::expected<std::shared_ptr<WfsDevice>, WfsError> Recovery::OpenUsrDirectoryWi
     throw std::logic_error("Failed to find /usr/save/system");
   }
   std::shared_ptr<const Area> sub_area;
-  for (const auto& [name, metadata] : system_save_dir->map_) {
+  for (const auto& [name, metadata] : *system_save_dir->map_) {
     // this is probably a corrupted quota, let's check
     if (!metadata.get()->is_quota())
       continue;

--- a/src/wfs_device.cpp
+++ b/src/wfs_device.cpp
@@ -87,11 +87,16 @@ void WfsDevice::Flush() {
 }
 
 std::shared_ptr<QuotaArea> WfsDevice::GetRootArea() {
-  return std::make_shared<QuotaArea>(shared_from_this(), root_block_);
+  if (auto root_area = root_area_.lock())
+    return root_area;
+  auto root_area = std::make_shared<QuotaArea>(shared_from_this(), root_block_);
+  root_area_ = root_area;
+  return root_area;
 }
 
 std::expected<std::shared_ptr<Directory>, WfsError> WfsDevice::GetRootDirectory() {
-  return GetRootArea()->LoadRootDirectory("", {root_block_, root_block_->to_offset(&header()->root_quota_metadata)});
+  return GetRootArea()->LoadRootDirectory(
+      "", Entry::CreateMetadataHandle({root_block_, root_block_->to_offset(&header()->root_quota_metadata)}));
 }
 
 // static

--- a/src/wfs_device.cpp
+++ b/src/wfs_device.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<QuotaArea> WfsDevice::GetRootArea() {
 
 std::expected<std::shared_ptr<Directory>, WfsError> WfsDevice::GetRootDirectory() {
   return GetRootArea()->LoadRootDirectory(
-      "", Entry::CreateMetadataHandle({root_block_, root_block_->to_offset(&header()->root_quota_metadata)}));
+      Entry::CreateEntryHandle("", {root_block_, root_block_->to_offset(&header()->root_quota_metadata)}));
 }
 
 // static

--- a/src/wfs_device.cpp
+++ b/src/wfs_device.cpp
@@ -96,7 +96,7 @@ std::shared_ptr<QuotaArea> WfsDevice::GetRootArea() {
 
 std::expected<std::shared_ptr<Directory>, WfsError> WfsDevice::GetRootDirectory() {
   return GetRootArea()->LoadRootDirectory(
-      Entry::CreateEntryHandle("", {root_block_, root_block_->to_offset(&header()->root_quota_metadata)}));
+      Entry::CreateSyntheticEntryHandle("", {root_block_, root_block_->to_offset(&header()->root_quota_metadata)}));
 }
 
 // static

--- a/tests/directory_map_tests.cpp
+++ b/tests/directory_map_tests.cpp
@@ -17,6 +17,7 @@
 #include <vector>
 
 #include <wfslib/wfs_device.h>
+#include <wfslib/file.h>
 
 #include "directory_map.h"
 #include "free_blocks_allocator.h"
@@ -58,6 +59,17 @@ void InsertFixedSizeEntries(DirectoryMap& dir_tree, uint32_t entries_count, int 
   TestEntryMetadata metadata(6);
   for (uint32_t i = 0; i < entries_count; ++i) {
     metadata.data()->flags = i;
+    REQUIRE(dir_tree.insert(EntryName(i, width), metadata.data()));
+  }
+}
+
+void InsertFixedSizeFiles(DirectoryMap& dir_tree, uint32_t entries_count, int width = 5) {
+  TestEntryMetadata metadata(6);
+  metadata.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+  metadata.data()->filename_length = static_cast<uint8_t>(width);
+  for (uint32_t i = 0; i < entries_count; ++i) {
+    metadata.data()->file_size = i;
+    metadata.data()->size_on_disk = i;
     REQUIRE(dir_tree.insert(EntryName(i, width), metadata.data()));
   }
 }
@@ -279,6 +291,64 @@ TEST_CASE_METHOD(DirectoryMapFixture,
     REQUIRE(dir_tree.erase(EntryName(i)));
   }
   CHECK(free_blocks == (*wfs_device->GetRootArea()->GetFreeBlocksAllocator())->free_blocks_count());
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap refreshes live metadata handles after a leaf split",
+                 "[directory-map][white-box]") {
+  auto block = *wfs_device->GetRootArea()->AllocMetadataBlock();
+  auto map = std::make_shared<DirectoryMap>(wfs_device->GetRootArea(), block);
+  map->Init();
+  InsertFixedSizeFiles(*map, 80);
+
+  constexpr uint32_t kLiveIndex = 10;
+  auto live_it = map->find(EntryName(kLiveIndex));
+  REQUIRE(!live_it.is_end());
+  auto live_entry = map->LoadEntry(live_it);
+  REQUIRE(live_entry.has_value());
+  auto live_file = std::dynamic_pointer_cast<File>(*live_entry);
+  REQUIRE(live_file);
+  CHECK(live_file->Size() == kLiveIndex);
+
+  SubBlockAllocator<DirectoryTreeHeader> allocator{block};
+  while (allocator.Alloc(8)) {
+  }
+
+  TestEntryMetadata replacement(8);
+  replacement.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+  replacement.data()->filename_length = 5;
+  replacement.data()->file_size = 40;
+  replacement.data()->size_on_disk = 40;
+  auto result = map->replace_metadata(EntryName(40), replacement.data());
+  REQUIRE(result.has_value());
+
+  auto current_live = map->find(EntryName(kLiveIndex));
+  REQUIRE(!current_live.is_end());
+  (*current_live).metadata.get_mutable()->file_size = 1234;
+  CHECK(live_file->Size() == 1234);
+}
+
+TEST_CASE_METHOD(MetadataBlockFixture,
+                 "WfsDevice returns the same live file instance for repeated path lookups",
+                 "[directory-map][cache]") {
+  auto wfs_device = *WfsDevice::Create(test_device);
+  auto root_area = wfs_device->GetRootArea();
+  auto root_block = *root_area->LoadMetadataBlock(3, /*new_block=*/true);
+  DirectoryMap root_map{root_area, root_block};
+  root_map.Init();
+
+  TestEntryMetadata metadata(6);
+  metadata.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+  metadata.data()->filename_length = 4;
+  metadata.data()->file_size = 12;
+  metadata.data()->size_on_disk = 12;
+  REQUIRE(root_map.insert("file", metadata.data()));
+
+  auto first = wfs_device->GetFile("/file");
+  REQUIRE(first);
+  auto second = wfs_device->GetFile("/file");
+  REQUIRE(second);
+  CHECK(first == second);
 }
 
 TEST_CASE_METHOD(DirectoryMapFixture,

--- a/tests/directory_map_tests.cpp
+++ b/tests/directory_map_tests.cpp
@@ -16,8 +16,8 @@
 #include <string>
 #include <vector>
 
-#include <wfslib/wfs_device.h>
 #include <wfslib/file.h>
+#include <wfslib/wfs_device.h>
 
 #include "directory_map.h"
 #include "free_blocks_allocator.h"
@@ -326,6 +326,34 @@ TEST_CASE_METHOD(DirectoryMapFixture,
   REQUIRE(!current_live.is_end());
   (*current_live).metadata.get_mutable()->file_size = 1234;
   CHECK(live_file->Size() == 1234);
+}
+
+TEST_CASE_METHOD(DirectoryMapFixture,
+                 "DirectoryMap metadata replacement updates live entry names",
+                 "[directory-map][cache]") {
+  auto block = *wfs_device->GetRootArea()->AllocMetadataBlock();
+  auto map = std::make_shared<DirectoryMap>(wfs_device->GetRootArea(), block);
+  map->Init();
+
+  TestEntryMetadata metadata(6);
+  metadata.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+  metadata.data()->filename_length = 8;
+  REQUIRE(map->insert("filename", metadata.data()));
+
+  auto it = map->find("filename");
+  REQUIRE(!it.is_end());
+  auto entry = map->LoadEntry(it);
+  REQUIRE(entry.has_value());
+  CHECK((*entry)->name() == "filename");
+
+  TestEntryMetadata replacement(6);
+  replacement.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+  replacement.data()->filename_length = 8;
+  replacement.data()->case_bitmap = 0x1;
+  auto result = map->replace_metadata("filename", replacement.data());
+  REQUIRE(result.has_value());
+
+  CHECK((*entry)->name() == "Filename");
 }
 
 TEST_CASE_METHOD(MetadataBlockFixture,

--- a/tests/directory_map_tests.cpp
+++ b/tests/directory_map_tests.cpp
@@ -379,6 +379,49 @@ TEST_CASE_METHOD(MetadataBlockFixture,
   CHECK(first == second);
 }
 
+TEST_CASE_METHOD(MetadataBlockFixture,
+                 "WfsDevice keeps quota-backed live file instances across root area lookups",
+                 "[directory-map][cache]") {
+  auto wfs_device = *WfsDevice::Create(test_device);
+
+  {
+    constexpr uint32_t kChildBlocksCount = 256;
+    auto root_area = wfs_device->GetRootArea();
+    auto root_block = *root_area->LoadMetadataBlock(3, /*new_block=*/true);
+    DirectoryMap root_map{root_area, root_block};
+    root_map.Init();
+
+    auto fragments = root_area->AllocAreaBlocks(kChildBlocksCount);
+    REQUIRE(fragments.has_value());
+    auto child_area = QuotaArea::Create(wfs_device, root_area, kChildBlocksCount, BlockSize::Logical, *fragments);
+    REQUIRE(child_area.has_value());
+
+    auto child_root_block = *(*child_area)->LoadMetadataBlock(3, /*new_block=*/true);
+    DirectoryMap child_root_map{*child_area, child_root_block};
+    child_root_map.Init();
+
+    TestEntryMetadata quota_metadata(6);
+    quota_metadata.data()->flags = EntryMetadata::DIRECTORY | EntryMetadata::AREA_SIZE_REGULAR | EntryMetadata::QUOTA;
+    quota_metadata.data()->filename_length = 5;
+    quota_metadata.data()->quota_blocks_count = kChildBlocksCount;
+    quota_metadata.data()->directory_block_number = (*fragments)[0].block_number;
+    REQUIRE(root_map.insert("quota", quota_metadata.data()));
+
+    TestEntryMetadata file_metadata(6);
+    file_metadata.data()->flags = EntryMetadata::UNENCRYPTED_FILE;
+    file_metadata.data()->filename_length = 4;
+    file_metadata.data()->file_size = 12;
+    file_metadata.data()->size_on_disk = 12;
+    REQUIRE(child_root_map.insert("file", file_metadata.data()));
+  }
+
+  auto first = wfs_device->GetFile("/quota/file");
+  REQUIRE(first);
+  auto second = wfs_device->GetFile("/quota/file");
+  REQUIRE(second);
+  CHECK(first == second);
+}
+
 TEST_CASE_METHOD(DirectoryMapFixture,
                  "DirectoryMap metadata replacement works in a multi-level tree",
                  "[directory-map][integration]") {

--- a/tests/file_layout_accessor_tests.cpp
+++ b/tests/file_layout_accessor_tests.cpp
@@ -23,6 +23,7 @@
 #include <wfslib/wfs_device.h>
 
 #include "block.h"
+#include "directory_map.h"
 #include "file_layout.h"
 #include "quota_area.h"
 #include "structs.h"
@@ -46,12 +47,14 @@ class FileLayoutAccessorFixture : public MetadataBlockFixture {
  public:
   std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
   std::shared_ptr<QuotaArea> quota = wfs_device->GetRootArea();
+  std::shared_ptr<Block> directory_block = *quota->AllocMetadataBlock();
+  std::shared_ptr<DirectoryMap> directory_map = std::make_shared<DirectoryMap>(quota, directory_block);
+
+  FileLayoutAccessorFixture() { directory_map->Init(); }
 
   TestFile CreateFile(std::string_view name, const FileLayout& layout) {
-    auto metadata_block = *quota->AllocMetadataBlock();
-    auto* metadata = metadata_block->get_mutable_object<EntryMetadata>(0);
-    std::fill(reinterpret_cast<std::byte*>(metadata),
-              reinterpret_cast<std::byte*>(metadata) + (size_t{1} << layout.metadata_log2_size), std::byte{0});
+    std::vector<std::byte> metadata_storage(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_storage.data());
     metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
     metadata->file_size = layout.file_size;
     metadata->size_on_disk = layout.size_on_disk;
@@ -59,8 +62,15 @@ class FileLayoutAccessorFixture : public MetadataBlockFixture {
     metadata->size_category = FileLayout::CategoryValue(layout.category);
     metadata->filename_length = static_cast<uint8_t>(name.size());
 
-    auto file = std::make_shared<File>(std::string{name}, Entry::MetadataRef{metadata_block, 0}, quota);
-    return {std::move(file), std::move(metadata_block), metadata};
+    REQUIRE(directory_map->insert(name, metadata));
+    auto it = directory_map->find(name);
+    REQUIRE(!it.is_end());
+    auto stored_metadata = (*it).metadata;
+    auto entry = directory_map->LoadEntry(it);
+    REQUIRE(entry.has_value());
+    auto file = std::dynamic_pointer_cast<File>(*entry);
+    REQUIRE(file);
+    return {std::move(file), stored_metadata.block, stored_metadata.get_mutable()};
   }
 
   TestFile CreateFile(std::string_view name, uint32_t file_size) {


### PR DESCRIPTION
## Summary
- Cache root/quota areas and per-directory `DirectoryMap` instances so live path lookups share directory state.
- Add shared entry metadata handles owned by `DirectoryMap`; loaded entries keep their parent map alive and are reused while live.
- Keep child areas strongly attached to their parent area so quota-backed lookups preserve ancestor caches while avoiding a device/root-area reference cycle.
- Refresh live metadata handles after directory leaf splits and metadata replacement, and update tests to create files through directory-owned metadata.

## Testing
- `CC=gcc-14 CXX=g++-14 cmake --preset tests`
- `cmake --build --preset debug-tests`
- `ctest --preset run-debug-tests --output-on-failure`
- GitHub Actions build matrix and clang-format passed on the latest push.