### PR TITLE
Implement file resize category transitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_library(${PROJECT_NAME}
     src/file_layout_accessor.cpp
     src/file_resizer.cpp
     src/file_resizer_data_units.cpp
+    src/file_resizer_transitions.cpp
     src/free_blocks_allocator.cpp
     src/free_blocks_tree_iterator.cpp
     src/free_blocks_tree.cpp

--- a/src/block.cpp
+++ b/src/block.cpp
@@ -49,7 +49,7 @@ Block::~Block() {
 }
 
 void Block::Resize(uint32_t data_size) {
-  assert(!device_->device()->IsReadOnly());
+  assert(!device_ || !device_->device()->IsReadOnly());
   // Ensure that block data is aligned to device sectors
   if (data_size_ == data_size)
     return;
@@ -94,11 +94,13 @@ void Block::Flush() {
 
 uint32_t Block::GetAlignedSize(uint32_t size) const {
   assert(size > 0 && size <= capacity());
+  if (!device_)
+    return size;
   return static_cast<uint32_t>(div_ceil(size, device_->device()->SectorSize()) * device_->device()->SectorSize());
 }
 
 std::span<std::byte> Block::GetDataForWriting() {
-  assert(!device_->device()->IsReadOnly());
+  assert(!device_ || !device_->device()->IsReadOnly());
   dirty_ = true;
   return {data_.data(), data_.data() + size()};
 }

--- a/src/file_layout.cpp
+++ b/src/file_layout.cpp
@@ -152,6 +152,10 @@ FileLayoutCategory MaximumCategory(uint32_t file_size, uint8_t filename_length, 
   return FileLayoutCategory::Inline;
 }
 
+bool CategoryLess(FileLayoutCategory lhs, FileLayoutCategory rhs) {
+  return FileLayout::CategoryValue(lhs) < FileLayout::CategoryValue(rhs);
+}
+
 }  // namespace
 
 size_t FileLayout::BaseMetadataSize(uint8_t filename_length) {
@@ -215,12 +219,18 @@ uint32_t FileLayout::MaxFileSize(uint8_t block_size_log2) {
   return static_cast<uint32_t>(std::min(max_by_size_on_disk, max_by_cluster_metadata_blocks));
 }
 
-FileLayout FileLayout::Calculate(uint32_t file_size,
+FileLayout FileLayout::Calculate(uint32_t old_file_size,
+                                 uint32_t target_file_size,
                                  uint8_t filename_length,
                                  uint8_t block_size_log2,
-                                 FileLayoutMode mode) {
-  const auto category = mode == FileLayoutMode::MinimumForGrow
-                            ? MinimumCategory(file_size, filename_length, block_size_log2)
-                            : MaximumCategory(file_size, filename_length, block_size_log2);
-  return BuildLayout(file_size, filename_length, block_size_log2, category);
+                                 FileLayoutCategory current_category) {
+  if (target_file_size > old_file_size) {
+    const auto smallest_target_category = MinimumCategory(target_file_size, filename_length, block_size_log2);
+    const auto target_category = std::max(smallest_target_category, current_category, CategoryLess);
+    return BuildLayout(target_file_size, filename_length, block_size_log2, target_category);
+  }
+
+  const auto largest_target_category = MaximumCategory(target_file_size, filename_length, block_size_log2);
+  const auto target_category = std::min(largest_target_category, current_category, CategoryLess);
+  return BuildLayout(target_file_size, filename_length, block_size_log2, target_category);
 }

--- a/src/file_layout.h
+++ b/src/file_layout.h
@@ -10,11 +10,6 @@
 #include <cstddef>
 #include <cstdint>
 
-enum class FileLayoutMode {
-  MinimumForGrow,
-  MaximumForShrink,
-};
-
 enum class FileLayoutCategory : uint8_t {
   Inline = 0,
   Blocks = 1,
@@ -40,8 +35,9 @@ struct FileLayout {
   static uint32_t ClusterMetadataBlocksCount(uint32_t clusters_count, uint8_t block_size_log2);
   static uint32_t MaxFileSize(uint8_t block_size_log2);
 
-  static FileLayout Calculate(uint32_t file_size,
+  static FileLayout Calculate(uint32_t old_file_size,
+                              uint32_t target_file_size,
                               uint8_t filename_length,
                               uint8_t block_size_log2,
-                              FileLayoutMode mode);
+                              FileLayoutCategory current_category = FileLayoutCategory::Inline);
 };

--- a/src/file_resizer.cpp
+++ b/src/file_resizer.cpp
@@ -13,7 +13,9 @@
 #include <span>
 #include <stdexcept>
 #include <utility>
+#include <vector>
 
+#include "block.h"
 #include "directory_map.h"
 #include "errors.h"
 #include "file_layout.h"
@@ -37,8 +39,10 @@ std::span<std::byte> InlinePayload(EntryMetadata* metadata) {
 }
 }  // namespace
 
+// TODO: This is a Block only because target data-block Flush writes hashes through block-backed HashRef. If resize
+// gets a staged data-block write path, keep replacement metadata as plain owned bytes instead.
 EntryMetadataReplacement::EntryMetadataReplacement(const EntryMetadata* source, const FileLayout& layout)
-    : storage_(size_t{1} << layout.metadata_log2_size, std::byte{0}) {
+    : block_(Block::CreateDetached(std::vector(size_t{1} << layout.metadata_log2_size, std::byte{0}))) {
   auto* metadata = get();
   std::memcpy(metadata, source, source->size());
   metadata->file_size = layout.file_size;
@@ -48,11 +52,15 @@ EntryMetadataReplacement::EntryMetadataReplacement(const EntryMetadata* source, 
 }
 
 EntryMetadata* EntryMetadataReplacement::get() {
-  return reinterpret_cast<EntryMetadata*>(storage_.data());
+  return block_->get_mutable_object<EntryMetadata>(0);
 }
 
 const EntryMetadata* EntryMetadataReplacement::get() const {
-  return reinterpret_cast<const EntryMetadata*>(storage_.data());
+  return block_->get_object<EntryMetadata>(0);
+}
+
+const std::shared_ptr<Block>& EntryMetadataReplacement::block() const {
+  return block_;
 }
 
 FileResizer::FileResizer(std::shared_ptr<File> file) : file_(std::move(file)) {}
@@ -67,13 +75,14 @@ void FileResizer::Resize(size_t new_size) {
   if (target_size == old_size)
     return;
 
-  const auto mode = target_size > old_size ? FileLayoutMode::MinimumForGrow : FileLayoutMode::MaximumForShrink;
-  const auto target_layout =
-      FileLayout::Calculate(target_size, metadata->filename_length.value(), file_->quota()->block_size_log2(), mode);
   const auto current_category = CurrentCategory(metadata);
+  const auto target_layout = FileLayout::Calculate(old_size, target_size, metadata->filename_length.value(),
+                                                   file_->quota()->block_size_log2(), current_category);
 
-  if (target_layout.category != current_category)
-    ThrowResizeUnimplemented();
+  if (target_layout.category != current_category) {
+    ResizeAcrossLayouts(target_layout);
+    return;
+  }
 
   switch (target_layout.category) {
     case FileLayoutCategory::Inline:

--- a/src/file_resizer.h
+++ b/src/file_resizer.h
@@ -9,7 +9,6 @@
 
 #include <cstddef>
 #include <memory>
-#include <vector>
 
 #include "file.h"
 #include "file_layout.h"
@@ -20,9 +19,10 @@ class EntryMetadataReplacement {
 
   EntryMetadata* get();
   const EntryMetadata* get() const;
+  const std::shared_ptr<Block>& block() const;
 
  private:
-  std::vector<std::byte> storage_;
+  std::shared_ptr<Block> block_;
 };
 
 class FileResizer {
@@ -33,6 +33,7 @@ class FileResizer {
 
  private:
   void ResizeInline(const FileLayout& target_layout);
+  void ResizeAcrossLayouts(const FileLayout& target_layout);
   void ReplaceMetadata(EntryMetadata* metadata);
 
   template <FileLayoutCategory Category>

--- a/src/file_resizer_transitions.cpp
+++ b/src/file_resizer_transitions.cpp
@@ -1,0 +1,368 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "file_resizer.h"
+
+#include <algorithm>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+#include "block.h"
+#include "errors.h"
+#include "file_data_units.h"
+#include "file_layout_accessor.h"
+#include "quota_area.h"
+#include "utils.h"
+
+namespace {
+struct DataBlockCacheRef {
+  // Old-cache identity captured before metadata replacement. Hash refs are intentionally omitted; post-commit detach
+  // should only evict stale cached blocks, not flush through old hash locations.
+  uint32_t block_number;
+  BlockType block_type;
+  uint32_t data_size;
+};
+
+struct DataUnitRef {
+  uint32_t block_number;
+  uint32_t blocks_count;
+};
+
+[[noreturn]] void ThrowResizeUnimplemented() {
+  throw std::logic_error("File resize for this layout transition is not implemented");
+}
+
+FileLayoutCategory CurrentCategory(const EntryMetadata* metadata) {
+  return FileLayout::CategoryFromValue(metadata->size_category.value());
+}
+
+bool IsTransitionCategory(FileLayoutCategory category) {
+  return category != FileLayoutCategory::ClusterMetadataBlocks;
+}
+
+uint32_t UsedDataBlockSize(uint32_t file_size, size_t block_offset, size_t log2_block_size) {
+  if (file_size <= block_offset)
+    return 0;
+  return static_cast<uint32_t>(std::min(size_t{1} << log2_block_size, size_t{file_size} - block_offset));
+}
+
+BlockType AllocationBlockType(FileLayoutCategory category) {
+  switch (category) {
+    case FileLayoutCategory::Blocks:
+      return BlockType::Single;
+    case FileLayoutCategory::LargeBlocks:
+      return BlockType::Large;
+    case FileLayoutCategory::Clusters:
+      return BlockType::Cluster;
+    case FileLayoutCategory::Inline:
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+
+template <FileLayoutCategory Category>
+FileLayout CurrentLayout(const EntryMetadata* metadata, uint8_t block_size_log2) {
+  return FileLayout{
+      .category = Category,
+      .metadata_log2_size = metadata->metadata_log2_size.value(),
+      .file_size = metadata->file_size.value(),
+      .size_on_disk = metadata->size_on_disk.value(),
+      .data_units_count = FileLayout::DataUnitsCount(Category, metadata->size_on_disk.value(), block_size_log2),
+  };
+}
+
+FileLayout CurrentLayout(const EntryMetadata* metadata, uint8_t block_size_log2) {
+  switch (CurrentCategory(metadata)) {
+    case FileLayoutCategory::Inline:
+      return FileLayout{
+          .category = FileLayoutCategory::Inline,
+          .metadata_log2_size = metadata->metadata_log2_size.value(),
+          .file_size = metadata->file_size.value(),
+          .size_on_disk = metadata->size_on_disk.value(),
+          .data_units_count = 0,
+      };
+    case FileLayoutCategory::Blocks:
+      return CurrentLayout<FileLayoutCategory::Blocks>(metadata, block_size_log2);
+    case FileLayoutCategory::LargeBlocks:
+      return CurrentLayout<FileLayoutCategory::LargeBlocks>(metadata, block_size_log2);
+    case FileLayoutCategory::Clusters:
+      return CurrentLayout<FileLayoutCategory::Clusters>(metadata, block_size_log2);
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+
+class AllocatedTargetDataUnits {
+ public:
+  AllocatedTargetDataUnits(std::shared_ptr<QuotaArea> quota, const FileLayout& layout) : quota_(std::move(quota)) {
+    if (layout.data_units_count == 0)
+      return;
+
+    const auto block_type = AllocationBlockType(layout.category);
+    block_numbers_ = throw_if_error(quota_->AllocDataBlocks(layout.data_units_count, block_type));
+    blocks_count_ = uint32_t{1} << log2_size(block_type);
+  }
+
+  ~AllocatedTargetDataUnits() {
+    // Until metadata replacement succeeds, newly allocated data units are rollback state.
+    if (!released_) {
+      for (const auto block_number : block_numbers_)
+        quota_->DeleteBlocks(block_number, blocks_count_);
+    }
+  }
+
+  const std::vector<uint32_t>& block_numbers() const { return block_numbers_; }
+
+  void release() { released_ = true; }
+
+ private:
+  std::shared_ptr<QuotaArea> quota_;
+  std::vector<uint32_t> block_numbers_;
+  uint32_t blocks_count_{0};
+  bool released_{false};
+};
+
+template <FileLayoutCategory Category>
+void StoreAllocatedDataUnits(EntryMetadata* metadata, std::span<const uint32_t> block_numbers) {
+  using Traits = FileDataUnitLayoutTraits<Category>;
+  using Metadata = typename Traits::Metadata;
+
+  std::vector<Metadata> data_units(block_numbers.size());
+  for (auto&& [data_unit, block_number] : std::views::zip(data_units, block_numbers))
+    Traits::set_unit_block_number(data_unit, block_number);
+
+  auto stored_metadata = MutableFileDataUnitLogicalMetadataItems<Category>(metadata, data_units.size());
+  std::ranges::copy(data_units, stored_metadata.begin());
+}
+
+void StoreAllocatedDataUnits(FileLayoutCategory category,
+                             EntryMetadata* metadata,
+                             std::span<const uint32_t> block_numbers) {
+  switch (category) {
+    case FileLayoutCategory::Blocks:
+      StoreAllocatedDataUnits<FileLayoutCategory::Blocks>(metadata, block_numbers);
+      return;
+    case FileLayoutCategory::LargeBlocks:
+      StoreAllocatedDataUnits<FileLayoutCategory::LargeBlocks>(metadata, block_numbers);
+      return;
+    case FileLayoutCategory::Clusters:
+      StoreAllocatedDataUnits<FileLayoutCategory::Clusters>(metadata, block_numbers);
+      return;
+    case FileLayoutCategory::Inline:
+      return;
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+
+template <FileLayoutCategory Category>
+std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& metadata_block,
+                                                  const EntryMetadata* metadata,
+                                                  const FileLayout& layout,
+                                                  uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
+  const auto data_blocks_count = div_ceil(layout.file_size, size_t{1} << data_block_log2_size);
+  std::vector<DataBlockCacheRef> refs;
+  refs.reserve(data_blocks_count);
+
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
+    auto location = FileDataBlockLocationFor<Category>(metadata_block, metadata, data_block_index, block_size_log2);
+    refs.push_back({location.block_number, location.block_type, data_size});
+  }
+
+  return refs;
+}
+
+std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& metadata_block,
+                                                  const EntryMetadata* metadata,
+                                                  const FileLayout& layout,
+                                                  uint8_t block_size_log2) {
+  switch (layout.category) {
+    case FileLayoutCategory::Inline:
+      return {};
+    case FileLayoutCategory::Blocks:
+      return DataBlockCacheRefs<FileLayoutCategory::Blocks>(metadata_block, metadata, layout, block_size_log2);
+    case FileLayoutCategory::LargeBlocks:
+      return DataBlockCacheRefs<FileLayoutCategory::LargeBlocks>(metadata_block, metadata, layout, block_size_log2);
+    case FileLayoutCategory::Clusters:
+      return DataBlockCacheRefs<FileLayoutCategory::Clusters>(metadata_block, metadata, layout, block_size_log2);
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+
+template <FileLayoutCategory Category>
+std::vector<DataUnitRef> DataUnitRefs(const EntryMetadata* metadata, uint32_t data_units_count) {
+  using Traits = FileDataUnitLayoutTraits<Category>;
+
+  auto metadata_items = FileDataUnitLogicalMetadataItems<Category>(metadata, data_units_count);
+  return metadata_items | std::views::transform([](const auto& metadata) {
+           return DataUnitRef{Traits::unit_block_number(metadata), FileDataUnitAreaBlocksCount<Category>()};
+         }) |
+         std::ranges::to<std::vector>();
+}
+
+std::vector<DataUnitRef> DataUnitRefs(const EntryMetadata* metadata, const FileLayout& layout) {
+  switch (layout.category) {
+    case FileLayoutCategory::Inline:
+      return {};
+    case FileLayoutCategory::Blocks:
+      return DataUnitRefs<FileLayoutCategory::Blocks>(metadata, layout.data_units_count);
+    case FileLayoutCategory::LargeBlocks:
+      return DataUnitRefs<FileLayoutCategory::LargeBlocks>(metadata, layout.data_units_count);
+    case FileLayoutCategory::Clusters:
+      return DataUnitRefs<FileLayoutCategory::Clusters>(metadata, layout.data_units_count);
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+
+void DetachDataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                      std::span<const DataBlockCacheRef> refs,
+                      bool encrypted,
+                      uint8_t block_size_log2) {
+  // After metadata replacement, cached blocks still point at old hash refs and may have obsolete used sizes. Load
+  // cache entries without touching disk so every old block object is detached and future I/O reloads from new metadata.
+  for (const auto& ref : refs) {
+    auto data_block =
+        throw_if_error(quota->LoadDataBlock(ref.block_number, static_cast<BlockSize>(block_size_log2), ref.block_type,
+                                            ref.data_size, Block::HashRef{}, encrypted, /*new_block=*/true));
+    data_block->Detach();
+  }
+}
+
+void FreeDataUnits(const std::shared_ptr<QuotaArea>& quota, std::span<const DataUnitRef> refs) {
+  for (const auto& ref : refs) {
+    if (!quota->DeleteBlocks(ref.block_number, ref.blocks_count))
+      throw WfsException(WfsError::kFreeBlocksAllocatorCorrupted);
+  }
+}
+
+template <typename SourceAccessor>
+void ReadExact(SourceAccessor& source, std::byte* output, size_t offset, size_t size) {
+  // LayoutAccessor::Read stops at the current source block. Transitions may copy many small source blocks into one
+  // larger target block, so keep reading until the requested range is complete.
+  size_t copied = 0;
+  while (copied != size) {
+    const auto read = source.Read(output + copied, offset + copied, size - copied);
+    if (read == 0)
+      throw std::runtime_error("Failed to copy file layout data");
+    copied += read;
+  }
+}
+
+template <typename SourceAccessor>
+void CopyToInlineLayout(SourceAccessor& source, EntryMetadata* target_metadata, size_t bytes_to_preserve) {
+  auto target_data = std::span{reinterpret_cast<std::byte*>(target_metadata) + target_metadata->size(),
+                               target_metadata->size_on_disk.value()};
+  if (bytes_to_preserve == 0)
+    return;
+  ReadExact(source, target_data.data(), 0, bytes_to_preserve);
+}
+
+template <FileLayoutCategory Category, typename SourceAccessor>
+void CopyToDataUnitLayout(SourceAccessor& source,
+                          const std::shared_ptr<QuotaArea>& quota,
+                          const EntryMetadataReplacement& replacement,
+                          const FileLayout& target_layout,
+                          size_t bytes_to_preserve,
+                          bool encrypted,
+                          uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<Category>(block_size_log2);
+  const auto data_blocks_count = div_ceil(target_layout.file_size, size_t{1} << data_block_log2_size);
+
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(target_layout.file_size, block_offset, data_block_log2_size);
+    auto location =
+        FileDataBlockLocationFor<Category>(replacement.block(), replacement.get(), data_block_index, block_size_log2);
+    auto data_block =
+        throw_if_error(quota->LoadDataBlock(location.block_number, static_cast<BlockSize>(block_size_log2),
+                                            location.block_type, data_size, std::move(location.hash), encrypted,
+                                            /*new_block=*/true));
+
+    auto data = data_block->mutable_data();
+    std::ranges::fill(data, std::byte{0});
+    if (block_offset < bytes_to_preserve) {
+      const auto bytes_to_copy = std::min<size_t>(data_size, bytes_to_preserve - block_offset);
+      ReadExact(source, data.data(), block_offset, bytes_to_copy);
+    }
+
+    data_block->Flush();
+    data_block->Detach();
+  }
+}
+
+template <typename SourceAccessor>
+void CopyToTargetLayout(SourceAccessor& source,
+                        const std::shared_ptr<QuotaArea>& quota,
+                        EntryMetadataReplacement& replacement,
+                        const FileLayout& target_layout,
+                        size_t bytes_to_preserve,
+                        bool encrypted,
+                        uint8_t block_size_log2) {
+  switch (target_layout.category) {
+    case FileLayoutCategory::Inline:
+      CopyToInlineLayout(source, replacement.get(), bytes_to_preserve);
+      return;
+    case FileLayoutCategory::Blocks:
+      CopyToDataUnitLayout<FileLayoutCategory::Blocks>(source, quota, replacement, target_layout, bytes_to_preserve,
+                                                       encrypted, block_size_log2);
+      return;
+    case FileLayoutCategory::LargeBlocks:
+      CopyToDataUnitLayout<FileLayoutCategory::LargeBlocks>(source, quota, replacement, target_layout,
+                                                            bytes_to_preserve, encrypted, block_size_log2);
+      return;
+    case FileLayoutCategory::Clusters:
+      CopyToDataUnitLayout<FileLayoutCategory::Clusters>(source, quota, replacement, target_layout, bytes_to_preserve,
+                                                         encrypted, block_size_log2);
+      return;
+    case FileLayoutCategory::ClusterMetadataBlocks:
+      break;
+  }
+  ThrowResizeUnimplemented();
+}
+}  // namespace
+
+void FileResizer::ResizeAcrossLayouts(const FileLayout& target_layout) {
+  const auto* metadata = file_->metadata();
+  const auto old_layout = CurrentLayout(metadata, file_->quota()->block_size_log2());
+  if (!IsTransitionCategory(old_layout.category) || !IsTransitionCategory(target_layout.category))
+    ThrowResizeUnimplemented();
+
+  const auto block_size_log2 = file_->quota()->block_size_log2();
+  const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
+  const auto bytes_to_preserve = std::min(old_layout.file_size, target_layout.file_size);
+  auto source = File::CreateLayoutAccessor(file_);
+
+  const auto old_data_blocks = DataBlockCacheRefs(file_->metadata_block(), metadata, old_layout, block_size_log2);
+  const auto old_data_units = DataUnitRefs(metadata, old_layout);
+
+  EntryMetadataReplacement replacement(metadata, target_layout);
+  AllocatedTargetDataUnits allocated_units(file_->quota(), target_layout);
+  StoreAllocatedDataUnits(target_layout.category, replacement.get(), allocated_units.block_numbers());
+
+  CopyToTargetLayout(*source, file_->quota(), replacement, target_layout, bytes_to_preserve, encrypted,
+                     block_size_log2);
+
+  // Commit point: target data and hashes are already durable but not referenced until this metadata replacement.
+  ReplaceMetadata(replacement.get());
+  allocated_units.release();
+
+  DetachDataBlocks(file_->quota(), old_data_blocks, encrypted, block_size_log2);
+  FreeDataUnits(file_->quota(), old_data_units);
+}

--- a/tests/file_layout_accessor_tests.cpp
+++ b/tests/file_layout_accessor_tests.cpp
@@ -74,8 +74,8 @@ class FileLayoutAccessorFixture : public MetadataBlockFixture {
   }
 
   TestFile CreateFile(std::string_view name, uint32_t file_size) {
-    return CreateFile(name, FileLayout::Calculate(file_size, static_cast<uint8_t>(name.size()),
-                                                  quota->block_size_log2(), FileLayoutMode::MinimumForGrow));
+    return CreateFile(name,
+                      FileLayout::Calculate(0, file_size, static_cast<uint8_t>(name.size()), quota->block_size_log2()));
   }
 
   void StoreDataBlock(uint32_t area_block_number, std::span<const std::byte> data) {

--- a/tests/file_layout_tests.cpp
+++ b/tests/file_layout_tests.cpp
@@ -24,11 +24,12 @@ constexpr uint32_t kLargeBlockSize = uint32_t{1} << (kBlockSizeLog2 + log2_size(
 constexpr uint32_t kClusterSize = uint32_t{1} << (kBlockSizeLog2 + log2_size(BlockType::Cluster));
 
 FileLayout Minimum(uint32_t file_size, uint8_t filename_length = kDefaultTestFilenameLength) {
-  return FileLayout::Calculate(file_size, filename_length, kBlockSizeLog2, FileLayoutMode::MinimumForGrow);
+  return FileLayout::Calculate(0, file_size, filename_length, kBlockSizeLog2);
 }
 
 FileLayout Maximum(uint32_t file_size, uint8_t filename_length = kDefaultTestFilenameLength) {
-  return FileLayout::Calculate(file_size, filename_length, kBlockSizeLog2, FileLayoutMode::MaximumForShrink);
+  return FileLayout::Calculate(file_size, file_size, filename_length, kBlockSizeLog2,
+                               FileLayoutCategory::ClusterMetadataBlocks);
 }
 }  // namespace
 
@@ -150,6 +151,33 @@ TEST_CASE("File layout maximum shrink keeps the largest valid category") {
   CHECK(Maximum(kClusterSize).category == FileLayoutCategory::ClusterMetadataBlocks);
 }
 
+TEST_CASE("File layout resize shrink does not raise the current category") {
+  const auto blocks_shrink =
+      FileLayout::Calculate(2 * kSingleBlockSize + 8, kSingleBlockSize + 4, kDefaultTestFilenameLength, kBlockSizeLog2,
+                            FileLayoutCategory::Blocks);
+  CHECK(blocks_shrink.category == FileLayoutCategory::Blocks);
+  CHECK(blocks_shrink.size_on_disk == 2 * kSingleBlockSize);
+
+  const auto large_blocks_shrink =
+      FileLayout::Calculate(5 * kSingleBlockSize + 1, kSingleBlockSize, kDefaultTestFilenameLength, kBlockSizeLog2,
+                            FileLayoutCategory::LargeBlocks);
+  CHECK(large_blocks_shrink.category == FileLayoutCategory::Blocks);
+  CHECK(large_blocks_shrink.size_on_disk == kSingleBlockSize);
+}
+
+TEST_CASE("File layout resize grow does not lower the current category") {
+  const auto large_blocks_grow =
+      FileLayout::Calculate(kSingleBlockSize + 1, kSingleBlockSize + 4, kDefaultTestFilenameLength, kBlockSizeLog2,
+                            FileLayoutCategory::LargeBlocks);
+  CHECK(large_blocks_grow.category == FileLayoutCategory::LargeBlocks);
+  CHECK(large_blocks_grow.size_on_disk == kLargeBlockSize);
+
+  const auto clusters_grow = FileLayout::Calculate(kLargeBlockSize + 1, kLargeBlockSize + 4, kDefaultTestFilenameLength,
+                                                   kBlockSizeLog2, FileLayoutCategory::Clusters);
+  CHECK(clusters_grow.category == FileLayoutCategory::Clusters);
+  CHECK(clusters_grow.size_on_disk == kClusterSize);
+}
+
 TEST_CASE("File layout rounds metadata log2 sizes") {
   auto empty = Minimum(0);
   CHECK(empty.metadata_log2_size == 6);
@@ -168,8 +196,7 @@ TEST_CASE("File layout throws when requested size exceeds max file size") {
   CHECK(max_spec.file_size == max_file_size);
   CHECK(max_spec.size_on_disk == max_file_size);
 
-  CHECK_THROWS_MATCHES(FileLayout::Calculate(max_file_size + 1, kDefaultTestFilenameLength, kBlockSizeLog2,
-                                             FileLayoutMode::MinimumForGrow),
+  CHECK_THROWS_MATCHES(FileLayout::Calculate(0, max_file_size + 1, kDefaultTestFilenameLength, kBlockSizeLog2),
                        WfsException, Catch::Matchers::Predicate<WfsException>([](const WfsException& e) {
                          return e.error() == WfsError::kFileTooLarge;
                        }));

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -73,12 +73,17 @@ class FileResizeFixture : public MetadataBlockFixture {
   }
 
   TestFile CreateFile(std::string_view name, uint32_t file_size) {
-    return CreateFile(name, FileLayout::Calculate(file_size, static_cast<uint8_t>(name.size()),
-                                                  quota->block_size_log2(), FileLayoutMode::MinimumForGrow));
+    return CreateFile(name,
+                      FileLayout::Calculate(0, file_size, static_cast<uint8_t>(name.size()), quota->block_size_log2()));
   }
 
   TestFile CreateDataUnitFile(std::string_view name, uint32_t file_size, std::span<const std::byte> data) {
-    auto test_file = CreateFile(name, file_size);
+    return CreateDataUnitFile(
+        name, FileLayout::Calculate(0, file_size, static_cast<uint8_t>(name.size()), quota->block_size_log2()), data);
+  }
+
+  TestFile CreateDataUnitFile(std::string_view name, const FileLayout& layout, std::span<const std::byte> data) {
+    auto test_file = CreateFile(name, layout);
     AssignDataBlocks(test_file.metadata);
     StoreFileData(test_file.metadata, data);
     return test_file;
@@ -255,8 +260,8 @@ TEST_CASE_METHOD(FileResizeFixture,
   std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
 
   const auto old_metadata_log2_size = test_file.metadata->metadata_log2_size.value();
-  const auto target_layout = FileLayout::Calculate(kGrownSize, static_cast<uint8_t>(kTestFilename.size()),
-                                                   quota->block_size_log2(), FileLayoutMode::MinimumForGrow);
+  const auto target_layout =
+      FileLayout::Calculate(0, kGrownSize, static_cast<uint8_t>(kTestFilename.size()), quota->block_size_log2());
   REQUIRE(target_layout.category == FileLayoutCategory::Inline);
   REQUIRE(target_layout.metadata_log2_size > old_metadata_log2_size);
 
@@ -288,8 +293,8 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline file to zero",
   auto test_file = CreateFile(kTestFilename, kInitialSize);
   REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
 
-  const auto target_layout = FileLayout::Calculate(0, static_cast<uint8_t>(kTestFilename.size()),
-                                                   quota->block_size_log2(), FileLayoutMode::MaximumForShrink);
+  const auto target_layout =
+      FileLayout::Calculate(kInitialSize, 0, static_cast<uint8_t>(kTestFilename.size()), quota->block_size_log2());
 
   test_file.file->Resize(0);
 
@@ -301,14 +306,27 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline file to zero",
   CHECK(InlinePayload(metadata).empty());
 }
 
-TEST_CASE_METHOD(FileResizeFixture, "File resize throws for unsupported layout transitions", "[file-resize][unit]") {
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows inline file into category 1", "[file-resize][unit]") {
   auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+  const auto target_size = FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size())) + 1;
+  const auto free_blocks_before = FreeBlocksCount();
 
-  CHECK_THROWS_AS(test_file.file->Resize(FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size())) + 1),
-                  std::logic_error);
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{kInitialData.begin(), kInitialData.end()};
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == quota->block_size());
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_blocks_before - 1);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 
-TEST_CASE_METHOD(FileResizeFixture, "File resize throws when shrink target category differs", "[file-resize][unit]") {
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize shrink keeps current category when target still fits",
+                 "[file-resize][unit]") {
   const auto block_size = static_cast<uint32_t>(quota->block_size());
   const auto initial_size = 2 * block_size + 8;
   const auto target_size = block_size + 4;
@@ -316,8 +334,172 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize throws when shrink target categ
   auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
   REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
 
-  CHECK_THROWS_AS(test_file.file->Resize(target_size), std::logic_error);
-  CHECK(test_file.file->Size() == initial_size);
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 2 * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 1 into inline data", "[file-resize][unit]") {
+  const auto initial_size = FileLayout::InlineCapacity(static_cast<uint8_t>(kTestFilename.size())) + 1;
+  const auto target_size = static_cast<uint32_t>(kInitialData.size());
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == target_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CHECK(FreeBlocksCount() == free_blocks_before + 1);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 1 into category 2", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto initial_size = 5 * block_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == large_block_blocks_count * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + 5 - large_block_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 2 into category 1", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto initial_size = 5 * block_size + 1;
+  const auto target_size = block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + large_block_blocks_count - 1);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 2 without lowering category", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto large_block_size = large_block_blocks_count * block_size;
+  const auto initial_size = block_size + 1;
+  const auto target_size = block_size + 4;
+  const auto layout = FileLayout::Calculate(initial_size, initial_size, static_cast<uint8_t>(kTestFilename.size()),
+                                            quota->block_size_log2(), FileLayoutCategory::LargeBlocks);
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, layout, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == large_block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 2 into category 3", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto large_block_size = large_block_blocks_count * block_size;
+  const auto initial_size = 5 * large_block_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == cluster_blocks_count * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  CHECK(FreeBlocksCount() == free_blocks_before + 5 * large_block_blocks_count - cluster_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 3 into category 2", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto large_block_size = large_block_blocks_count * block_size;
+  const auto initial_size = 5 * large_block_size + 1;
+  const auto target_size = large_block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == large_block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + cluster_blocks_count - large_block_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize can grow across more than one category", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto large_block_size = large_block_blocks_count * block_size;
+  const auto initial_size = block_size + 4;
+  const auto target_size = 5 * large_block_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == cluster_blocks_count * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  CHECK(FreeBlocksCount() == free_blocks_before + 2 - cluster_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 
 TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 1 by one block", "[file-resize][unit]") {


### PR DESCRIPTION
Summary:
- add resize transitions between inline, blocks, large-blocks, and cluster layouts
- copy preserved file data into the replacement layout before the metadata commit point
- route resize target selection through FileLayout::Calculate with the current category, so shrink never raises and grow never lowers the category unless a transition is required
- use the inline category as the default current category so tests/fixtures and future create-with-initial-size flows can calculate layout as growth from zero
- cover inline/data-unit transitions, adjacent transitions, skipped-category growth, and resize layout selection

Follow-up:
- open layout accessor invalidation after category-changing resize is intentionally split into its own planned PR in wfs-file-resize-plan.md

Tests:
- ./build/local-tests/tests/wfslib_tests "File layout*","[file-resize][unit]"
- ctest --test-dir build/local-tests --output-on-failure