### PR TITLE
Add free block tree regression tests

### DIFF
--- a/src/free_blocks_allocator.cpp
+++ b/src/free_blocks_allocator.cpp
@@ -96,7 +96,7 @@ uint32_t FreeBlocksAllocator::FindSmallestFreeBlockExtent(uint32_t near, std::ve
   // logic bit more complex than original.
   for (size_t i = 0; i < kSizeBuckets.size(); ++i) {
     FreeBlocksTreeBucket bucket(this, i);
-    for (auto it = bucket.find(near); it != bucket.end(); ++it) {
+    for (auto it = bucket.find(near, /*exact_match=*/false); it != bucket.end(); ++it) {
       FreeBlocksExtentInfo possible_result = *it;
       auto res = std::ranges::find_if(allocated, [&possible_result](FreeBlocksExtentInfo& info) {
         return info.block_number == possible_result.block_number;
@@ -282,7 +282,8 @@ void FreeBlocksAllocator::RecreateEPTreeIfNeeded() {
     // Already trivial
     return;
   }
-  auto last = eptree.end()--;
+  auto last = eptree.end();
+  --last;
   if ((*last).key() || (*last).value() != 2)
     return;
   uint32_t last_value = (*last).value();
@@ -467,7 +468,7 @@ std::optional<std::vector<FreeBlocksRangeInfo>> FreeBlocksAllocator::AllocAreaBl
     return std::nullopt;  // not enough space
   // now sort by block number
   std::ranges::sort(used_ranges,
-                    [](const auto& a, const auto& b) { return a.range.block_number < b.range.blocks_count; });
+                    [](const auto& a, const auto& b) { return a.range.block_number < b.range.block_number; });
   // remove from first chunk unneeded blocks
   auto remainder = total_blocks - wanted_blocks_count;
   used_ranges[0].range.block_number += remainder;

--- a/src/free_blocks_tree_bucket.cpp
+++ b/src/free_blocks_tree_bucket.cpp
@@ -37,7 +37,7 @@ bool FreeBlocksTreeBucket::insert(iterator& pos, FTree::iterator::value_type key
     for (const auto& ftree : old_ftrees.ftrees()) {
       if (ftree.size() > 0) {
         auto first = ftree.begin();
-        *allocated_extent = {(*first).key(), 1, ftree.index()};
+        allocated_extent = FreeBlocksExtentInfo{(*first).key(), 1, ftree.index()};
         break;
       }
     }

--- a/src/ftrees_iterator.cpp
+++ b/src/ftrees_iterator.cpp
@@ -17,7 +17,10 @@ FTreesIterator& FTreesIterator::operator++() {
     reverse_end_.reset(index_);
     // todo: enumrate
     for (auto& ftree : ftrees_) {
-      while (!reverse_end_.test(ftree.node.index()) && !ftree.iterator.is_end() && (*++ftree.iterator).key() < key) {
+      while (!reverse_end_.test(ftree.node.index()) && !ftree.iterator.is_end()) {
+        ++ftree.iterator;
+        if (ftree.iterator.is_end() || (*ftree.iterator).key() >= key)
+          break;
       }
     }
     is_forward_ = true;

--- a/tests/free_blocks_allocator_tests.cpp
+++ b/tests/free_blocks_allocator_tests.cpp
@@ -10,7 +10,9 @@
 #include <random>
 #include <ranges>
 
+#include "eptree.h"
 #include "free_blocks_tree.h"
+#include "free_blocks_tree_bucket.h"
 
 #include "utils/range_assertions.h"
 #include "utils/test_fixtures.h"
@@ -294,4 +296,65 @@ TEST_CASE_METHOD(AreaAllocatorFixture,
   REQUIRE(ranges->at(0).blocks_count == kTreeBlocksCount / 2);
   REQUIRE(ranges->at(1).block_number == kThirdFragmentAddress);
   REQUIRE(ranges->at(1).blocks_count == kTreeBlocksCount);
+}
+
+TEST_CASE_METHOD(FreeBlocksAllocatorFixture,
+                 "FreeBlocksAllocator finds a nearby free extent without an exact key match",
+                 "[free-blocks][allocator][regression]") {
+  REQUIRE(allocator.Init(0));
+
+  FreeBlocksTreeBucket bucket{&allocator, 0};
+  REQUIRE(bucket.insert({10, nibble{0}}));
+
+  std::vector<FreeBlocksExtentInfo> allocated;
+  REQUIRE(allocator.FindSmallestFreeBlockExtent(11, allocated) == 10);
+  REQUIRE(allocated == std::vector<FreeBlocksExtentInfo>{{10, 1, 0}});
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator recreates a collapsed EPTree",
+                 "[free-blocks][allocator][regression]") {
+  REQUIRE(allocator.Init(1000000));
+
+  EPTree eptree{&allocator};
+  constexpr uint32_t kExtraEntries = 1000;
+  for (uint32_t i = 1; i <= kExtraEntries; ++i) {
+    REQUIRE(eptree.insert({i, i + 1000}));
+  }
+
+  std::vector<FreeBlocksRangeInfo> blocks_to_delete;
+  for (uint32_t i = 1; i <= kExtraEntries; ++i) {
+    REQUIRE(eptree.erase(i, blocks_to_delete));
+  }
+  REQUIRE((eptree.tree_header()->depth.value() > 1 || eptree.tree_header()->current_tree.tree_depth.value() > 0));
+
+  allocator.RecreateEPTreeForTesting();
+
+  EPTree recreated_eptree{&allocator};
+  REQUIRE(recreated_eptree.tree_header()->depth.value() == 1);
+  REQUIRE(recreated_eptree.tree_header()->current_tree.tree_depth.value() == 0);
+  REQUIRE(CollectKeyValues(recreated_eptree) ==
+          std::vector<std::pair<uint32_t, uint32_t>>{{0, allocator.initial_ftrees_block_number()}});
+}
+
+TEST_CASE_METHOD(AreaAllocatorFixture,
+                 "FreeBlocksAllocator trims fragmented area allocation from the lowest selected range",
+                 "[free-blocks][allocator][regression]") {
+  REQUIRE(allocator.Init(0));
+  allocator.set_blocks_cache_size_log2(0);
+
+  REQUIRE(allocator.AddFreeBlocks({1000, 100}));
+  REQUIRE(allocator.AddFreeBlocks({2000, 100}));
+
+  auto ranges = allocator.AllocAreaBlocks(150, BlockType::Single);
+  REQUIRE(ranges);
+  REQUIRE(ranges->size() == 2);
+  REQUIRE(ranges->at(0).block_number == 1050);
+  REQUIRE(ranges->at(0).blocks_count == 50);
+  REQUIRE(ranges->at(1).block_number == 2000);
+  REQUIRE(ranges->at(1).blocks_count == 100);
+  REQUIRE(allocator.GetHeader()->free_blocks_count.value() == 50);
+  REQUIRE(allocator.IsRangeIsFree({1000, 50}));
+  REQUIRE_FALSE(allocator.IsRangeIsFree({1050, 50}));
+  REQUIRE_FALSE(allocator.IsRangeIsFree({2000, 100}));
 }

--- a/tests/free_blocks_tree_bucket_tests.cpp
+++ b/tests/free_blocks_tree_bucket_tests.cpp
@@ -180,3 +180,22 @@ TEST_CASE_METHOD(FreeBlocksTreeBucketFixture,
 
   RequireBidirectionalIteration(bucket, kFreeBlocksBucketStressItems, [](const auto& extent) { return extent.key(); });
 }
+
+TEST_CASE_METHOD(FreeBlocksAllocatorFixture,
+                 "FreeBlocksTreeBucket splits a full FTrees block without cache",
+                 "[free-blocks][tree-bucket][regression]") {
+  REQUIRE(allocator.Init(0));
+
+  FreeBlocksTreeBucket split_bucket{&allocator, 0};
+  constexpr uint32_t kFirstFreeBlock = 1000;
+  constexpr uint32_t kInsertedExtents = 2000;
+  allocator.set_free_blocks_count_for_testing(kInsertedExtents);
+
+  for (uint32_t i = 0; i < kInsertedExtents; ++i) {
+    CAPTURE(i);
+    REQUIRE(split_bucket.insert({kFirstFreeBlock + i, nibble{0}}));
+  }
+
+  REQUIRE(split_bucket.find(kFirstFreeBlock, true) == split_bucket.end());
+  REQUIRE(split_bucket.find(kFirstFreeBlock + kInsertedExtents - 1, true) != split_bucket.end());
+}

--- a/tests/ftrees_tests.cpp
+++ b/tests/ftrees_tests.cpp
@@ -80,6 +80,20 @@ TEST_CASE_METHOD(FTreesFixture, "FTrees iterator walks forward and backward", "[
   RequireBidirectionalIteration(ftrees, kFTreesItems, [](const auto& extent) { return extent.key(); });
 }
 
+TEST_CASE_METHOD(FTreesFixture,
+                 "FTrees iterator can move forward after reversing from the last extent",
+                 "[ftrees][iterator][regression]") {
+  REQUIRE(ftrees.ftrees()[0].insert({0, nibble{0}}));
+  REQUIRE(ftrees.ftrees()[1].insert({10, nibble{0}}));
+
+  auto it = ftrees.end();
+  --it;
+  REQUIRE((*it).key() == 10);
+
+  ++it;
+  REQUIRE(it == ftrees.end());
+}
+
 TEST_CASE_METHOD(FTreesFixture, "FTrees find returns exact and nearest extents", "[ftrees][unit]") {
   for (uint32_t i = 0; i < kFTreesItems; ++i) {
     REQUIRE(ftrees.ftrees()[i % kSizeBuckets.size()].insert({i * 2, static_cast<nibble>(i % 16)}));

--- a/tests/utils/test_free_blocks_allocator.h
+++ b/tests/utils/test_free_blocks_allocator.h
@@ -27,6 +27,8 @@ class TestFreeBlocksAllocator : public FreeBlocksAllocator {
   uint32_t initial_frees_block_number() const { return initial_frees_block_number_; }
 
   void set_blocks_cache_size_log2(size_t size) { blocks_cache_size_log2_ = size; }
+  void set_free_blocks_count_for_testing(uint32_t count) { mutable_header()->free_blocks_count = count; }
+  void RecreateEPTreeForTesting() { RecreateEPTreeIfNeeded(); }
 
   const FreeBlocksAllocatorHeader* GetHeader() const { return header(); }
 


### PR DESCRIPTION
## Summary

- Add regression coverage for free block allocation tree edge cases around cache-empty FTrees splitting, EPTree collapse, non-exact extent lookup, fragmented area range trimming, and FTrees iterator direction changes.
- Fix the covered allocator/tree issues so the new tests pass.

## Validation

- `cmake -S . -B build/gcc14-tests -G "Ninja Multi-Config" -DCMAKE_TOOLCHAIN_FILE=/tmp/wfslib-free-blocks-tree-regression-tests/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_TESTS=ON -DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14`
- `cmake --build build/gcc14-tests --config Debug --target wfslib_tests`
- `build/gcc14-tests/tests/Debug/wfslib_tests "[regression]"`
- `build/gcc14-tests/tests/Debug/wfslib_tests "[free-blocks]"`
- `build/gcc14-tests/tests/Debug/wfslib_tests "[ftrees]"`
- `ctest --test-dir build/gcc14-tests -C Debug --output-on-failure`