### PR TITLE
Implement same-category file resize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(${PROJECT_NAME}
     src/file_layout.cpp
     src/file_layout_accessor.cpp
     src/file_resizer.cpp
+    src/file_resizer_data_units.cpp
     src/free_blocks_allocator.cpp
     src/free_blocks_tree_iterator.cpp
     src/free_blocks_tree.cpp

--- a/src/block.h
+++ b/src/block.h
@@ -127,6 +127,7 @@ class Block {
   int log2_size() const { return ::log2_size(block_size_) + ::log2_size(block_type_); }
 
   bool encrypted() const { return encrypted_; }
+  bool detached() const { return detached_; }
 
   void Resize(uint32_t data_size);
 

--- a/src/file_data_units.h
+++ b/src/file_data_units.h
@@ -45,45 +45,32 @@ std::span<T> MutableEntryMetadataItems(EntryMetadata* metadata, size_t count) {
 template <FileLayoutCategory Category>
 struct FileDataUnitLayoutTraits;
 
-template <>
-struct FileDataUnitLayoutTraits<FileLayoutCategory::Blocks> {
+template <BlockType UnitBlockType>
+struct SingleBlockFileDataUnitLayoutTraits {
   using Metadata = DataBlockMetadata;
 
-  static constexpr BlockType kAllocationBlockType = BlockType::Single;
-  static constexpr BlockType kDataBlockType = BlockType::Single;
+  static constexpr BlockType kAllocationBlockType = UnitBlockType;
+  static constexpr BlockType kDataBlockType = UnitBlockType;
   static constexpr size_t kDataBlocksPerUnit = 1;
 
-  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
+  static uint32_t unit_block_number(const Metadata& metadata) { return metadata.block_number.value(); }
 
-  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
+  static void set_unit_block_number(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
 
-  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
-                                                        const Metadata& metadata,
-                                                        [[maybe_unused]] size_t block_index) {
+  static FileDataBlockLocation data_block_location_for_unit(const std::shared_ptr<Block>& metadata_block,
+                                                            const Metadata& metadata,
+                                                            [[maybe_unused]] size_t block_index) {
     assert(block_index == 0);
     return {metadata.block_number.value(), kDataBlockType, {metadata_block, metadata_block->to_offset(metadata.hash)}};
   }
 };
 
 template <>
-struct FileDataUnitLayoutTraits<FileLayoutCategory::LargeBlocks> {
-  using Metadata = DataBlockMetadata;
+struct FileDataUnitLayoutTraits<FileLayoutCategory::Blocks> : SingleBlockFileDataUnitLayoutTraits<BlockType::Single> {};
 
-  static constexpr BlockType kAllocationBlockType = BlockType::Large;
-  static constexpr BlockType kDataBlockType = BlockType::Large;
-  static constexpr size_t kDataBlocksPerUnit = 1;
-
-  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
-
-  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
-
-  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
-                                                        const Metadata& metadata,
-                                                        [[maybe_unused]] size_t block_index) {
-    assert(block_index == 0);
-    return {metadata.block_number.value(), kDataBlockType, {metadata_block, metadata_block->to_offset(metadata.hash)}};
-  }
-};
+template <>
+struct FileDataUnitLayoutTraits<FileLayoutCategory::LargeBlocks>
+    : SingleBlockFileDataUnitLayoutTraits<BlockType::Large> {};
 
 template <>
 struct FileDataUnitLayoutTraits<FileLayoutCategory::Clusters> {
@@ -94,13 +81,13 @@ struct FileDataUnitLayoutTraits<FileLayoutCategory::Clusters> {
   static constexpr size_t kDataBlocksPerUnit = (size_t{1} << log2_size(BlockType::Cluster)) >>
                                                log2_size(kDataBlockType);
 
-  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
+  static uint32_t unit_block_number(const Metadata& metadata) { return metadata.block_number.value(); }
 
-  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
+  static void set_unit_block_number(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
 
-  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
-                                                        const Metadata& metadata,
-                                                        size_t block_index) {
+  static FileDataBlockLocation data_block_location_for_unit(const std::shared_ptr<Block>& metadata_block,
+                                                            const Metadata& metadata,
+                                                            size_t block_index) {
     assert(block_index < kDataBlocksPerUnit);
     return {metadata.block_number.value() + static_cast<uint32_t>(block_index << log2_size(kDataBlockType)),
             kDataBlockType,
@@ -147,7 +134,7 @@ FileDataBlockLocation FileDataBlockLocationForLogicalMetadata(const std::shared_
 
   const auto unit_index = data_block_index / Traits::kDataBlocksPerUnit;
   const auto block_index = data_block_index % Traits::kDataBlocksPerUnit;
-  return Traits::DataBlockLocationForUnit(metadata_block, std::ranges::begin(units)[unit_index], block_index);
+  return Traits::data_block_location_for_unit(metadata_block, std::ranges::begin(units)[unit_index], block_index);
 }
 
 template <FileLayoutCategory Category>

--- a/src/file_data_units.h
+++ b/src/file_data_units.h
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+
+#include "block.h"
+#include "file_layout.h"
+#include "structs.h"
+#include "utils.h"
+
+struct FileDataBlockLocation {
+  uint32_t block_number;
+  BlockType block_type;
+  Block::HashRef hash;
+};
+
+template <typename T>
+std::span<const T> EntryMetadataItems(const EntryMetadata* metadata, size_t count) {
+  const auto* metadata_bytes = reinterpret_cast<const std::byte*>(metadata);
+  const auto metadata_size = sizeof(T) * count;
+  const auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+  return {reinterpret_cast<const T*>(end - metadata_size), count};
+}
+
+template <typename T>
+std::span<T> MutableEntryMetadataItems(EntryMetadata* metadata, size_t count) {
+  auto* metadata_bytes = reinterpret_cast<std::byte*>(metadata);
+  const auto metadata_size = sizeof(T) * count;
+  auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+  return {reinterpret_cast<T*>(end - metadata_size), count};
+}
+
+template <FileLayoutCategory Category>
+struct FileDataUnitLayoutTraits;
+
+template <>
+struct FileDataUnitLayoutTraits<FileLayoutCategory::Blocks> {
+  using Metadata = DataBlockMetadata;
+
+  static constexpr BlockType kAllocationBlockType = BlockType::Single;
+  static constexpr BlockType kDataBlockType = BlockType::Single;
+  static constexpr size_t kDataBlocksPerUnit = 1;
+
+  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
+
+  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
+
+  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
+                                                        const Metadata& metadata,
+                                                        [[maybe_unused]] size_t block_index) {
+    assert(block_index == 0);
+    return {metadata.block_number.value(), kDataBlockType, {metadata_block, metadata_block->to_offset(metadata.hash)}};
+  }
+};
+
+template <>
+struct FileDataUnitLayoutTraits<FileLayoutCategory::LargeBlocks> {
+  using Metadata = DataBlockMetadata;
+
+  static constexpr BlockType kAllocationBlockType = BlockType::Large;
+  static constexpr BlockType kDataBlockType = BlockType::Large;
+  static constexpr size_t kDataBlocksPerUnit = 1;
+
+  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
+
+  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
+
+  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
+                                                        const Metadata& metadata,
+                                                        [[maybe_unused]] size_t block_index) {
+    assert(block_index == 0);
+    return {metadata.block_number.value(), kDataBlockType, {metadata_block, metadata_block->to_offset(metadata.hash)}};
+  }
+};
+
+template <>
+struct FileDataUnitLayoutTraits<FileLayoutCategory::Clusters> {
+  using Metadata = DataBlocksClusterMetadata;
+
+  static constexpr BlockType kAllocationBlockType = BlockType::Cluster;
+  static constexpr BlockType kDataBlockType = BlockType::Large;
+  static constexpr size_t kDataBlocksPerUnit = (size_t{1} << log2_size(BlockType::Cluster)) >>
+                                               log2_size(kDataBlockType);
+
+  static uint32_t UnitBlockNumber(const Metadata& metadata) { return metadata.block_number.value(); }
+
+  static void SetUnitBlockNumber(Metadata& metadata, uint32_t block_number) { metadata.block_number = block_number; }
+
+  static FileDataBlockLocation DataBlockLocationForUnit(const std::shared_ptr<Block>& metadata_block,
+                                                        const Metadata& metadata,
+                                                        size_t block_index) {
+    assert(block_index < kDataBlocksPerUnit);
+    return {metadata.block_number.value() + static_cast<uint32_t>(block_index << log2_size(kDataBlockType)),
+            kDataBlockType,
+            {metadata_block, metadata_block->to_offset(metadata.hash[block_index])}};
+  }
+};
+
+template <FileLayoutCategory Category>
+constexpr uint32_t FileDataUnitAreaBlocksCount() {
+  return uint32_t{1} << log2_size(FileDataUnitLayoutTraits<Category>::kAllocationBlockType);
+}
+
+template <FileLayoutCategory Category>
+size_t FileDataBlockLog2Size(uint8_t block_size_log2) {
+  return block_size_log2 + log2_size(FileDataUnitLayoutTraits<Category>::kDataBlockType);
+}
+
+template <FileLayoutCategory Category>
+auto FileDataUnitLogicalMetadataItems(const EntryMetadata* metadata, size_t count) {
+  using Metadata = typename FileDataUnitLayoutTraits<Category>::Metadata;
+  return EntryMetadataItems<Metadata>(metadata, count) | std::views::reverse;
+}
+
+template <FileLayoutCategory Category>
+auto FileDataUnitLogicalMetadataItemsForLayout(const EntryMetadata* metadata, uint8_t block_size_log2) {
+  return FileDataUnitLogicalMetadataItems<Category>(
+      metadata,
+      static_cast<size_t>(FileLayout::MetadataItemsCount(Category, metadata->size_on_disk.value(), block_size_log2)));
+}
+
+template <FileLayoutCategory Category>
+auto MutableFileDataUnitLogicalMetadataItems(EntryMetadata* metadata, size_t count) {
+  using Metadata = typename FileDataUnitLayoutTraits<Category>::Metadata;
+  return MutableEntryMetadataItems<Metadata>(metadata, count) | std::views::reverse;
+}
+
+template <FileLayoutCategory Category, std::ranges::random_access_range Units>
+FileDataBlockLocation FileDataBlockLocationForLogicalMetadata(const std::shared_ptr<Block>& metadata_block,
+                                                              Units&& units,
+                                                              size_t data_block_index) {
+  using Traits = FileDataUnitLayoutTraits<Category>;
+
+  const auto unit_index = data_block_index / Traits::kDataBlocksPerUnit;
+  const auto block_index = data_block_index % Traits::kDataBlocksPerUnit;
+  return Traits::DataBlockLocationForUnit(metadata_block, std::ranges::begin(units)[unit_index], block_index);
+}
+
+template <FileLayoutCategory Category>
+FileDataBlockLocation FileDataBlockLocationFor(const std::shared_ptr<Block>& metadata_block,
+                                               const EntryMetadata* metadata,
+                                               size_t data_block_index,
+                                               uint8_t block_size_log2) {
+  auto units = FileDataUnitLogicalMetadataItemsForLayout<Category>(metadata, block_size_log2);
+  return FileDataBlockLocationForLogicalMetadata<Category>(metadata_block, units, data_block_index);
+}
+
+inline FileDataBlockLocation FileDataBlockLocationFor(FileLayoutCategory category,
+                                                      const std::shared_ptr<Block>& metadata_block,
+                                                      const EntryMetadata* metadata,
+                                                      size_t data_block_index,
+                                                      uint8_t block_size_log2) {
+  switch (category) {
+    case FileLayoutCategory::Blocks:
+      return FileDataBlockLocationFor<FileLayoutCategory::Blocks>(metadata_block, metadata, data_block_index,
+                                                                  block_size_log2);
+    case FileLayoutCategory::LargeBlocks:
+      return FileDataBlockLocationFor<FileLayoutCategory::LargeBlocks>(metadata_block, metadata, data_block_index,
+                                                                       block_size_log2);
+    case FileLayoutCategory::Clusters:
+      return FileDataBlockLocationFor<FileLayoutCategory::Clusters>(metadata_block, metadata, data_block_index,
+                                                                    block_size_log2);
+    case FileLayoutCategory::Inline:
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  throw std::invalid_argument("File layout category does not store data-unit metadata in entry metadata");
+}

--- a/src/file_data_units.h
+++ b/src/file_data_units.h
@@ -121,6 +121,8 @@ size_t FileDataBlockLog2Size(uint8_t block_size_log2) {
 template <FileLayoutCategory Category>
 auto FileDataUnitLogicalMetadataItems(const EntryMetadata* metadata, size_t count) {
   using Metadata = typename FileDataUnitLayoutTraits<Category>::Metadata;
+  // WFS stores data-unit metadata from the end of the entry allocation backwards. Expose it in file-offset order so
+  // callers can index by logical unit number.
   return EntryMetadataItems<Metadata>(metadata, count) | std::views::reverse;
 }
 

--- a/src/file_layout.cpp
+++ b/src/file_layout.cpp
@@ -151,6 +151,7 @@ FileLayoutCategory MaximumCategory(uint32_t file_size, uint8_t filename_length, 
     return FileLayoutCategory::Blocks;
   return FileLayoutCategory::Inline;
 }
+
 }  // namespace
 
 size_t FileLayout::BaseMetadataSize(uint8_t filename_length) {

--- a/src/file_layout_accessor.cpp
+++ b/src/file_layout_accessor.cpp
@@ -157,6 +157,8 @@ class File::BlockListLayoutAccessor : public File::LayoutAccessor {
   }
 
   void LoadDataBlock(uint32_t block_number, uint32_t data_size, Block::HashRef data_hash) {
+    // Resize detaches stale cached blocks; reusing them would route later writes into an object that can no longer
+    // flush to disk.
     if (current_data_block && !current_data_block->detached() &&
         file_->quota()->to_area_block_number(current_data_block->physical_block_number()) == block_number)
       return;

--- a/src/file_layout_accessor.cpp
+++ b/src/file_layout_accessor.cpp
@@ -157,7 +157,7 @@ class File::BlockListLayoutAccessor : public File::LayoutAccessor {
   }
 
   void LoadDataBlock(uint32_t block_number, uint32_t data_size, Block::HashRef data_hash) {
-    if (current_data_block &&
+    if (current_data_block && !current_data_block->detached() &&
         file_->quota()->to_area_block_number(current_data_block->physical_block_number()) == block_number)
       return;
     auto block = file_->quota()->LoadDataBlock(block_number, static_cast<BlockSize>(file_->quota()->block_size_log2()),

--- a/src/file_layout_accessor.cpp
+++ b/src/file_layout_accessor.cpp
@@ -12,6 +12,14 @@
 #include <iterator>
 #include <stdexcept>
 
+#include "file_data_units.h"
+
+namespace {
+FileLayoutCategory CurrentCategory(const EntryMetadata* metadata) {
+  return FileLayout::CategoryFromValue(metadata->size_category.value());
+}
+}  // namespace
+
 // Category 0 - File data is in the attribute metadata (limited to 512 bytes minus attribute size) (no minumum)
 class File::InlineLayoutAccessor : public File::LayoutAccessor {
  public:
@@ -72,12 +80,13 @@ class File::BlockListLayoutAccessor : public File::LayoutAccessor {
   }
 
   virtual DataRef GetDataRef(size_t offset, size_t size, size_t file_size) {
-    auto blocks_list = DataBlockRefs();
     auto block_position = BlockPositionForOffset(offset, GetDataBlockSize());
+    auto location =
+        FileDataBlockLocationFor(CurrentCategory(file_->metadata()), file_->metadata_block(), file_->metadata(),
+                                 block_position.index, file_->quota()->block_size_log2());
     auto block_ref =
-        DataBlockRef{blocks_list[block_position.index].block_number.value(), GetDataBlockType(), block_position.offset,
-                     DataSizeForBlock(file_size, block_position.offset, GetDataBlockSize()),
-                     HashRef(file_->metadata_block(), blocks_list[block_position.index].hash)};
+        DataBlockRef{location.block_number, location.block_type, block_position.offset,
+                     DataSizeForBlock(file_size, block_position.offset, GetDataBlockSize()), std::move(location.hash)};
     return GetDataFromBlock(std::move(block_ref), block_position.offset_in_block, size);
   }
 
@@ -208,15 +217,13 @@ class File::ClustersLayoutAccessor : public File::LargeBlocksLayoutAccessor {
                                      const std::shared_ptr<Block>& metadata_block,
                                      ClusterArray&& clusters_list) {
     auto offset_in_cluster_list = offset - (cluster_list_start << ClusterDataLog2Size());
-    auto [cluster_index, offset_in_cluster] = div_pow2(offset_in_cluster_list, ClusterDataLog2Size());
-    auto block_position = BlockPositionForOffset(offset_in_cluster, GetDataBlockSize());
+    auto block_position = BlockPositionForOffset(offset_in_cluster_list, GetDataBlockSize());
     auto block_offset = floor_pow2(offset, GetDataBlockSize());
-    return GetDataFromBlock(
-        {clusters_list[cluster_index].block_number.value() +
-             static_cast<uint32_t>(block_position.index << log2_size(GetDataBlockType())),
-         GetDataBlockType(), block_offset, DataSizeForBlock(file_size, block_offset, GetDataBlockSize()),
-         HashRef(metadata_block, clusters_list[cluster_index].hash[block_position.index])},
-        block_position.offset_in_block, size);
+    auto location = FileDataBlockLocationForLogicalMetadata<FileLayoutCategory::Clusters>(metadata_block, clusters_list,
+                                                                                          block_position.index);
+    return GetDataFromBlock({location.block_number, location.block_type, block_offset,
+                             DataSizeForBlock(file_size, block_offset, GetDataBlockSize()), std::move(location.hash)},
+                            block_position.offset_in_block, size);
   }
 
   template <typename ClusterArray>
@@ -227,20 +234,15 @@ class File::ClustersLayoutAccessor : public File::LargeBlocksLayoutAccessor {
     std::vector<DataBlockRef> refs;
     refs.reserve(clusters_list.size() * (size_t{1} << log2_size(BlockType::Cluster) >> log2_size(GetDataBlockType())));
 
-    size_t cluster_offset = cluster_list_start << ClusterDataLog2Size();
-    for (const auto& cluster : clusters_list) {
-      if (cluster_offset >= size)
-        break;
-      for (size_t block_index = 0; block_index < std::size(cluster.hash); ++block_index) {
-        auto block_offset = cluster_offset + (block_index << GetDataBlockSize());
-        if (block_offset >= size)
-          break;
-        refs.push_back(
-            {cluster.block_number.value() + static_cast<uint32_t>(block_index << log2_size(GetDataBlockType())),
-             GetDataBlockType(), block_offset, DataSizeForBlock(size, block_offset, GetDataBlockSize()),
-             HashRef(metadata_block, cluster.hash[block_index])});
-      }
-      cluster_offset += size_t{1} << ClusterDataLog2Size();
+    size_t block_offset = cluster_list_start << ClusterDataLog2Size();
+    const auto data_blocks_count =
+        std::ranges::size(clusters_list) * FileDataUnitLayoutTraits<FileLayoutCategory::Clusters>::kDataBlocksPerUnit;
+    for (size_t data_block_index = 0; data_block_index < data_blocks_count && block_offset < size; ++data_block_index) {
+      auto location = FileDataBlockLocationForLogicalMetadata<FileLayoutCategory::Clusters>(
+          metadata_block, clusters_list, data_block_index);
+      refs.push_back({location.block_number, location.block_type, block_offset,
+                      DataSizeForBlock(size, block_offset, GetDataBlockSize()), std::move(location.hash)});
+      block_offset += size_t{1} << GetDataBlockSize();
     }
 
     return refs;

--- a/src/file_layout_accessor.h
+++ b/src/file_layout_accessor.h
@@ -19,28 +19,22 @@
 #include <vector>
 
 #include "block.h"
+#include "file_data_units.h"
 #include "file_layout.h"
 #include "quota_area.h"
 #include "structs.h"
 
 class File::LayoutAccessor {
-  template <typename T, bool AlignToEnd = false>
+  template <typename T>
   auto Metadata() const {
     const auto count = GetMetadataItemsCount();
-    const auto file_metadata_size = sizeof(T) * count;
     const auto base_metadata_size = file_->metadata()->size();
-    auto* metadata = [&]() {
-      if constexpr (std::is_const_v<T>) {
-        return reinterpret_cast<const std::byte*>(file_->metadata());
-      } else {
-        return reinterpret_cast<std::byte*>(file_->mutable_metadata());
-      }
-    }();
-    if constexpr (AlignToEnd) {
-      auto* end = metadata + align_to_power_of_2(base_metadata_size + file_metadata_size);
-      return std::span<T>{reinterpret_cast<T*>(end - file_metadata_size), count} | std::views::reverse;
+    if constexpr (std::is_const_v<T>) {
+      return std::span<T>{
+          reinterpret_cast<T*>(reinterpret_cast<const std::byte*>(file_->metadata()) + base_metadata_size), count};
     } else {
-      return std::span<T>{reinterpret_cast<T*>(metadata + base_metadata_size), count};
+      return std::span<T>{
+          reinterpret_cast<T*>(reinterpret_cast<std::byte*>(file_->mutable_metadata()) + base_metadata_size), count};
     }
   }
 
@@ -126,12 +120,28 @@ class File::LayoutAccessor {
  protected:
   auto InlinePayload() const { return Metadata<const std::byte>(); }
   auto MutableInlinePayload() const { return Metadata<std::byte>(); }
-  auto DataBlockRefs() const { return Metadata<const DataBlockMetadata, true>(); }
-  auto MutableDataBlockRefs() const { return Metadata<DataBlockMetadata, true>(); }
-  auto ClusterRefs() const { return Metadata<const DataBlocksClusterMetadata, true>(); }
-  auto MutableClusterRefs() const { return Metadata<DataBlocksClusterMetadata, true>(); }
-  auto ClusterMetadataBlockRefs() const { return Metadata<const uint32_be_t, true>(); }
-  auto MutableClusterMetadataBlockRefs() const { return Metadata<uint32_be_t, true>(); }
+  auto DataBlockRefs() const {
+    return EntryMetadataItems<DataBlockMetadata>(file_->metadata(), GetMetadataItemsCount()) | std::views::reverse;
+  }
+  auto MutableDataBlockRefs() const {
+    return MutableEntryMetadataItems<DataBlockMetadata>(file_->mutable_metadata(), GetMetadataItemsCount()) |
+           std::views::reverse;
+  }
+  auto ClusterRefs() const {
+    return EntryMetadataItems<DataBlocksClusterMetadata>(file_->metadata(), GetMetadataItemsCount()) |
+           std::views::reverse;
+  }
+  auto MutableClusterRefs() const {
+    return MutableEntryMetadataItems<DataBlocksClusterMetadata>(file_->mutable_metadata(), GetMetadataItemsCount()) |
+           std::views::reverse;
+  }
+  auto ClusterMetadataBlockRefs() const {
+    return EntryMetadataItems<uint32_be_t>(file_->metadata(), GetMetadataItemsCount()) | std::views::reverse;
+  }
+  auto MutableClusterMetadataBlockRefs() const {
+    return MutableEntryMetadataItems<uint32_be_t>(file_->mutable_metadata(), GetMetadataItemsCount()) |
+           std::views::reverse;
+  }
 
   BlockPosition BlockPositionForOffset(size_t offset, size_t log2_block_size) const {
     auto [index, offset_in_block] = div_pow2(offset, log2_block_size);

--- a/src/file_resizer.cpp
+++ b/src/file_resizer.cpp
@@ -13,7 +13,6 @@
 #include <span>
 #include <stdexcept>
 #include <utility>
-#include <vector>
 
 #include "directory_map.h"
 #include "errors.h"
@@ -21,7 +20,7 @@
 #include "quota_area.h"
 
 namespace {
-FileLayoutCategory Category(const EntryMetadata* metadata) {
+FileLayoutCategory CurrentCategory(const EntryMetadata* metadata) {
   return FileLayout::CategoryFromValue(metadata->size_category.value());
 }
 
@@ -33,10 +32,28 @@ std::span<std::byte> InlinePayload(EntryMetadata* metadata) {
   return {reinterpret_cast<std::byte*>(metadata) + metadata->size(), metadata->size_on_disk.value()};
 }
 
-[[noreturn]] void ThrowNonInlineResizeUnimplemented() {
-  throw std::logic_error("File resize for non-inline layouts is not implemented");
+[[noreturn]] void ThrowResizeUnimplemented() {
+  throw std::logic_error("File resize for this layout transition is not implemented");
 }
 }  // namespace
+
+EntryMetadataReplacement::EntryMetadataReplacement(const EntryMetadata* source, const FileLayout& layout)
+    : storage_(size_t{1} << layout.metadata_log2_size, std::byte{0}) {
+  auto* metadata = get();
+  std::memcpy(metadata, source, source->size());
+  metadata->file_size = layout.file_size;
+  metadata->size_on_disk = layout.size_on_disk;
+  metadata->metadata_log2_size = layout.metadata_log2_size;
+  metadata->size_category = FileLayout::CategoryValue(layout.category);
+}
+
+EntryMetadata* EntryMetadataReplacement::get() {
+  return reinterpret_cast<EntryMetadata*>(storage_.data());
+}
+
+const EntryMetadata* EntryMetadataReplacement::get() const {
+  return reinterpret_cast<const EntryMetadata*>(storage_.data());
+}
 
 FileResizer::FileResizer(std::shared_ptr<File> file) : file_(std::move(file)) {}
 
@@ -53,34 +70,48 @@ void FileResizer::Resize(size_t new_size) {
   const auto mode = target_size > old_size ? FileLayoutMode::MinimumForGrow : FileLayoutMode::MaximumForShrink;
   const auto target_layout =
       FileLayout::Calculate(target_size, metadata->filename_length.value(), file_->quota()->block_size_log2(), mode);
+  const auto current_category = CurrentCategory(metadata);
 
-  if (Category(metadata) != FileLayoutCategory::Inline || target_layout.category != FileLayoutCategory::Inline)
-    ThrowNonInlineResizeUnimplemented();
+  if (target_layout.category != current_category)
+    ThrowResizeUnimplemented();
 
-  ResizeInline(target_layout);
+  switch (target_layout.category) {
+    case FileLayoutCategory::Inline:
+      ResizeInline(target_layout);
+      return;
+    case FileLayoutCategory::Blocks:
+      ResizeDataUnitLayout<FileLayoutCategory::Blocks>(target_layout);
+      return;
+    case FileLayoutCategory::LargeBlocks:
+      ResizeDataUnitLayout<FileLayoutCategory::LargeBlocks>(target_layout);
+      return;
+    case FileLayoutCategory::Clusters:
+      ResizeDataUnitLayout<FileLayoutCategory::Clusters>(target_layout);
+      return;
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+
+  ThrowResizeUnimplemented();
 }
 
 void FileResizer::ResizeInline(const FileLayout& target_layout) {
   const auto* metadata = file_->metadata();
-  const auto allocation_size = size_t{1} << target_layout.metadata_log2_size;
-  std::vector<std::byte> replacement_storage(allocation_size, std::byte{0});
-  auto* replacement_metadata = reinterpret_cast<EntryMetadata*>(replacement_storage.data());
-
-  std::memcpy(replacement_metadata, metadata, metadata->size());
-  replacement_metadata->file_size = target_layout.file_size;
-  replacement_metadata->size_on_disk = target_layout.size_on_disk;
-  replacement_metadata->metadata_log2_size = target_layout.metadata_log2_size;
-  replacement_metadata->size_category = FileLayout::CategoryValue(target_layout.category);
+  EntryMetadataReplacement replacement(metadata, target_layout);
 
   const auto bytes_to_preserve = std::min(metadata->file_size.value(), target_layout.file_size);
   if (bytes_to_preserve != 0)
-    std::memcpy(InlinePayload(replacement_metadata).data(), InlinePayload(metadata).data(), bytes_to_preserve);
+    std::memcpy(InlinePayload(replacement.get()).data(), InlinePayload(metadata).data(), bytes_to_preserve);
 
+  ReplaceMetadata(replacement.get());
+}
+
+void FileResizer::ReplaceMetadata(EntryMetadata* metadata) {
   const auto& directory_map = file_->handle_->directory_map();
   if (!directory_map)
     throw std::logic_error("File metadata is not attached to a directory entry");
 
-  auto result = directory_map->replace_metadata(file_->handle_->key(), replacement_metadata);
+  auto result = directory_map->replace_metadata(file_->handle_->key(), metadata);
   if (!result.has_value())
     throw WfsException(result.error());
 }

--- a/src/file_resizer.h
+++ b/src/file_resizer.h
@@ -9,9 +9,21 @@
 
 #include <cstddef>
 #include <memory>
+#include <vector>
 
 #include "file.h"
 #include "file_layout.h"
+
+class EntryMetadataReplacement {
+ public:
+  EntryMetadataReplacement(const EntryMetadata* source, const FileLayout& layout);
+
+  EntryMetadata* get();
+  const EntryMetadata* get() const;
+
+ private:
+  std::vector<std::byte> storage_;
+};
 
 class FileResizer {
  public:
@@ -21,6 +33,10 @@ class FileResizer {
 
  private:
   void ResizeInline(const FileLayout& target_layout);
+  void ReplaceMetadata(EntryMetadata* metadata);
+
+  template <FileLayoutCategory Category>
+  void ResizeDataUnitLayout(const FileLayout& target_layout);
 
   std::shared_ptr<File> file_;
 };

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -116,20 +116,24 @@ std::shared_ptr<Block> LoadResizableDataBlock(const std::shared_ptr<QuotaArea>& 
 }
 
 template <FileLayoutCategory Category>
-void FlushAndDetachCachedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
-                                    const std::shared_ptr<Block>& metadata_block,
-                                    EntryMetadata* metadata,
-                                    const FileLayout& layout,
-                                    bool encrypted,
-                                    uint8_t block_size_log2) {
+void DetachOldDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                         const std::shared_ptr<Block>& metadata_block,
+                         EntryMetadata* metadata,
+                         const FileLayout& old_layout,
+                         const FileLayout& target_layout,
+                         bool encrypted,
+                         uint8_t block_size_log2) {
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
-  const auto data_blocks_count = div_ceil(layout.file_size, uint32_t{1} << data_block_log2_size);
+  const auto data_blocks_count = div_ceil(old_layout.file_size, uint32_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
     const auto block_offset = data_block_index << data_block_log2_size;
-    const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
+    const auto data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);
+    const auto target_data_size = UsedDataBlockSize(target_layout.file_size, block_offset, data_block_log2_size);
     auto data_block = LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index, data_size,
                                                        encrypted, /*new_block=*/true, block_size_log2);
-    data_block->Flush();
+    // Dropped blocks follow truncate semantics; only retained bytes need current hashes copied to replacement metadata.
+    if (target_data_size != 0)
+      data_block->Flush();
     data_block->Detach();
   }
 }
@@ -186,8 +190,8 @@ void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
   const auto old_layout = CurrentLayout<Category>(metadata, block_size_log2);
   const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
 
-  FlushAndDetachCachedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(),
-                                           old_layout, encrypted, block_size_log2);
+  DetachOldDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
+                                target_layout, encrypted, block_size_log2);
 
   const auto old_metadata = LogicalMetadata<Category>(metadata, old_layout.data_units_count);
   const auto allocated_units_count = target_layout.data_units_count > old_layout.data_units_count

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -116,20 +116,21 @@ std::shared_ptr<Block> LoadResizableDataBlock(const std::shared_ptr<QuotaArea>& 
 }
 
 template <FileLayoutCategory Category>
-void DetachCachedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
-                            const std::shared_ptr<Block>& metadata_block,
-                            EntryMetadata* metadata,
-                            const FileLayout& layout,
-                            bool encrypted,
-                            uint8_t block_size_log2) {
+void FlushAndDetachCachedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                                    const std::shared_ptr<Block>& metadata_block,
+                                    EntryMetadata* metadata,
+                                    const FileLayout& layout,
+                                    bool encrypted,
+                                    uint8_t block_size_log2) {
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
   const auto data_blocks_count = div_ceil(layout.file_size, uint32_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
     const auto block_offset = data_block_index << data_block_log2_size;
     const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
-    LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index, data_size, encrypted,
-                                     /*new_block=*/true, block_size_log2)
-        ->Detach();
+    auto data_block = LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index, data_size,
+                                                       encrypted, /*new_block=*/true, block_size_log2);
+    data_block->Flush();
+    data_block->Detach();
   }
 }
 
@@ -183,20 +184,21 @@ void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
 
   const auto block_size_log2 = file_->quota()->block_size_log2();
   const auto old_layout = CurrentLayout<Category>(metadata, block_size_log2);
+  const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
+
+  FlushAndDetachCachedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(),
+                                           old_layout, encrypted, block_size_log2);
+
+  const auto old_metadata = LogicalMetadata<Category>(metadata, old_layout.data_units_count);
   const auto allocated_units_count = target_layout.data_units_count > old_layout.data_units_count
                                          ? target_layout.data_units_count - old_layout.data_units_count
                                          : 0;
   AllocatedDataUnits<Category> allocated_units(file_->quota(), allocated_units_count);
   EntryMetadataReplacement replacement(metadata, target_layout);
 
-  const auto old_metadata = LogicalMetadata<Category>(metadata, old_layout.data_units_count);
   const auto replacement_metadata = BuildReplacementUnitMetadata<Category>(old_metadata, target_layout.data_units_count,
                                                                            allocated_units.block_numbers());
   StoreLogicalMetadata<Category>(replacement.get(), replacement_metadata);
-
-  const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
-  DetachCachedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
-                                   encrypted, block_size_log2);
 
   ReplaceMetadata(replacement.get());
   allocated_units.release();

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -104,7 +104,7 @@ std::vector<typename FileDataUnitLayoutTraits<Category>::Metadata> BuildReplacem
 
   auto appended_metadata = replacement_metadata | std::views::drop(old_metadata.size());
   for (auto&& [metadata, block_number] : std::views::zip(appended_metadata, allocated_block_numbers))
-    Traits::SetUnitBlockNumber(metadata, block_number);
+    Traits::set_unit_block_number(metadata, block_number);
 
   return replacement_metadata;
 }
@@ -219,7 +219,7 @@ void FreeRemovedDataUnits(const std::shared_ptr<QuotaArea>& quota,
   using Traits = FileDataUnitLayoutTraits<Category>;
 
   for (const auto& metadata : old_metadata | std::views::drop(target_units_count)) {
-    if (!quota->DeleteBlocks(Traits::UnitBlockNumber(metadata), FileDataUnitAreaBlocksCount<Category>()))
+    if (!quota->DeleteBlocks(Traits::unit_block_number(metadata), FileDataUnitAreaBlocksCount<Category>()))
       throw WfsException(WfsError::kFreeBlocksAllocatorCorrupted);
   }
 }

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -26,6 +26,8 @@ namespace {
 }
 
 struct DataBlockCacheRef {
+  // Old-cache identity captured before metadata replacement. Hash refs are intentionally omitted; post-commit detach
+  // should only evict stale cached blocks, not flush through old hash locations.
   uint32_t block_number;
   BlockType block_type;
   uint32_t data_size;
@@ -48,6 +50,7 @@ class AllocatedDataUnits {
                                         FileDataUnitLayoutTraits<Category>::kAllocationBlockType))) {}
 
   ~AllocatedDataUnits() {
+    // Until metadata replacement succeeds, newly allocated data units are rollback state.
     if (!released_) {
       for (const auto block_number : block_numbers_)
         quota_->DeleteBlocks(block_number, FileDataUnitAreaBlocksCount<Category>());
@@ -149,6 +152,8 @@ void FlushRetainedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
                              const FileLayout& target_layout,
                              bool encrypted,
                              uint8_t block_size_log2) {
+  // Before the commit point, only retained blocks are flushed. Dropped blocks must stay attached because a failed
+  // metadata replacement leaves the old layout authoritative.
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
   const auto data_blocks_count = div_ceil(old_layout.file_size, size_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
@@ -168,6 +173,8 @@ void DetachDataBlocks(const std::shared_ptr<QuotaArea>& quota,
                       std::span<const DataBlockCacheRef> refs,
                       bool encrypted,
                       uint8_t block_size_log2) {
+  // After metadata replacement, cached blocks still point at old hash refs and may have obsolete used sizes. Load
+  // cache entries without touching disk so every old block object is detached and future I/O reloads from new metadata.
   for (const auto& ref : refs) {
     auto data_block =
         throw_if_error(quota->LoadDataBlock(ref.block_number, static_cast<BlockSize>(block_size_log2), ref.block_type,
@@ -244,6 +251,7 @@ void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
                                                                            allocated_units.block_numbers());
   StoreLogicalMetadata<Category>(replacement.get(), replacement_metadata);
 
+  // Commit point: after this succeeds, the replacement metadata is authoritative and old caches/units can be dropped.
   ReplaceMetadata(replacement.get());
   allocated_units.release();
 

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -124,7 +124,7 @@ void DetachOldDataBlocks(const std::shared_ptr<QuotaArea>& quota,
                          bool encrypted,
                          uint8_t block_size_log2) {
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
-  const auto data_blocks_count = div_ceil(old_layout.file_size, uint32_t{1} << data_block_log2_size);
+  const auto data_blocks_count = div_ceil(old_layout.file_size, size_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
     const auto block_offset = data_block_index << data_block_log2_size;
     const auto data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);
@@ -148,7 +148,7 @@ void ResizeChangedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
                              uint8_t block_size_log2) {
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
   const auto data_blocks_count =
-      div_ceil(std::max(old_layout.file_size, target_layout.file_size), uint32_t{1} << data_block_log2_size);
+      div_ceil(std::max(old_layout.file_size, target_layout.file_size), size_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
     const auto block_offset = data_block_index << data_block_log2_size;
     const auto old_data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -25,6 +25,12 @@ namespace {
   return FileLayout::CategoryFromValue(metadata->size_category.value());
 }
 
+struct DataBlockCacheRef {
+  uint32_t block_number;
+  BlockType block_type;
+  uint32_t data_size;
+};
+
 uint32_t UsedDataBlockSize(uint32_t file_size, size_t block_offset, size_t log2_block_size) {
   if (file_size <= block_offset)
     return 0;
@@ -116,24 +122,56 @@ std::shared_ptr<Block> LoadResizableDataBlock(const std::shared_ptr<QuotaArea>& 
 }
 
 template <FileLayoutCategory Category>
-void DetachOldDataBlocks(const std::shared_ptr<QuotaArea>& quota,
-                         const std::shared_ptr<Block>& metadata_block,
-                         EntryMetadata* metadata,
-                         const FileLayout& old_layout,
-                         const FileLayout& target_layout,
-                         bool encrypted,
-                         uint8_t block_size_log2) {
+std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& metadata_block,
+                                                  const EntryMetadata* metadata,
+                                                  const FileLayout& layout,
+                                                  uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
+  const auto data_blocks_count = div_ceil(layout.file_size, size_t{1} << data_block_log2_size);
+  std::vector<DataBlockCacheRef> refs;
+  refs.reserve(data_blocks_count);
+
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
+    auto location = FileDataBlockLocationFor<Category>(metadata_block, metadata, data_block_index, block_size_log2);
+    refs.push_back({location.block_number, location.block_type, data_size});
+  }
+
+  return refs;
+}
+
+template <FileLayoutCategory Category>
+void FlushRetainedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                             const std::shared_ptr<Block>& metadata_block,
+                             EntryMetadata* metadata,
+                             const FileLayout& old_layout,
+                             const FileLayout& target_layout,
+                             bool encrypted,
+                             uint8_t block_size_log2) {
   const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
   const auto data_blocks_count = div_ceil(old_layout.file_size, size_t{1} << data_block_log2_size);
   for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
     const auto block_offset = data_block_index << data_block_log2_size;
-    const auto data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);
     const auto target_data_size = UsedDataBlockSize(target_layout.file_size, block_offset, data_block_log2_size);
+    if (target_data_size == 0)
+      continue;
+
+    const auto data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);
     auto data_block = LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index, data_size,
-                                                       encrypted, /*new_block=*/true, block_size_log2);
-    // Dropped blocks follow truncate semantics; only retained bytes need current hashes copied to replacement metadata.
-    if (target_data_size != 0)
-      data_block->Flush();
+                                                       encrypted, /*new_block=*/false, block_size_log2);
+    data_block->Flush();
+  }
+}
+
+void DetachDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                      std::span<const DataBlockCacheRef> refs,
+                      bool encrypted,
+                      uint8_t block_size_log2) {
+  for (const auto& ref : refs) {
+    auto data_block =
+        throw_if_error(quota->LoadDataBlock(ref.block_number, static_cast<BlockSize>(block_size_log2), ref.block_type,
+                                            ref.data_size, Block::HashRef{}, encrypted, /*new_block=*/true));
     data_block->Detach();
   }
 }
@@ -190,8 +228,10 @@ void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
   const auto old_layout = CurrentLayout<Category>(metadata, block_size_log2);
   const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
 
-  DetachOldDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
-                                target_layout, encrypted, block_size_log2);
+  const auto old_data_blocks =
+      DataBlockCacheRefs<Category>(file_->metadata_block(), metadata, old_layout, block_size_log2);
+  FlushRetainedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
+                                    target_layout, encrypted, block_size_log2);
 
   const auto old_metadata = LogicalMetadata<Category>(metadata, old_layout.data_units_count);
   const auto allocated_units_count = target_layout.data_units_count > old_layout.data_units_count
@@ -207,6 +247,7 @@ void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
   ReplaceMetadata(replacement.get());
   allocated_units.release();
 
+  DetachDataBlocks(file_->quota(), old_data_blocks, encrypted, block_size_log2);
   ResizeChangedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
                                     target_layout, encrypted, block_size_log2);
   FreeRemovedDataUnits<Category>(file_->quota(), old_metadata, target_layout.data_units_count);

--- a/src/file_resizer_data_units.cpp
+++ b/src/file_resizer_data_units.cpp
@@ -1,0 +1,211 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "file_resizer.h"
+
+#include <algorithm>
+#include <cassert>
+#include <ranges>
+#include <span>
+#include <utility>
+#include <vector>
+
+#include "block.h"
+#include "errors.h"
+#include "file_data_units.h"
+#include "quota_area.h"
+#include "utils.h"
+
+namespace {
+[[maybe_unused]] FileLayoutCategory CurrentCategory(const EntryMetadata* metadata) {
+  return FileLayout::CategoryFromValue(metadata->size_category.value());
+}
+
+uint32_t UsedDataBlockSize(uint32_t file_size, size_t block_offset, size_t log2_block_size) {
+  if (file_size <= block_offset)
+    return 0;
+  return static_cast<uint32_t>(std::min(size_t{1} << log2_block_size, size_t{file_size} - block_offset));
+}
+
+template <FileLayoutCategory Category>
+class AllocatedDataUnits {
+ public:
+  AllocatedDataUnits(std::shared_ptr<QuotaArea> quota, uint32_t count)
+      : quota_(std::move(quota)),
+        block_numbers_(count == 0 ? std::vector<uint32_t>{}
+                                  : throw_if_error(quota_->AllocDataBlocks(
+                                        count,
+                                        FileDataUnitLayoutTraits<Category>::kAllocationBlockType))) {}
+
+  ~AllocatedDataUnits() {
+    if (!released_) {
+      for (const auto block_number : block_numbers_)
+        quota_->DeleteBlocks(block_number, FileDataUnitAreaBlocksCount<Category>());
+    }
+  }
+
+  const std::vector<uint32_t>& block_numbers() const { return block_numbers_; }
+
+  void release() { released_ = true; }
+
+ private:
+  std::shared_ptr<QuotaArea> quota_;
+  std::vector<uint32_t> block_numbers_;
+  bool released_{false};
+};
+
+template <FileLayoutCategory Category>
+FileLayout CurrentLayout(const EntryMetadata* metadata, uint8_t block_size_log2) {
+  return FileLayout{
+      .category = Category,
+      .metadata_log2_size = metadata->metadata_log2_size.value(),
+      .file_size = metadata->file_size.value(),
+      .size_on_disk = metadata->size_on_disk.value(),
+      .data_units_count = FileLayout::DataUnitsCount(Category, metadata->size_on_disk.value(), block_size_log2),
+  };
+}
+
+template <FileLayoutCategory Category>
+std::vector<typename FileDataUnitLayoutTraits<Category>::Metadata> LogicalMetadata(const EntryMetadata* metadata,
+                                                                                   size_t count) {
+  using Metadata = typename FileDataUnitLayoutTraits<Category>::Metadata;
+  return FileDataUnitLogicalMetadataItems<Category>(metadata, count) | std::ranges::to<std::vector<Metadata>>();
+}
+
+template <FileLayoutCategory Category>
+void StoreLogicalMetadata(EntryMetadata* metadata,
+                          std::span<const typename FileDataUnitLayoutTraits<Category>::Metadata> logical_metadata) {
+  auto stored_metadata = MutableFileDataUnitLogicalMetadataItems<Category>(metadata, logical_metadata.size());
+  std::ranges::copy(logical_metadata, stored_metadata.begin());
+}
+
+template <FileLayoutCategory Category>
+std::vector<typename FileDataUnitLayoutTraits<Category>::Metadata> BuildReplacementUnitMetadata(
+    const std::vector<typename FileDataUnitLayoutTraits<Category>::Metadata>& old_metadata,
+    uint32_t target_units_count,
+    const std::vector<uint32_t>& allocated_block_numbers) {
+  using Traits = FileDataUnitLayoutTraits<Category>;
+
+  auto replacement_metadata = old_metadata;
+  replacement_metadata.resize(target_units_count);
+
+  auto appended_metadata = replacement_metadata | std::views::drop(old_metadata.size());
+  for (auto&& [metadata, block_number] : std::views::zip(appended_metadata, allocated_block_numbers))
+    Traits::SetUnitBlockNumber(metadata, block_number);
+
+  return replacement_metadata;
+}
+
+template <FileLayoutCategory Category>
+std::shared_ptr<Block> LoadResizableDataBlock(const std::shared_ptr<QuotaArea>& quota,
+                                              const std::shared_ptr<Block>& metadata_block,
+                                              EntryMetadata* metadata,
+                                              size_t data_block_index,
+                                              uint32_t data_size,
+                                              bool encrypted,
+                                              bool new_block,
+                                              uint8_t block_size_log2) {
+  auto location = FileDataBlockLocationFor<Category>(metadata_block, metadata, data_block_index, block_size_log2);
+  return throw_if_error(quota->LoadDataBlock(location.block_number, static_cast<BlockSize>(block_size_log2),
+                                             location.block_type, data_size, std::move(location.hash), encrypted,
+                                             new_block));
+}
+
+template <FileLayoutCategory Category>
+void DetachCachedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                            const std::shared_ptr<Block>& metadata_block,
+                            EntryMetadata* metadata,
+                            const FileLayout& layout,
+                            bool encrypted,
+                            uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
+  const auto data_blocks_count = div_ceil(layout.file_size, uint32_t{1} << data_block_log2_size);
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
+    LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index, data_size, encrypted,
+                                     /*new_block=*/true, block_size_log2)
+        ->Detach();
+  }
+}
+
+template <FileLayoutCategory Category>
+void ResizeChangedDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                             const std::shared_ptr<Block>& metadata_block,
+                             EntryMetadata* metadata,
+                             const FileLayout& old_layout,
+                             const FileLayout& target_layout,
+                             bool encrypted,
+                             uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
+  const auto data_blocks_count =
+      div_ceil(std::max(old_layout.file_size, target_layout.file_size), uint32_t{1} << data_block_log2_size);
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto old_data_size = UsedDataBlockSize(old_layout.file_size, block_offset, data_block_log2_size);
+    const auto new_data_size = UsedDataBlockSize(target_layout.file_size, block_offset, data_block_log2_size);
+    if (old_data_size == new_data_size || new_data_size == 0)
+      continue;
+
+    auto data_block = LoadResizableDataBlock<Category>(quota, metadata_block, metadata, data_block_index,
+                                                       old_data_size == 0 ? new_data_size : old_data_size, encrypted,
+                                                       /*new_block=*/old_data_size == 0, block_size_log2);
+    if (old_data_size == 0) {
+      std::ranges::fill(data_block->mutable_data(), std::byte{0});
+    } else {
+      data_block->Resize(new_data_size);
+    }
+  }
+}
+
+template <FileLayoutCategory Category>
+void FreeRemovedDataUnits(const std::shared_ptr<QuotaArea>& quota,
+                          std::span<const typename FileDataUnitLayoutTraits<Category>::Metadata> old_metadata,
+                          uint32_t target_units_count) {
+  using Traits = FileDataUnitLayoutTraits<Category>;
+
+  for (const auto& metadata : old_metadata | std::views::drop(target_units_count)) {
+    if (!quota->DeleteBlocks(Traits::UnitBlockNumber(metadata), FileDataUnitAreaBlocksCount<Category>()))
+      throw WfsException(WfsError::kFreeBlocksAllocatorCorrupted);
+  }
+}
+}  // namespace
+
+template <FileLayoutCategory Category>
+void FileResizer::ResizeDataUnitLayout(const FileLayout& target_layout) {
+  const auto* metadata = file_->metadata();
+  assert(CurrentCategory(metadata) == Category);
+  assert(target_layout.category == Category);
+
+  const auto block_size_log2 = file_->quota()->block_size_log2();
+  const auto old_layout = CurrentLayout<Category>(metadata, block_size_log2);
+  const auto allocated_units_count = target_layout.data_units_count > old_layout.data_units_count
+                                         ? target_layout.data_units_count - old_layout.data_units_count
+                                         : 0;
+  AllocatedDataUnits<Category> allocated_units(file_->quota(), allocated_units_count);
+  EntryMetadataReplacement replacement(metadata, target_layout);
+
+  const auto old_metadata = LogicalMetadata<Category>(metadata, old_layout.data_units_count);
+  const auto replacement_metadata = BuildReplacementUnitMetadata<Category>(old_metadata, target_layout.data_units_count,
+                                                                           allocated_units.block_numbers());
+  StoreLogicalMetadata<Category>(replacement.get(), replacement_metadata);
+
+  const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
+  DetachCachedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
+                                   encrypted, block_size_log2);
+
+  ReplaceMetadata(replacement.get());
+  allocated_units.release();
+
+  ResizeChangedDataBlocks<Category>(file_->quota(), file_->metadata_block(), file_->mutable_metadata(), old_layout,
+                                    target_layout, encrypted, block_size_log2);
+  FreeRemovedDataUnits<Category>(file_->quota(), old_metadata, target_layout.data_units_count);
+}
+
+template void FileResizer::ResizeDataUnitLayout<FileLayoutCategory::Blocks>(const FileLayout& target_layout);
+template void FileResizer::ResizeDataUnitLayout<FileLayoutCategory::LargeBlocks>(const FileLayout& target_layout);
+template void FileResizer::ResizeDataUnitLayout<FileLayoutCategory::Clusters>(const FileLayout& target_layout);

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -35,6 +35,7 @@ namespace {
 constexpr std::string_view kTestFilename = "file";
 constexpr std::array kInitialData{std::byte{0x11}, std::byte{0x22}, std::byte{0x33}, std::byte{0x44}};
 constexpr std::array kReplacementData{std::byte{0xaa}, std::byte{0xbb}, std::byte{0xcc}, std::byte{0xdd}};
+constexpr std::array kPostResizeData{std::byte{0x55}, std::byte{0x66}, std::byte{0x77}, std::byte{0x88}};
 
 struct TestFile {
   std::shared_ptr<File> file;
@@ -359,6 +360,36 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize preserves dirty cached data blo
 
   auto expected = initial_data;
   std::ranges::copy(kReplacementData, expected.begin());
+  expected.resize(target_size, std::byte{0});
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize lets existing file devices reload detached blocks",
+                 "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size + 4;
+  const auto target_size = 2 * block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  {
+    std::array<std::byte, kPostResizeData.size()> data{};
+    File::file_device writer(test_file.file);
+    const auto read = writer.read(reinterpret_cast<char*>(data.data()), static_cast<std::streamsize>(data.size()));
+    REQUIRE(read == static_cast<std::streamsize>(data.size()));
+    writer.seek(0, std::ios_base::beg);
+
+    test_file.file->Resize(target_size);
+
+    const auto wrote = writer.write(reinterpret_cast<const char*>(kPostResizeData.data()),
+                                    static_cast<std::streamsize>(kPostResizeData.size()));
+    REQUIRE(wrote == static_cast<std::streamsize>(kPostResizeData.size()));
+  }
+
+  auto expected = initial_data;
+  std::ranges::copy(kPostResizeData, expected.begin());
   expected.resize(target_size, std::byte{0});
   CHECK(ReadFile(test_file.file, target_size) == expected);
 }

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -25,8 +25,10 @@
 #include "block.h"
 #include "directory_map.h"
 #include "file_layout.h"
+#include "free_blocks_allocator.h"
 #include "quota_area.h"
 #include "structs.h"
+#include "utils.h"
 #include "utils/test_fixtures.h"
 
 namespace {
@@ -74,10 +76,114 @@ class FileResizeFixture : public MetadataBlockFixture {
                                                   quota->block_size_log2(), FileLayoutMode::MinimumForGrow));
   }
 
+  TestFile CreateDataUnitFile(std::string_view name, uint32_t file_size, std::span<const std::byte> data) {
+    auto test_file = CreateFile(name, file_size);
+    AssignDataBlocks(test_file.metadata);
+    StoreFileData(test_file.metadata, data);
+    return test_file;
+  }
+
   EntryMetadata* StoredMetadata(std::string_view name) {
     auto it = directory_map->find(name);
     REQUIRE(!it.is_end());
     return (*it).metadata.get_mutable();
+  }
+
+  uint32_t FreeBlocksCount() { return (*quota->GetFreeBlocksAllocator())->free_blocks_count(); }
+
+ private:
+  static FileLayoutCategory Category(const EntryMetadata* metadata) {
+    return FileLayout::CategoryFromValue(metadata->size_category.value());
+  }
+
+  static BlockType AllocationBlockType(FileLayoutCategory category) {
+    switch (category) {
+      case FileLayoutCategory::Blocks:
+        return BlockType::Single;
+      case FileLayoutCategory::LargeBlocks:
+        return BlockType::Large;
+      case FileLayoutCategory::Clusters:
+        return BlockType::Cluster;
+      case FileLayoutCategory::Inline:
+      case FileLayoutCategory::ClusterMetadataBlocks:
+        break;
+    }
+    throw std::logic_error("Unexpected test file layout category");
+  }
+
+  static BlockType DataBlockType(FileLayoutCategory category) {
+    switch (category) {
+      case FileLayoutCategory::Blocks:
+        return BlockType::Single;
+      case FileLayoutCategory::LargeBlocks:
+      case FileLayoutCategory::Clusters:
+        return BlockType::Large;
+      case FileLayoutCategory::Inline:
+      case FileLayoutCategory::ClusterMetadataBlocks:
+        break;
+    }
+    throw std::logic_error("Unexpected test file layout category");
+  }
+
+  template <typename T>
+  std::span<T> AlignedMetadataItems(EntryMetadata* metadata, size_t count) {
+    auto* metadata_bytes = reinterpret_cast<std::byte*>(metadata);
+    const auto metadata_size = sizeof(T) * count;
+    auto* end = metadata_bytes + align_to_power_of_2(metadata->size() + metadata_size);
+    return {reinterpret_cast<T*>(end - metadata_size), count};
+  }
+
+  void AssignDataBlocks(EntryMetadata* metadata) {
+    const auto category = Category(metadata);
+    const auto metadata_items_count =
+        FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), quota->block_size_log2());
+    auto allocated_blocks = quota->AllocDataBlocks(metadata_items_count, AllocationBlockType(category));
+    REQUIRE(allocated_blocks.has_value());
+
+    if (category == FileLayoutCategory::Blocks || category == FileLayoutCategory::LargeBlocks) {
+      auto block_refs = AlignedMetadataItems<DataBlockMetadata>(metadata, metadata_items_count);
+      for (size_t i = 0; i < allocated_blocks->size(); ++i)
+        block_refs[allocated_blocks->size() - i - 1].block_number = (*allocated_blocks)[i];
+      return;
+    }
+
+    auto cluster_refs = AlignedMetadataItems<DataBlocksClusterMetadata>(metadata, metadata_items_count);
+    for (size_t i = 0; i < allocated_blocks->size(); ++i)
+      cluster_refs[allocated_blocks->size() - i - 1].block_number = (*allocated_blocks)[i];
+  }
+
+  void StoreDataBlock(uint32_t area_block_number, std::span<const std::byte> data) {
+    std::vector<std::byte> aligned_data(
+        div_ceil(data.size(), test_device->device()->SectorSize()) * test_device->device()->SectorSize(), std::byte{0});
+    std::ranges::copy(data, aligned_data.begin());
+    test_device->blocks_[quota->to_physical_block_number(area_block_number)] = std::move(aligned_data);
+  }
+
+  void StoreFileData(EntryMetadata* metadata, std::span<const std::byte> data) {
+    const auto category = Category(metadata);
+    const auto data_block_size = size_t{1} << (quota->block_size_log2() + log2_size(DataBlockType(category)));
+
+    if (category == FileLayoutCategory::Blocks || category == FileLayoutCategory::LargeBlocks) {
+      auto block_refs = AlignedMetadataItems<DataBlockMetadata>(
+          metadata, FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), quota->block_size_log2()));
+      for (size_t i = 0, offset = 0; offset < data.size(); ++i, offset += data_block_size) {
+        const auto chunk_size = std::min(data_block_size, data.size() - offset);
+        StoreDataBlock(block_refs[block_refs.size() - i - 1].block_number.value(), data.subspan(offset, chunk_size));
+      }
+      return;
+    }
+
+    constexpr size_t kLargeBlocksPerCluster = size_t{1} << log2_size(BlockType::Cluster) >> log2_size(BlockType::Large);
+    auto cluster_refs = AlignedMetadataItems<DataBlocksClusterMetadata>(
+        metadata, FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), quota->block_size_log2()));
+    for (size_t i = 0, offset = 0; offset < data.size(); ++i, offset += data_block_size) {
+      const auto cluster_index = i / kLargeBlocksPerCluster;
+      const auto large_block_index = i % kLargeBlocksPerCluster;
+      const auto chunk_size = std::min(data_block_size, data.size() - offset);
+      const auto cluster_block_number = cluster_refs[cluster_refs.size() - cluster_index - 1].block_number.value();
+      StoreDataBlock(cluster_block_number + static_cast<uint32_t>(large_block_index << log2_size(BlockType::Large)),
+                     data.subspan(offset, chunk_size));
+    }
   }
 };
 
