### PR TITLE
Integrate file resize into writes

### DIFF
--- a/src/file.cpp
+++ b/src/file.cpp
@@ -8,6 +8,7 @@
 #include "file.h"
 
 #include <algorithm>
+#include <limits>
 
 #include "block.h"
 #include "file_layout_accessor.h"
@@ -36,7 +37,11 @@ size_t File::file_device::size() const {
 }
 
 std::streamsize File::file_device::read(char_type* s, std::streamsize n) {
-  std::streamsize amt = static_cast<std::streamsize>(size() - pos_);
+  const auto file_size = static_cast<boost::iostreams::stream_offset>(size());
+  if (pos_ < 0 || pos_ >= file_size)
+    return -1;  // EOF
+
+  std::streamsize amt = static_cast<std::streamsize>(file_size - pos_);
   std::streamsize result = std::min(n, amt);
 
   if (result <= 0)
@@ -54,19 +59,29 @@ std::streamsize File::file_device::read(char_type* s, std::streamsize n) {
   return result;
 }
 std::streamsize File::file_device::write(const char_type* s, std::streamsize n) {
-  auto layout = CreateLayoutAccessor(file_);
-  std::streamsize amt = static_cast<std::streamsize>(size() - pos_);
-  if (n > amt) {
-    // Try to resize file
-    // TODO: This call can't stay like that when we will need to allocate new pages and even change the category
-    layout->Resize(std::min(static_cast<size_t>(file_->SizeOnDisk()), static_cast<size_t>(pos_ + n)));
-    amt = static_cast<std::streamsize>(size() - pos_);
-  }
+  if (n <= 0)
+    return -1;  // Failed to write
+
+  const auto file_size = static_cast<boost::iostreams::stream_offset>(size());
+  if (pos_ < 0 || pos_ > file_size)
+    return -1;  // Seek beyond EOF is not supported.
+
+  if (n > std::numeric_limits<boost::iostreams::stream_offset>::max() - pos_)
+    throw std::ios_base::failure("bad write size");
+
+  const auto write_end = pos_ + static_cast<boost::iostreams::stream_offset>(n);
+  if (write_end > file_size)
+    file_->Resize(static_cast<size_t>(write_end));
+
+  const auto resized_file_size = static_cast<boost::iostreams::stream_offset>(size());
+  std::streamsize amt = static_cast<std::streamsize>(resized_file_size - pos_);
   std::streamsize result = std::min(n, amt);
 
   if (result <= 0)
     return -1;  // Failed to resize file
 
+  // Resize can change the layout category, so choose the accessor after metadata is updated.
+  auto layout = CreateLayoutAccessor(file_);
   std::streamsize to_write = result;
   while (to_write > 0) {
     size_t wrote =
@@ -79,6 +94,8 @@ std::streamsize File::file_device::write(const char_type* s, std::streamsize n) 
 }
 boost::iostreams::stream_offset File::file_device::seek(boost::iostreams::stream_offset off,
                                                         std::ios_base::seekdir way) {
+  const auto file_size = static_cast<boost::iostreams::stream_offset>(size());
+
   // Determine new value of pos_
   boost::iostreams::stream_offset next;
   if (way == std::ios_base::beg) {
@@ -86,13 +103,13 @@ boost::iostreams::stream_offset File::file_device::seek(boost::iostreams::stream
   } else if (way == std::ios_base::cur) {
     next = pos_ + off;
   } else if (way == std::ios_base::end) {
-    next = size() + off - 1;
+    next = file_size + off;
   } else {
     throw std::ios_base::failure("bad seek direction");
   }
 
   // Check for errors
-  if (next < 0 || next >= static_cast<boost::iostreams::stream_offset>(size()))
+  if (next < 0 || next > file_size)
     throw std::ios_base::failure("bad seek offset");
 
   pos_ = next;

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -288,6 +288,111 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize allows writing after inline gro
   CHECK(ReadFile(test_file.file, expected.size()) == expected);
 }
 
+TEST_CASE_METHOD(FileResizeFixture, "File device write appends to empty file", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, 0);
+
+  CHECK(WriteFile(test_file.file, kReplacementData, 0) == kReplacementData.size());
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  const std::vector<std::byte> expected(kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(test_file.file->SizeOnDisk() == expected.size());
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device write appends to non-empty file", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  CHECK(WriteFile(test_file.file, kReplacementData, kInitialData.size()) == kReplacementData.size());
+
+  std::vector<std::byte> expected(kInitialData.begin(), kInitialData.end());
+  expected.insert(expected.end(), kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device write overwrites without resizing", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  CHECK(WriteFile(test_file.file, kReplacementData, 0) == kReplacementData.size());
+
+  const std::vector<std::byte> expected(kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device write grows within current category", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = block_size + static_cast<uint32_t>(kInitialData.size());
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  CHECK(WriteFile(test_file.file, kReplacementData, initial_size) == kReplacementData.size());
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.insert(expected.end(), kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(test_file.file->SizeOnDisk() == 2 * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+  CHECK(FreeBlocksCount() == free_blocks_before);
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device write grows across categories", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto initial_size = 5 * block_size;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  CHECK(WriteFile(test_file.file, kReplacementData, initial_size) == kReplacementData.size());
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.insert(expected.end(), kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(test_file.file->SizeOnDisk() == large_block_blocks_count * block_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device write appends after truncate", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto initial_size = 2 * block_size + static_cast<uint32_t>(kInitialData.size());
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Blocks));
+
+  test_file.file->Resize(block_size);
+  CHECK(WriteFile(test_file.file, kReplacementData, block_size) == kReplacementData.size());
+
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + block_size};
+  expected.insert(expected.end(), kReplacementData.begin(), kReplacementData.end());
+  CHECK(test_file.file->Size() == expected.size());
+  CHECK(ReadFile(test_file.file, expected.size()) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File device seek allows EOF but rejects beyond EOF", "[file-resize][unit]") {
+  auto test_file = CreateFile(kTestFilename, static_cast<uint32_t>(kInitialData.size()));
+  std::ranges::copy(kInitialData, InlinePayload(test_file.metadata).begin());
+
+  File::file_device device(test_file.file);
+  CHECK(device.seek(0, std::ios_base::end) == static_cast<boost::iostreams::stream_offset>(kInitialData.size()));
+  CHECK(device.seek(static_cast<boost::iostreams::stream_offset>(kInitialData.size()), std::ios_base::beg) ==
+        static_cast<boost::iostreams::stream_offset>(kInitialData.size()));
+  CHECK_THROWS_AS(device.seek(1, std::ios_base::end), std::ios_base::failure);
+  CHECK_THROWS_AS(
+      device.seek(static_cast<boost::iostreams::stream_offset>(kInitialData.size() + 1), std::ios_base::beg),
+      std::ios_base::failure);
+}
+
 TEST_CASE_METHOD(FileResizeFixture, "File resize truncates inline file to zero", "[file-resize][unit]") {
   constexpr uint32_t kInitialSize = 80;
   auto test_file = CreateFile(kTestFilename, kInitialSize);


### PR DESCRIPTION
## Summary
- grow file_device writes through File::Resize before selecting a layout accessor
- allow seeking exactly to EOF for append while still rejecting seek-beyond-EOF
- add end-to-end write tests for append, overwrite, category growth, truncate-then-write, and EOF seek behavior

## Tests
- /tmp/wfslib-clang-format-venv/bin/clang-format -style=file --dry-run --Werror src/file.cpp tests/file_resize_tests.cpp
- cmake --build --preset debug-tests
- ./build/tests/tests/Debug/wfslib_tests "[file-resize]"
- ctest --preset run-debug-tests --output-on-failure