### PR TITLE
Implement inline file resize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(${PROJECT_NAME}
     src/file_device.cpp
     src/file_layout.cpp
     src/file_layout_accessor.cpp
+    src/file_resizer.cpp
     src/free_blocks_allocator.cpp
     src/free_blocks_tree_iterator.cpp
     src/free_blocks_tree.cpp

--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -14,6 +14,7 @@
 #include "entry.h"
 
 class QuotaArea;
+class FileResizer;
 
 class File : public Entry, public std::enable_shared_from_this<File> {
   class LayoutAccessor;
@@ -54,6 +55,8 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   typedef boost::iostreams::stream<file_device> stream;
 
  private:
+  friend class FileResizer;
+
   std::shared_ptr<QuotaArea> quota() const { return quota_; }
 
   // TODO: We may have cyclic reference here if we do cache in area.

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -11,6 +11,7 @@
 
 #include "block.h"
 #include "file_layout_accessor.h"
+#include "file_resizer.h"
 
 uint32_t File::Size() const {
   return metadata()->file_size.value();
@@ -25,12 +26,7 @@ bool File::IsEncrypted() const {
 }
 
 void File::Resize(size_t new_size) {
-  // TODO: implment it, write now change up to size_on_disk without ever chaning size_on_disk
-  new_size = std::min(new_size, static_cast<size_t>(metadata()->size_on_disk.value()));
-  size_t old_size = metadata()->file_size.value();
-  if (new_size != old_size) {
-    CreateLayoutAccessor(shared_from_this())->Resize(new_size);
-  }
+  FileResizer(shared_from_this()).Resize(new_size);
 }
 
 File::file_device::file_device(const std::shared_ptr<File>& file)

--- a/src/file_resizer.cpp
+++ b/src/file_resizer.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "file_resizer.h"
+
+#include <algorithm>
+#include <cstring>
+#include <limits>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "directory_map.h"
+#include "errors.h"
+#include "file_layout.h"
+#include "quota_area.h"
+
+namespace {
+FileLayoutCategory Category(const EntryMetadata* metadata) {
+  return FileLayout::CategoryFromValue(metadata->size_category.value());
+}
+
+std::span<const std::byte> InlinePayload(const EntryMetadata* metadata) {
+  return {reinterpret_cast<const std::byte*>(metadata) + metadata->size(), metadata->size_on_disk.value()};
+}
+
+std::span<std::byte> InlinePayload(EntryMetadata* metadata) {
+  return {reinterpret_cast<std::byte*>(metadata) + metadata->size(), metadata->size_on_disk.value()};
+}
+
+[[noreturn]] void ThrowNonInlineResizeUnimplemented() {
+  throw std::logic_error("File resize for non-inline layouts is not implemented");
+}
+}  // namespace
+
+FileResizer::FileResizer(std::shared_ptr<File> file) : file_(std::move(file)) {}
+
+void FileResizer::Resize(size_t new_size) {
+  if (new_size > std::numeric_limits<uint32_t>::max())
+    throw WfsException(WfsError::kFileTooLarge);
+
+  const auto* metadata = file_->metadata();
+  const auto old_size = metadata->file_size.value();
+  const auto target_size = static_cast<uint32_t>(new_size);
+  if (target_size == old_size)
+    return;
+
+  const auto mode = target_size > old_size ? FileLayoutMode::MinimumForGrow : FileLayoutMode::MaximumForShrink;
+  const auto target_layout =
+      FileLayout::Calculate(target_size, metadata->filename_length.value(), file_->quota()->block_size_log2(), mode);
+
+  if (Category(metadata) != FileLayoutCategory::Inline || target_layout.category != FileLayoutCategory::Inline)
+    ThrowNonInlineResizeUnimplemented();
+
+  ResizeInline(target_layout);
+}
+
+void FileResizer::ResizeInline(const FileLayout& target_layout) {
+  const auto* metadata = file_->metadata();
+  const auto allocation_size = size_t{1} << target_layout.metadata_log2_size;
+  std::vector<std::byte> replacement_storage(allocation_size, std::byte{0});
+  auto* replacement_metadata = reinterpret_cast<EntryMetadata*>(replacement_storage.data());
+
+  std::memcpy(replacement_metadata, metadata, metadata->size());
+  replacement_metadata->file_size = target_layout.file_size;
+  replacement_metadata->size_on_disk = target_layout.size_on_disk;
+  replacement_metadata->metadata_log2_size = target_layout.metadata_log2_size;
+  replacement_metadata->size_category = FileLayout::CategoryValue(target_layout.category);
+
+  const auto bytes_to_preserve = std::min(metadata->file_size.value(), target_layout.file_size);
+  if (bytes_to_preserve != 0)
+    std::memcpy(InlinePayload(replacement_metadata).data(), InlinePayload(metadata).data(), bytes_to_preserve);
+
+  const auto& directory_map = file_->handle_->directory_map();
+  if (!directory_map)
+    throw std::logic_error("File metadata is not attached to a directory entry");
+
+  auto result = directory_map->replace_metadata(file_->handle_->key(), replacement_metadata);
+  if (!result.has_value())
+    throw WfsException(result.error());
+}

--- a/src/file_resizer.h
+++ b/src/file_resizer.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+
+#include "file.h"
+#include "file_layout.h"
+
+class FileResizer {
+ public:
+  explicit FileResizer(std::shared_ptr<File> file);
+
+  void Resize(size_t new_size);
+
+ private:
+  void ResizeInline(const FileLayout& target_layout);
+
+  std::shared_ptr<File> file_;
+};

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(WFSLIB_BEHAVIOR_TEST_SOURCES
   eptree_tests.cpp
   file_layout_accessor_tests.cpp
   file_layout_tests.cpp
+  file_resize_tests.cpp
   free_blocks_allocator_tests.cpp
   free_blocks_tree_bucket_tests.cpp
   free_blocks_tree_tests.cpp

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <ios>
+#include <memory>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <vector>
+
+#include <wfslib/device.h>
+#include <wfslib/file.h>
+#include <wfslib/wfs_device.h>
+
+#include "block.h"
+#include "directory_map.h"
+#include "file_layout.h"
+#include "quota_area.h"
+#include "structs.h"
+#include "utils/test_fixtures.h"
+
+namespace {
+constexpr std::string_view kTestFilename = "file";
+constexpr std::array kInitialData{std::byte{0x11}, std::byte{0x22}, std::byte{0x33}, std::byte{0x44}};
+constexpr std::array kReplacementData{std::byte{0xaa}, std::byte{0xbb}, std::byte{0xcc}, std::byte{0xdd}};
+
+struct TestFile {
+  std::shared_ptr<File> file;
+  EntryMetadata* metadata;
+};
+
+class FileResizeFixture : public MetadataBlockFixture {
+ public:
+  std::shared_ptr<WfsDevice> wfs_device = *WfsDevice::Create(test_device);
+  std::shared_ptr<QuotaArea> quota = wfs_device->GetRootArea();
+  std::shared_ptr<Block> directory_block = *quota->AllocMetadataBlock();
+  std::shared_ptr<DirectoryMap> directory_map = std::make_shared<DirectoryMap>(quota, directory_block);
+
+  FileResizeFixture() { directory_map->Init(); }
+
+  TestFile CreateFile(std::string_view name, const FileLayout& layout) {
+    std::vector<std::byte> metadata_storage(size_t{1} << layout.metadata_log2_size, std::byte{0});
+    auto* metadata = reinterpret_cast<EntryMetadata*>(metadata_storage.data());
+    metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+    metadata->file_size = layout.file_size;
+    metadata->size_on_disk = layout.size_on_disk;
+    metadata->metadata_log2_size = layout.metadata_log2_size;
+    metadata->size_category = FileLayout::CategoryValue(layout.category);
+    metadata->filename_length = static_cast<uint8_t>(name.size());
+
+    REQUIRE(directory_map->insert(name, metadata));
+    auto it = directory_map->find(name);
+    REQUIRE(!it.is_end());
+    auto stored_metadata = (*it).metadata;
+    auto entry = directory_map->LoadEntry(it);
+    REQUIRE(entry.has_value());
+    auto file = std::dynamic_pointer_cast<File>(*entry);
+    REQUIRE(file);
+    return {std::move(file), stored_metadata.get_mutable()};
+  }
+
+  TestFile CreateFile(std::string_view name, uint32_t file_size) {
+    return CreateFile(name, FileLayout::Calculate(file_size, static_cast<uint8_t>(name.size()),
+                                                  quota->block_size_log2(), FileLayoutMode::MinimumForGrow));
+  }
+
+  EntryMetadata* StoredMetadata(std::string_view name) {
+    auto it = directory_map->find(name);
+    REQUIRE(!it.is_end());
+    return (*it).metadata.get_mutable();
+  }
+};
+
+std::span<std::byte> InlinePayload(EntryMetadata* metadata) {
+  return {reinterpret_cast<std::byte*>(metadata) + metadata->size(), metadata->size_on_disk.value()};
+}
+
+std::vector<std::byte> ReadFile(const std::shared_ptr<File>& file, size_t size) {
+  std::vector<std::byte> output(size);
+  if (output.empty())
+    return output;
+
+  File::file_device device(file);
+  const auto read = device.read(reinterpret_cast<char*>(output.data()), static_cast<std::streamsize>(output.size()));
+  REQUIRE(read == static_cast<std::streamsize>(output.size()));
+  return output;
+}
+
+size_t WriteFile(const std::shared_ptr<File>& file, std::span<const std::byte> input, size_t offset) {
+  File::file_device device(file);
+  if (offset != 0)
+    device.seek(static_cast<boost::iostreams::stream_offset>(offset), std::ios_base::beg);
+  const auto wrote =
+      device.write(reinterpret_cast<const char*>(input.data()), static_cast<std::streamsize>(input.size()));
+  REQUIRE(wrote >= 0);
+  return static_cast<size_t>(wrote);
+}
+}  // namespace
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows empty inline file", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, 0);
+
+  test_file.file->Resize(4);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  CHECK(test_file.file->Size() == 4);
+  CHECK(test_file.file->SizeOnDisk() == 4);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CHECK(ReadFile(test_file.file, 4) == std::vector<std::byte>(4, std::byte{0}));
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks inline file", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  test_file.file->Resize(2);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  const std::vector expected{kInitialData[0], kInitialData[1]};
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(test_file.file->SizeOnDisk() == expected.size());
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize grows inline file across metadata allocation sizes",
+                 "[file-resize][unit]") {
+  constexpr uint32_t kGrownSize = 80;
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  const auto old_metadata_log2_size = test_file.metadata->metadata_log2_size.value();
+  const auto target_layout = FileLayout::Calculate(kGrownSize, static_cast<uint8_t>(kTestFilename.size()),
+                                                   quota->block_size_log2(), FileLayoutMode::MinimumForGrow);
+  REQUIRE(target_layout.category == FileLayoutCategory::Inline);
+  REQUIRE(target_layout.metadata_log2_size > old_metadata_log2_size);
+
+  test_file.file->Resize(kGrownSize);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  std::vector expected(kGrownSize, std::byte{0});
+  std::ranges::copy(kInitialData, expected.begin());
+  CHECK(test_file.file->Size() == kGrownSize);
+  CHECK(test_file.file->SizeOnDisk() == kGrownSize);
+  CHECK(metadata->metadata_log2_size.value() == target_layout.metadata_log2_size);
+  CHECK(ReadFile(test_file.file, kGrownSize) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize allows writing after inline growth", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  test_file.file->Resize(kInitialData.size() + kReplacementData.size());
+
+  CHECK(WriteFile(test_file.file, kReplacementData, kInitialData.size()) == kReplacementData.size());
+  std::vector<std::byte> expected{kInitialData.begin(), kInitialData.end()};
+  expected.insert(expected.end(), kReplacementData.begin(), kReplacementData.end());
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline file to zero", "[file-resize][unit]") {
+  constexpr uint32_t kInitialSize = 80;
+  auto test_file = CreateFile(kTestFilename, kInitialSize);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+
+  const auto target_layout = FileLayout::Calculate(0, static_cast<uint8_t>(kTestFilename.size()),
+                                                   quota->block_size_log2(), FileLayoutMode::MaximumForShrink);
+
+  test_file.file->Resize(0);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  CHECK(test_file.file->Size() == 0);
+  CHECK(test_file.file->SizeOnDisk() == 0);
+  CHECK(metadata->metadata_log2_size.value() == target_layout.metadata_log2_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CHECK(InlinePayload(metadata).empty());
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize throws for non-inline layouts", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+
+  CHECK_THROWS_AS(test_file.file->Resize(FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size())) + 1),
+                  std::logic_error);
+}


### PR DESCRIPTION
## Summary
- Add a private `FileResizer` that owns `File::Resize()` layout calculation and metadata replacement.
- Implement physical resize support for inline category 0 files, including metadata reallocation, byte preservation, and zero-filled growth.
- Leave non-inline resize paths explicitly unimplemented with a C++ `std::logic_error`.

## Testing
- `/tmp/wfslib-clang-format-venv/bin/clang-format --dry-run --Werror include/wfslib/file.h src/file.cpp src/file_resizer.h src/file_resizer.cpp tests/file_resize_tests.cpp`
- `CC=gcc-14 CXX=g++-14 cmake --preset tests`
- `cmake --build --preset debug-tests -j2`
- `ctest --preset run-debug-tests --output-on-failure`
- `./build/tests/tests/Debug/wfslib_tests "[file-resize]"`