@@ -94,6 +200,13 @@ std::vector<std::byte> ReadFile(const std::shared_ptr<File>& file, size_t size) 
   const auto read = device.read(reinterpret_cast<char*>(output.data()), static_cast<std::streamsize>(output.size()));
   REQUIRE(read == static_cast<std::streamsize>(output.size()));
   return output;
+}
+
+std::vector<std::byte> DataPattern(size_t size) {
+  std::vector<std::byte> data(size);
+  for (size_t i = 0; i < data.size(); ++i)
+    data[i] = std::byte{static_cast<unsigned char>((i * 131 + 17) & 0xff)};
+  return data;
 }
 
 size_t WriteFile(const std::shared_ptr<File>& file, std::span<const std::byte> input, size_t offset) {
@@ -187,9 +300,185 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline file to zero",
   CHECK(InlinePayload(metadata).empty());
 }
 
-TEST_CASE_METHOD(FileResizeFixture, "File resize throws for non-inline layouts", "[file-resize][unit]") {
+TEST_CASE_METHOD(FileResizeFixture, "File resize throws for unsupported layout transitions", "[file-resize][unit]") {
   auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
 
   CHECK_THROWS_AS(test_file.file->Resize(FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size())) + 1),
                   std::logic_error);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize throws when shrink target category differs", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 2 * block_size + 8;
