### PR TITLE
Use current layout accessors for file devices

### DIFF
--- a/include/wfslib/file.h
+++ b/include/wfslib/file.h
@@ -47,8 +47,8 @@ class File : public Entry, public std::enable_shared_from_this<File> {
 
    private:
     size_t size() const;
+
     std::shared_ptr<File> file_;
-    std::shared_ptr<LayoutAccessor> layout_;
     boost::iostreams::stream_offset pos_;
   };
 
@@ -62,5 +62,5 @@ class File : public Entry, public std::enable_shared_from_this<File> {
   // TODO: We may have cyclic reference here if we do cache in area.
   std::shared_ptr<QuotaArea> quota_;
 
-  static std::shared_ptr<LayoutAccessor> CreateLayoutAccessor(std::shared_ptr<File> file);
+  static std::unique_ptr<LayoutAccessor> CreateLayoutAccessor(std::shared_ptr<File> file);
 };

--- a/src/file.cpp
+++ b/src/file.cpp
@@ -29,8 +29,7 @@ void File::Resize(size_t new_size) {
   FileResizer(shared_from_this()).Resize(new_size);
 }
 
-File::file_device::file_device(const std::shared_ptr<File>& file)
-    : file_(file), layout_(CreateLayoutAccessor(file)), pos_(0) {}
+File::file_device::file_device(const std::shared_ptr<File>& file) : file_(file), pos_(0) {}
 
 size_t File::file_device::size() const {
   return file_->metadata()->file_size.value();
@@ -43,10 +42,11 @@ std::streamsize File::file_device::read(char_type* s, std::streamsize n) {
   if (result <= 0)
     return -1;  // EOF
 
+  auto layout = CreateLayoutAccessor(file_);
   std::streamsize to_read = result;
   while (to_read > 0) {
     size_t read =
-        layout_->Read(reinterpret_cast<std::byte*>(s), static_cast<size_t>(pos_), static_cast<size_t>(to_read));
+        layout->Read(reinterpret_cast<std::byte*>(s), static_cast<size_t>(pos_), static_cast<size_t>(to_read));
     s += read;
     pos_ += read;
     to_read -= read;
@@ -54,11 +54,12 @@ std::streamsize File::file_device::read(char_type* s, std::streamsize n) {
   return result;
 }
 std::streamsize File::file_device::write(const char_type* s, std::streamsize n) {
+  auto layout = CreateLayoutAccessor(file_);
   std::streamsize amt = static_cast<std::streamsize>(size() - pos_);
   if (n > amt) {
     // Try to resize file
     // TODO: This call can't stay like that when we will need to allocate new pages and even change the category
-    layout_->Resize(std::min(static_cast<size_t>(file_->SizeOnDisk()), static_cast<size_t>(pos_ + n)));
+    layout->Resize(std::min(static_cast<size_t>(file_->SizeOnDisk()), static_cast<size_t>(pos_ + n)));
     amt = static_cast<std::streamsize>(size() - pos_);
   }
   std::streamsize result = std::min(n, amt);
@@ -69,7 +70,7 @@ std::streamsize File::file_device::write(const char_type* s, std::streamsize n) 
   std::streamsize to_write = result;
   while (to_write > 0) {
     size_t wrote =
-        layout_->Write(reinterpret_cast<const std::byte*>(s), static_cast<size_t>(pos_), static_cast<size_t>(to_write));
+        layout->Write(reinterpret_cast<const std::byte*>(s), static_cast<size_t>(pos_), static_cast<size_t>(to_write));
     s += wrote;
     pos_ += wrote;
     to_write -= wrote;

--- a/src/file_layout_accessor.cpp
+++ b/src/file_layout_accessor.cpp
@@ -317,18 +317,18 @@ class File::ClusterMetadataBlocksLayoutAccessor : public File::ClustersLayoutAcc
   size_t ClustersInBlock() const { return ClustersPerMetadataBlock(); }
 };
 
-std::shared_ptr<File::LayoutAccessor> File::CreateLayoutAccessor(std::shared_ptr<File> file) {
+std::unique_ptr<File::LayoutAccessor> File::CreateLayoutAccessor(std::shared_ptr<File> file) {
   switch (FileLayout::CategoryFromValue(file->metadata()->size_category.value())) {
     case FileLayoutCategory::Inline:
-      return std::make_shared<InlineLayoutAccessor>(file);
+      return std::make_unique<InlineLayoutAccessor>(file);
     case FileLayoutCategory::Blocks:
-      return std::make_shared<BlocksLayoutAccessor>(file);
+      return std::make_unique<BlocksLayoutAccessor>(file);
     case FileLayoutCategory::LargeBlocks:
-      return std::make_shared<LargeBlocksLayoutAccessor>(file);
+      return std::make_unique<LargeBlocksLayoutAccessor>(file);
     case FileLayoutCategory::Clusters:
-      return std::make_shared<ClustersLayoutAccessor>(file);
+      return std::make_unique<ClustersLayoutAccessor>(file);
     case FileLayoutCategory::ClusterMetadataBlocks:
-      return std::make_shared<ClusterMetadataBlocksLayoutAccessor>(file);
+      return std::make_unique<ClusterMetadataBlocksLayoutAccessor>(file);
   }
   throw std::runtime_error("Unexpected file category");  // TODO: Change to WfsError
 }

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -576,6 +576,56 @@ TEST_CASE_METHOD(FileResizeFixture,
   CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 
+TEST_CASE_METHOD(FileResizeFixture, "File device uses current layout after category growth", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 5 * block_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  {
+    File::file_device writer(test_file.file);
+    test_file.file->Resize(target_size);
+    REQUIRE(StoredMetadata(kTestFilename)->size_category.value() ==
+            FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+
+    writer.seek(block_size, std::ios_base::beg);
+    const auto wrote = writer.write(reinterpret_cast<const char*>(kPostResizeData.data()),
+                                    static_cast<std::streamsize>(kPostResizeData.size()));
+    REQUIRE(wrote == static_cast<std::streamsize>(kPostResizeData.size()));
+  }
+
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  std::ranges::copy(kPostResizeData, expected.begin() + block_size);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device uses current layout after category shrink", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 5 * block_size + 1;
+  const auto target_size = block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+
+  {
+    File::file_device writer(test_file.file);
+    test_file.file->Resize(target_size);
+    REQUIRE(StoredMetadata(kTestFilename)->size_category.value() ==
+            FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+    const auto wrote = writer.write(reinterpret_cast<const char*>(kPostResizeData.data()),
+                                    static_cast<std::streamsize>(kPostResizeData.size()));
+    REQUIRE(wrote == static_cast<std::streamsize>(kPostResizeData.size()));
+  }
+
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  std::ranges::copy(kPostResizeData, expected.begin());
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
 TEST_CASE_METHOD(FileResizeFixture,
                  "File resize failure keeps dirty writes in blocks that would be dropped",
                  "[file-resize][unit]") {


### PR DESCRIPTION
Summary:
- stop caching a concrete LayoutAccessor inside File::file_device
- create the current layout accessor for each read/write operation so post-resize I/O uses the current metadata category
- make CreateLayoutAccessor return std::unique_ptr to reflect short-lived exclusive ownership
- cover open file devices across category growth and shrink transitions

Tests:
- ./build/local-tests/tests/wfslib_tests "[file-resize][unit]"
- ctest --test-dir build/local-tests --output-on-failure