+  const auto target_size = block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  CHECK_THROWS_AS(test_file.file->Resize(target_size), std::logic_error);
+  CHECK(test_file.file->Size() == initial_size);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 1 by one block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size + 4;
+  const auto target_size = 2 * block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 3 * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_blocks_before - 1);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 1 to one block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 2 * block_size + 4;
+  const auto target_size = block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + 2);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 1 partial last block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size + 4;
+  const auto target_size = block_size + 8;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 2 * block_size);
+  CHECK(FreeBlocksCount() == free_blocks_before);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 1 partial last block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size;
+  const auto target_size = block_size - 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == block_size);
+  CHECK(FreeBlocksCount() == free_blocks_before);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 2 by one large block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  const auto initial_size = 5 * block_size + 4;
+  const auto target_size = large_block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 2 * large_block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before - (uint32_t{1} << log2_size(BlockType::Large)));
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 2 by one large block", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  const auto initial_size = large_block_size + 4;
+  const auto target_size = 5 * block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == large_block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + (uint32_t{1} << log2_size(BlockType::Large)));
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 3 by one cluster", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  const auto cluster_size = block_size << log2_size(BlockType::Cluster);
+  const auto initial_size = 5 * large_block_size + 4;
+  const auto target_size = cluster_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 2 * cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  CHECK(FreeBlocksCount() == free_blocks_before - (uint32_t{1} << log2_size(BlockType::Cluster)));
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 3 by one cluster", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_size = block_size << log2_size(BlockType::Large);
+  const auto cluster_size = block_size << log2_size(BlockType::Cluster);
+  const auto initial_size = cluster_size + 4;
+  const auto target_size = 5 * large_block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  CHECK(FreeBlocksCount() == free_blocks_before + (uint32_t{1} << log2_size(BlockType::Cluster)));
+  CHECK(ReadFile(test_file.file, target_size) == expected);
 }

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -340,6 +340,29 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 1 by one block",
   CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 
+TEST_CASE_METHOD(FileResizeFixture, "File resize preserves dirty cached data blocks", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size + 4;
+  const auto target_size = 2 * block_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  {
+    File::file_device writer(test_file.file);
+    const auto wrote = writer.write(reinterpret_cast<const char*>(kReplacementData.data()),
+                                    static_cast<std::streamsize>(kReplacementData.size()));
+    REQUIRE(wrote == static_cast<std::streamsize>(kReplacementData.size()));
+
+    test_file.file->Resize(target_size);
+  }
+
+  auto expected = initial_data;
+  std::ranges::copy(kReplacementData, expected.begin());
+  expected.resize(target_size, std::byte{0});
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
 TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 1 to one block", "[file-resize][unit]") {
   const auto block_size = static_cast<uint32_t>(quota->block_size());
   const auto initial_size = 2 * block_size + 4;

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -394,6 +394,37 @@ TEST_CASE_METHOD(FileResizeFixture,
   CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize failure keeps dirty writes in blocks that would be dropped",
+                 "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 2 * block_size + 4;
+  const auto target_size = block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  auto it = directory_map->find(kTestFilename);
+  REQUIRE(!it.is_end());
+  auto synthetic_file =
+      std::make_shared<File>(Entry::CreateSyntheticEntryHandle(std::string{kTestFilename}, (*it).metadata), quota);
+
+  File::file_device writer(synthetic_file);
+  writer.seek(block_size, std::ios_base::beg);
+  const auto wrote = writer.write(reinterpret_cast<const char*>(kReplacementData.data()),
+                                  static_cast<std::streamsize>(kReplacementData.size()));
+  REQUIRE(wrote == static_cast<std::streamsize>(kReplacementData.size()));
+
+  CHECK_THROWS_AS(synthetic_file->Resize(target_size), std::logic_error);
+
+  std::array<std::byte, kReplacementData.size()> observed{};
+  writer.seek(block_size, std::ios_base::beg);
+  const auto read =
+      writer.read(reinterpret_cast<char*>(observed.data()), static_cast<std::streamsize>(observed.size()));
+  REQUIRE(read == static_cast<std::streamsize>(observed.size()));
+  CHECK(observed == kReplacementData);
+}
+
 TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 1 to one block", "[file-resize][unit]") {
   const auto block_size = static_cast<uint32_t>(quota->block_size());
   const auto initial_size = 2 * block_size + 4;


### PR DESCRIPTION
## Summary
- Extend `FileResizer` to handle physical resize while staying in category 1, 2, or 3 data-unit layouts.
- Use the existing grow/shrink layout calculation as the single target-category decision; unsupported category transitions still raise the C++ unimplemented exception.
- Share data-unit traits, aligned entry-metadata views, logical block lookup, and block sizing through `file_data_units.h` so the layout accessor and resizer use the same category mapping.
- Flush retained cached data blocks before metadata replacement, then defer detaching old cached blocks until after replacement succeeds so failed resize attempts do not discard dirty writes in blocks that would have been dropped.
- Make existing file layout accessors reload detached data blocks after resize so post-resize I/O does not write to unflushable detached blocks.
- Keep helper symbols in the project global style, and keep metadata replacement with `FileResizer` instead of a separate resizer-metadata header.

## Testing
- `/tmp/wfslib-clang-format-venv/bin/clang-format --dry-run --Werror src/file_resizer_data_units.cpp tests/file_resize_tests.cpp`
- `cmake --build --preset debug-tests -j2`
- `cmake --build --preset release-tests -j2`
- `./build/tests/tests/Debug/wfslib_tests "[file-resize]"`
- `./build/tests/tests/Release/wfslib_tests "[file-resize]"`
- `./build/tests/tests/Debug/wfslib_tests "File layout accessor*"`
- `./build/tests/tests/Release/wfslib_tests "File layout accessor*"`
- `ctest --preset run-debug-tests --output-on-failure`