### PR TITLE
Support category 4 file resize

### DIFF
--- a/src/file_data_units.h
+++ b/src/file_data_units.h
@@ -126,6 +126,40 @@ auto MutableFileDataUnitLogicalMetadataItems(EntryMetadata* metadata, size_t cou
   return MutableEntryMetadataItems<Metadata>(metadata, count) | std::views::reverse;
 }
 
+inline auto ClusterMetadataBlockRefs(const EntryMetadata* metadata, size_t count) {
+  return EntryMetadataItems<uint32_be_t>(metadata, count) | std::views::reverse;
+}
+
+inline auto MutableClusterMetadataBlockRefs(EntryMetadata* metadata, size_t count) {
+  return MutableEntryMetadataItems<uint32_be_t>(metadata, count) | std::views::reverse;
+}
+
+inline std::span<DataBlocksClusterMetadata> MutableClusterMetadataBlockItems(
+    const std::shared_ptr<Block>& metadata_block,
+    size_t clusters_per_metadata_block) {
+  return {metadata_block->get_mutable_object<DataBlocksClusterMetadata>(sizeof(MetadataBlockHeader)),
+          clusters_per_metadata_block};
+}
+
+inline std::span<const DataBlocksClusterMetadata> ClusterMetadataBlockItems(
+    const std::shared_ptr<Block>& metadata_block,
+    size_t clusters_per_metadata_block) {
+  return {metadata_block->get_object<DataBlocksClusterMetadata>(sizeof(MetadataBlockHeader)),
+          clusters_per_metadata_block};
+}
+
+inline size_t ClusterMetadataBlockIndexForDataBlock(size_t data_block_index, uint8_t block_size_log2) {
+  const auto large_blocks_per_cluster = FileDataUnitLayoutTraits<FileLayoutCategory::Clusters>::kDataBlocksPerUnit;
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(block_size_log2);
+  return data_block_index / large_blocks_per_cluster / clusters_per_metadata_block;
+}
+
+inline size_t ClusterMetadataBlockDataBlockIndex(size_t data_block_index, uint8_t block_size_log2) {
+  const auto large_blocks_per_cluster = FileDataUnitLayoutTraits<FileLayoutCategory::Clusters>::kDataBlocksPerUnit;
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(block_size_log2);
+  return data_block_index % (large_blocks_per_cluster * clusters_per_metadata_block);
+}
+
 template <FileLayoutCategory Category, std::ranges::random_access_range Units>
 FileDataBlockLocation FileDataBlockLocationForLogicalMetadata(const std::shared_ptr<Block>& metadata_block,
                                                               Units&& units,
@@ -135,6 +169,27 @@ FileDataBlockLocation FileDataBlockLocationForLogicalMetadata(const std::shared_
   const auto unit_index = data_block_index / Traits::kDataBlocksPerUnit;
   const auto block_index = data_block_index % Traits::kDataBlocksPerUnit;
   return Traits::data_block_location_for_unit(metadata_block, std::ranges::begin(units)[unit_index], block_index);
+}
+
+inline FileDataBlockLocation ClusterMetadataBlockDataBlockLocationFor(const std::shared_ptr<Block>& metadata_block,
+                                                                      size_t data_block_index,
+                                                                      uint8_t block_size_log2) {
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(block_size_log2);
+  assert(data_block_index <
+         clusters_per_metadata_block * FileDataUnitLayoutTraits<FileLayoutCategory::Clusters>::kDataBlocksPerUnit);
+  const auto cluster_metadata = ClusterMetadataBlockItems(metadata_block, clusters_per_metadata_block);
+  return FileDataBlockLocationForLogicalMetadata<FileLayoutCategory::Clusters>(metadata_block, cluster_metadata,
+                                                                               data_block_index);
+}
+
+inline FileDataBlockLocation ClusterMetadataBlocksDataBlockLocationFor(
+    std::span<const std::shared_ptr<Block>> metadata_blocks,
+    size_t data_block_index,
+    uint8_t block_size_log2) {
+  const auto metadata_block_index = ClusterMetadataBlockIndexForDataBlock(data_block_index, block_size_log2);
+  return ClusterMetadataBlockDataBlockLocationFor(metadata_blocks[metadata_block_index],
+                                                  ClusterMetadataBlockDataBlockIndex(data_block_index, block_size_log2),
+                                                  block_size_log2);
 }
 
 template <FileLayoutCategory Category>

--- a/src/file_layout_accessor.cpp
+++ b/src/file_layout_accessor.cpp
@@ -263,39 +263,46 @@ class File::ClusterMetadataBlocksLayoutAccessor : public File::ClustersLayoutAcc
   size_t GetMetadataSize() const override { return GetMetadataItemsCount() * sizeof(uint32_be_t); }
 
   DataRef GetDataRef(size_t offset, size_t size, size_t file_size) override {
-    auto blocks_list = ClusterMetadataBlockRefs();
-    auto cluster_index = offset >> ClusterDataLog2Size();
-    int64_t block_index = cluster_index / ClustersInBlock();
-    LoadMetadataBlock(blocks_list[block_index].value());
-    return GetDataRefFromClustersList(
-        block_index * ClustersInBlock(), offset, size, file_size, current_metadata_block,
-        std::span<const DataBlocksClusterMetadata>{
-            current_metadata_block->get_object<DataBlocksClusterMetadata>(sizeof(MetadataBlockHeader)),
-            ClustersInBlock()});
+    auto block_position = BlockPositionForOffset(offset, GetDataBlockSize());
+    auto blocks_list = ::ClusterMetadataBlockRefs(file_->metadata(), GetMetadataItemsCount());
+    const auto metadata_block_index =
+        ClusterMetadataBlockIndexForDataBlock(block_position.index, file_->quota()->block_size_log2());
+    LoadMetadataBlock(blocks_list[metadata_block_index].value());
+
+    auto location = ClusterMetadataBlockDataBlockLocationFor(
+        current_metadata_block,
+        ClusterMetadataBlockDataBlockIndex(block_position.index, file_->quota()->block_size_log2()),
+        file_->quota()->block_size_log2());
+    return GetDataFromBlock(
+        {location.block_number, location.block_type, block_position.offset,
+         DataSizeForBlock(file_size, block_position.offset, GetDataBlockSize()), std::move(location.hash)},
+        block_position.offset_in_block, size);
   }
 
   std::vector<DataBlockRef> EnumerateBlocks() const override {
+    auto blocks_list = ::ClusterMetadataBlockRefs(file_->metadata(), GetMetadataItemsCount());
+    std::vector<std::shared_ptr<Block>> metadata_blocks;
+    metadata_blocks.reserve(blocks_list.size());
+    for (const auto& block_number : blocks_list)
+      metadata_blocks.push_back(throw_if_error(file_->quota()->LoadMetadataBlock(block_number.value())));
+
     std::vector<DataBlockRef> refs;
-    auto blocks_list = ClusterMetadataBlockRefs();
-    size_t cluster_list_start = 0;
-    for (const auto& block_number : blocks_list) {
-      if (cluster_list_start << ClusterDataLog2Size() >= file_->metadata()->size_on_disk.value())
-        break;
-      const auto metadata_block = throw_if_error(file_->quota()->LoadMetadataBlock(block_number.value()));
-      auto block_refs = EnumerateClusterDataBlockRefs(
-          cluster_list_start, metadata_block,
-          std::span<const DataBlocksClusterMetadata>{
-              metadata_block->get_object<DataBlocksClusterMetadata>(sizeof(MetadataBlockHeader)), ClustersInBlock()},
-          file_->metadata()->size_on_disk.value());
-      refs.insert(refs.end(), block_refs.begin(), block_refs.end());
-      cluster_list_start += ClustersInBlock();
+    const auto data_block_size = size_t{1} << GetDataBlockSize();
+    refs.reserve(div_ceil(file_->metadata()->size_on_disk.value(), data_block_size));
+    for (size_t data_block_index = 0, block_offset = 0; block_offset < file_->metadata()->size_on_disk.value();
+         ++data_block_index, block_offset += data_block_size) {
+      auto location = ClusterMetadataBlocksDataBlockLocationFor(metadata_blocks, data_block_index,
+                                                                file_->quota()->block_size_log2());
+      refs.push_back({location.block_number, location.block_type, block_offset,
+                      DataSizeForBlock(file_->metadata()->size_on_disk.value(), block_offset, GetDataBlockSize()),
+                      std::move(location.hash)});
     }
     return refs;
   }
 
   void FreeOwnedBlocks() override {
     ClustersLayoutAccessor::FreeOwnedBlocks();
-    for (const auto& block_number : ClusterMetadataBlockRefs()) {
+    for (const auto& block_number : ::ClusterMetadataBlockRefs(file_->metadata(), GetMetadataItemsCount())) {
       if (!file_->quota()->DeleteBlocks(block_number.value(), 1))
         throw WfsException(WfsError::kFreeBlocksAllocatorCorrupted);
     }
@@ -313,8 +320,6 @@ class File::ClusterMetadataBlocksLayoutAccessor : public File::ClustersLayoutAcc
       throw WfsException(WfsError::kFileMetadataCorrupted);
     current_metadata_block = std::move(*metadata_block);
   }
-
-  size_t ClustersInBlock() const { return ClustersPerMetadataBlock(); }
 };
 
 std::unique_ptr<File::LayoutAccessor> File::CreateLayoutAccessor(std::shared_ptr<File> file) {

--- a/src/file_layout_accessor.h
+++ b/src/file_layout_accessor.h
@@ -135,14 +135,6 @@ class File::LayoutAccessor {
     return MutableEntryMetadataItems<DataBlocksClusterMetadata>(file_->mutable_metadata(), GetMetadataItemsCount()) |
            std::views::reverse;
   }
-  auto ClusterMetadataBlockRefs() const {
-    return EntryMetadataItems<uint32_be_t>(file_->metadata(), GetMetadataItemsCount()) | std::views::reverse;
-  }
-  auto MutableClusterMetadataBlockRefs() const {
-    return MutableEntryMetadataItems<uint32_be_t>(file_->mutable_metadata(), GetMetadataItemsCount()) |
-           std::views::reverse;
-  }
-
   BlockPosition BlockPositionForOffset(size_t offset, size_t log2_block_size) const {
     auto [index, offset_in_block] = div_pow2(offset, log2_block_size);
     return {index, floor_pow2(offset, log2_block_size), offset_in_block};
@@ -151,10 +143,6 @@ class File::LayoutAccessor {
   size_t DataBlockLog2Size(BlockType type) const { return file_->quota()->block_size_log2() + log2_size(type); }
 
   size_t ClusterDataLog2Size() const { return DataBlockLog2Size(BlockType::Cluster); }
-
-  size_t ClustersPerMetadataBlock() const {
-    return FileLayout::ClustersPerClusterMetadataBlock(file_->quota()->block_size_log2());
-  }
 
   uint32_t DataSizeForBlock(size_t file_size, size_t block_offset, size_t log2_block_size) const {
     if (file_size <= block_offset)

--- a/src/file_resizer.cpp
+++ b/src/file_resizer.cpp
@@ -34,9 +34,6 @@ std::span<std::byte> InlinePayload(EntryMetadata* metadata) {
   return {reinterpret_cast<std::byte*>(metadata) + metadata->size(), metadata->size_on_disk.value()};
 }
 
-[[noreturn]] void ThrowResizeUnimplemented() {
-  throw std::logic_error("File resize for this layout transition is not implemented");
-}
 }  // namespace
 
 // TODO: This is a Block only because target data-block Flush writes hashes through block-backed HashRef. If resize
@@ -80,7 +77,7 @@ void FileResizer::Resize(size_t new_size) {
                                                    file_->quota()->block_size_log2(), current_category);
 
   if (target_layout.category != current_category) {
-    ResizeAcrossLayouts(target_layout);
+    ResizeViaLayoutRebuild(target_layout);
     return;
   }
 
@@ -98,10 +95,11 @@ void FileResizer::Resize(size_t new_size) {
       ResizeDataUnitLayout<FileLayoutCategory::Clusters>(target_layout);
       return;
     case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+      ResizeViaLayoutRebuild(target_layout);
+      return;
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-
-  ThrowResizeUnimplemented();
 }
 
 void FileResizer::ResizeInline(const FileLayout& target_layout) {

--- a/src/file_resizer.h
+++ b/src/file_resizer.h
@@ -33,7 +33,7 @@ class FileResizer {
 
  private:
   void ResizeInline(const FileLayout& target_layout);
-  void ResizeAcrossLayouts(const FileLayout& target_layout);
+  void ResizeViaLayoutRebuild(const FileLayout& target_layout);
   void ReplaceMetadata(EntryMetadata* metadata);
 
   template <FileLayoutCategory Category>

--- a/src/file_resizer_transitions.cpp
+++ b/src/file_resizer_transitions.cpp
@@ -35,16 +35,8 @@ struct DataUnitRef {
   uint32_t blocks_count;
 };
 
-[[noreturn]] void ThrowResizeUnimplemented() {
-  throw std::logic_error("File resize for this layout transition is not implemented");
-}
-
 FileLayoutCategory CurrentCategory(const EntryMetadata* metadata) {
   return FileLayout::CategoryFromValue(metadata->size_category.value());
-}
-
-bool IsTransitionCategory(FileLayoutCategory category) {
-  return category != FileLayoutCategory::ClusterMetadataBlocks;
 }
 
 uint32_t UsedDataBlockSize(uint32_t file_size, size_t block_offset, size_t log2_block_size) {
@@ -60,12 +52,26 @@ BlockType AllocationBlockType(FileLayoutCategory category) {
     case FileLayoutCategory::LargeBlocks:
       return BlockType::Large;
     case FileLayoutCategory::Clusters:
+    case FileLayoutCategory::ClusterMetadataBlocks:
       return BlockType::Cluster;
     case FileLayoutCategory::Inline:
-    case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
+}
+
+std::vector<std::shared_ptr<Block>> LoadClusterMetadataBlocks(const std::shared_ptr<QuotaArea>& quota,
+                                                              const EntryMetadata* metadata,
+                                                              const FileLayout& layout,
+                                                              uint8_t block_size_log2) {
+  const auto metadata_blocks_count =
+      FileLayout::MetadataItemsCount(layout.category, layout.size_on_disk, block_size_log2);
+  auto block_refs = ClusterMetadataBlockRefs(metadata, metadata_blocks_count);
+  std::vector<std::shared_ptr<Block>> blocks;
+  blocks.reserve(metadata_blocks_count);
+  for (const auto& block_ref : block_refs)
+    blocks.push_back(throw_if_error(quota->LoadMetadataBlock(block_ref.value())));
+  return blocks;
 }
 
 template <FileLayoutCategory Category>
@@ -96,9 +102,10 @@ FileLayout CurrentLayout(const EntryMetadata* metadata, uint8_t block_size_log2)
     case FileLayoutCategory::Clusters:
       return CurrentLayout<FileLayoutCategory::Clusters>(metadata, block_size_log2);
     case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+      return CurrentLayout<FileLayoutCategory::ClusterMetadataBlocks>(metadata, block_size_log2);
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
 }
 
 class AllocatedTargetDataUnits {
@@ -131,6 +138,51 @@ class AllocatedTargetDataUnits {
   bool released_{false};
 };
 
+class AllocatedTargetMetadataBlocks {
+ public:
+  AllocatedTargetMetadataBlocks(std::shared_ptr<QuotaArea> quota, const FileLayout& layout) : quota_(std::move(quota)) {
+    if (layout.category != FileLayoutCategory::ClusterMetadataBlocks)
+      return;
+
+    const auto metadata_blocks_count = FileLayout::MetadataItemsCount(layout.category, layout.size_on_disk,
+                                                                      static_cast<uint8_t>(quota_->block_size_log2()));
+    blocks_.reserve(metadata_blocks_count);
+    block_numbers_.reserve(metadata_blocks_count);
+    for (uint32_t i = 0; i < metadata_blocks_count; ++i) {
+      auto block = throw_if_error(quota_->AllocMetadataBlock());
+      std::ranges::fill(block->mutable_data(), std::byte{0});
+      block_numbers_.push_back(quota_->to_area_block_number(block->physical_block_number()));
+      blocks_.push_back(std::move(block));
+    }
+  }
+
+  ~AllocatedTargetMetadataBlocks() {
+    // Until metadata replacement succeeds, newly allocated metadata blocks are rollback state.
+    if (!released_) {
+      for (const auto& block : blocks_) {
+        quota_->DeleteBlocks(quota_->to_area_block_number(block->physical_block_number()), 1);
+        block->Detach();
+      }
+    }
+  }
+
+  const std::vector<std::shared_ptr<Block>>& blocks() const { return blocks_; }
+  const std::vector<uint32_t>& block_numbers() const { return block_numbers_; }
+
+  void Flush() const {
+    for (const auto& block : blocks_)
+      block->Flush();
+  }
+
+  void release() { released_ = true; }
+
+ private:
+  std::shared_ptr<QuotaArea> quota_;
+  std::vector<std::shared_ptr<Block>> blocks_;
+  std::vector<uint32_t> block_numbers_;
+  bool released_{false};
+};
+
 template <FileLayoutCategory Category>
 void StoreAllocatedDataUnits(EntryMetadata* metadata, std::span<const uint32_t> block_numbers) {
   using Traits = FileDataUnitLayoutTraits<Category>;
@@ -146,7 +198,9 @@ void StoreAllocatedDataUnits(EntryMetadata* metadata, std::span<const uint32_t> 
 
 void StoreAllocatedDataUnits(FileLayoutCategory category,
                              EntryMetadata* metadata,
-                             std::span<const uint32_t> block_numbers) {
+                             std::span<const uint32_t> block_numbers,
+                             const AllocatedTargetMetadataBlocks& metadata_blocks,
+                             uint8_t block_size_log2) {
   switch (category) {
     case FileLayoutCategory::Blocks:
       StoreAllocatedDataUnits<FileLayoutCategory::Blocks>(metadata, block_numbers);
@@ -159,10 +213,23 @@ void StoreAllocatedDataUnits(FileLayoutCategory category,
       return;
     case FileLayoutCategory::Inline:
       return;
-    case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+    case FileLayoutCategory::ClusterMetadataBlocks: {
+      // Category 4 has two allocation layers: entry metadata points at metadata blocks, and those metadata blocks
+      // point at the actual data clusters.
+      auto entry_refs = MutableClusterMetadataBlockRefs(metadata, metadata_blocks.block_numbers().size());
+      std::ranges::copy(metadata_blocks.block_numbers(), entry_refs.begin());
+
+      const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(block_size_log2);
+      for (size_t cluster_index = 0; cluster_index < block_numbers.size(); ++cluster_index) {
+        auto cluster_metadata = MutableClusterMetadataBlockItems(
+            metadata_blocks.blocks()[cluster_index / clusters_per_metadata_block], clusters_per_metadata_block);
+        cluster_metadata[cluster_index % clusters_per_metadata_block].block_number = block_numbers[cluster_index];
+      }
+      return;
+    }
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
 }
 
 template <FileLayoutCategory Category>
@@ -185,7 +252,28 @@ std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& 
   return refs;
 }
 
-std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& metadata_block,
+std::vector<DataBlockCacheRef> ClusterMetadataBlocksDataBlockCacheRefs(const std::shared_ptr<QuotaArea>& quota,
+                                                                       const EntryMetadata* metadata,
+                                                                       const FileLayout& layout,
+                                                                       uint8_t block_size_log2) {
+  const auto metadata_blocks = LoadClusterMetadataBlocks(quota, metadata, layout, block_size_log2);
+  const auto data_block_log2_size = FileDataBlockLog2Size<FileLayoutCategory::Clusters>(block_size_log2);
+  const auto data_blocks_count = div_ceil(layout.file_size, size_t{1} << data_block_log2_size);
+  std::vector<DataBlockCacheRef> refs;
+  refs.reserve(data_blocks_count);
+
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(layout.file_size, block_offset, data_block_log2_size);
+    auto location = ClusterMetadataBlocksDataBlockLocationFor(metadata_blocks, data_block_index, block_size_log2);
+    refs.push_back({location.block_number, location.block_type, data_size});
+  }
+
+  return refs;
+}
+
+std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<QuotaArea>& quota,
+                                                  const std::shared_ptr<Block>& metadata_block,
                                                   const EntryMetadata* metadata,
                                                   const FileLayout& layout,
                                                   uint8_t block_size_log2) {
@@ -199,9 +287,10 @@ std::vector<DataBlockCacheRef> DataBlockCacheRefs(const std::shared_ptr<Block>& 
     case FileLayoutCategory::Clusters:
       return DataBlockCacheRefs<FileLayoutCategory::Clusters>(metadata_block, metadata, layout, block_size_log2);
     case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+      return ClusterMetadataBlocksDataBlockCacheRefs(quota, metadata, layout, block_size_log2);
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
 }
 
 template <FileLayoutCategory Category>
@@ -215,7 +304,29 @@ std::vector<DataUnitRef> DataUnitRefs(const EntryMetadata* metadata, uint32_t da
          std::ranges::to<std::vector>();
 }
 
-std::vector<DataUnitRef> DataUnitRefs(const EntryMetadata* metadata, const FileLayout& layout) {
+std::vector<DataUnitRef> ClusterMetadataBlocksDataUnitRefs(const std::shared_ptr<QuotaArea>& quota,
+                                                           const EntryMetadata* metadata,
+                                                           const FileLayout& layout,
+                                                           uint8_t block_size_log2) {
+  const auto metadata_blocks = LoadClusterMetadataBlocks(quota, metadata, layout, block_size_log2);
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(block_size_log2);
+  std::vector<DataUnitRef> refs;
+  refs.reserve(layout.data_units_count);
+
+  for (size_t cluster_index = 0; cluster_index < layout.data_units_count; ++cluster_index) {
+    auto cluster_metadata = ClusterMetadataBlockItems(metadata_blocks[cluster_index / clusters_per_metadata_block],
+                                                      clusters_per_metadata_block);
+    refs.push_back({cluster_metadata[cluster_index % clusters_per_metadata_block].block_number.value(),
+                    FileDataUnitAreaBlocksCount<FileLayoutCategory::Clusters>()});
+  }
+
+  return refs;
+}
+
+std::vector<DataUnitRef> DataUnitRefs(const std::shared_ptr<QuotaArea>& quota,
+                                      const EntryMetadata* metadata,
+                                      const FileLayout& layout,
+                                      uint8_t block_size_log2) {
   switch (layout.category) {
     case FileLayoutCategory::Inline:
       return {};
@@ -226,9 +337,24 @@ std::vector<DataUnitRef> DataUnitRefs(const EntryMetadata* metadata, const FileL
     case FileLayoutCategory::Clusters:
       return DataUnitRefs<FileLayoutCategory::Clusters>(metadata, layout.data_units_count);
     case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+      return ClusterMetadataBlocksDataUnitRefs(quota, metadata, layout, block_size_log2);
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
+}
+
+std::vector<DataUnitRef> ClusterMetadataBlockUnitRefs(const EntryMetadata* metadata,
+                                                      const FileLayout& layout,
+                                                      uint8_t block_size_log2) {
+  if (layout.category != FileLayoutCategory::ClusterMetadataBlocks)
+    return {};
+
+  const auto metadata_blocks_count =
+      FileLayout::MetadataItemsCount(layout.category, layout.size_on_disk, block_size_log2);
+  auto block_refs = ClusterMetadataBlockRefs(metadata, metadata_blocks_count);
+  return block_refs |
+         std::views::transform([](const auto& block_number) { return DataUnitRef{block_number.value(), 1}; }) |
+         std::ranges::to<std::vector>();
 }
 
 void DetachDataBlocks(const std::shared_ptr<QuotaArea>& quota,
@@ -242,6 +368,13 @@ void DetachDataBlocks(const std::shared_ptr<QuotaArea>& quota,
         throw_if_error(quota->LoadDataBlock(ref.block_number, static_cast<BlockSize>(block_size_log2), ref.block_type,
                                             ref.data_size, Block::HashRef{}, encrypted, /*new_block=*/true));
     data_block->Detach();
+  }
+}
+
+void DetachMetadataBlocks(const std::shared_ptr<QuotaArea>& quota, std::span<const DataUnitRef> refs) {
+  for (const auto& ref : refs) {
+    auto metadata_block = throw_if_error(quota->LoadMetadataBlock(ref.block_number, /*new_block=*/true));
+    metadata_block->Detach();
   }
 }
 
@@ -308,9 +441,45 @@ void CopyToDataUnitLayout(SourceAccessor& source,
 }
 
 template <typename SourceAccessor>
+void CopyToClusterMetadataBlocksLayout(SourceAccessor& source,
+                                       const std::shared_ptr<QuotaArea>& quota,
+                                       const AllocatedTargetMetadataBlocks& metadata_blocks,
+                                       const FileLayout& target_layout,
+                                       size_t bytes_to_preserve,
+                                       bool encrypted,
+                                       uint8_t block_size_log2) {
+  const auto data_block_log2_size = FileDataBlockLog2Size<FileLayoutCategory::Clusters>(block_size_log2);
+  const auto data_blocks_count = div_ceil(target_layout.file_size, size_t{1} << data_block_log2_size);
+
+  for (const auto data_block_index : std::views::iota(size_t{0}, data_blocks_count)) {
+    const auto block_offset = data_block_index << data_block_log2_size;
+    const auto data_size = UsedDataBlockSize(target_layout.file_size, block_offset, data_block_log2_size);
+    auto location =
+        ClusterMetadataBlocksDataBlockLocationFor(metadata_blocks.blocks(), data_block_index, block_size_log2);
+    auto data_block =
+        throw_if_error(quota->LoadDataBlock(location.block_number, static_cast<BlockSize>(block_size_log2),
+                                            location.block_type, data_size, std::move(location.hash), encrypted,
+                                            /*new_block=*/true));
+
+    auto data = data_block->mutable_data();
+    std::ranges::fill(data, std::byte{0});
+    if (block_offset < bytes_to_preserve) {
+      const auto bytes_to_copy = std::min<size_t>(data_size, bytes_to_preserve - block_offset);
+      ReadExact(source, data.data(), block_offset, bytes_to_copy);
+    }
+
+    data_block->Flush();
+    data_block->Detach();
+  }
+
+  metadata_blocks.Flush();
+}
+
+template <typename SourceAccessor>
 void CopyToTargetLayout(SourceAccessor& source,
                         const std::shared_ptr<QuotaArea>& quota,
                         EntryMetadataReplacement& replacement,
+                        const AllocatedTargetMetadataBlocks& metadata_blocks,
                         const FileLayout& target_layout,
                         size_t bytes_to_preserve,
                         bool encrypted,
@@ -332,37 +501,47 @@ void CopyToTargetLayout(SourceAccessor& source,
                                                          encrypted, block_size_log2);
       return;
     case FileLayoutCategory::ClusterMetadataBlocks:
-      break;
+      CopyToClusterMetadataBlocksLayout(source, quota, metadata_blocks, target_layout, bytes_to_preserve, encrypted,
+                                        block_size_log2);
+      return;
+    default:
+      throw std::logic_error("Unexpected file resize layout state");
   }
-  ThrowResizeUnimplemented();
 }
 }  // namespace
 
-void FileResizer::ResizeAcrossLayouts(const FileLayout& target_layout) {
+void FileResizer::ResizeViaLayoutRebuild(const FileLayout& target_layout) {
   const auto* metadata = file_->metadata();
   const auto old_layout = CurrentLayout(metadata, file_->quota()->block_size_log2());
-  if (!IsTransitionCategory(old_layout.category) || !IsTransitionCategory(target_layout.category))
-    ThrowResizeUnimplemented();
 
   const auto block_size_log2 = file_->quota()->block_size_log2();
   const auto encrypted = !(metadata->flags.value() & EntryMetadata::UNENCRYPTED_FILE);
   const auto bytes_to_preserve = std::min(old_layout.file_size, target_layout.file_size);
+  // Category 4 uses this path even for same-category resize because the two-level metadata makes in-place mutation
+  // considerably riskier. Rebuilding keeps the commit point the same as cross-category resize.
   auto source = File::CreateLayoutAccessor(file_);
 
-  const auto old_data_blocks = DataBlockCacheRefs(file_->metadata_block(), metadata, old_layout, block_size_log2);
-  const auto old_data_units = DataUnitRefs(metadata, old_layout);
+  const auto old_data_blocks =
+      DataBlockCacheRefs(file_->quota(), file_->metadata_block(), metadata, old_layout, block_size_log2);
+  const auto old_data_units = DataUnitRefs(file_->quota(), metadata, old_layout, block_size_log2);
+  const auto old_metadata_blocks = ClusterMetadataBlockUnitRefs(metadata, old_layout, block_size_log2);
 
   EntryMetadataReplacement replacement(metadata, target_layout);
   AllocatedTargetDataUnits allocated_units(file_->quota(), target_layout);
-  StoreAllocatedDataUnits(target_layout.category, replacement.get(), allocated_units.block_numbers());
+  AllocatedTargetMetadataBlocks allocated_metadata_blocks(file_->quota(), target_layout);
+  StoreAllocatedDataUnits(target_layout.category, replacement.get(), allocated_units.block_numbers(),
+                          allocated_metadata_blocks, block_size_log2);
 
-  CopyToTargetLayout(*source, file_->quota(), replacement, target_layout, bytes_to_preserve, encrypted,
-                     block_size_log2);
+  CopyToTargetLayout(*source, file_->quota(), replacement, allocated_metadata_blocks, target_layout, bytes_to_preserve,
+                     encrypted, block_size_log2);
 
   // Commit point: target data and hashes are already durable but not referenced until this metadata replacement.
   ReplaceMetadata(replacement.get());
   allocated_units.release();
+  allocated_metadata_blocks.release();
 
   DetachDataBlocks(file_->quota(), old_data_blocks, encrypted, block_size_log2);
+  DetachMetadataBlocks(file_->quota(), old_metadata_blocks);
   FreeDataUnits(file_->quota(), old_data_units);
+  FreeDataUnits(file_->quota(), old_metadata_blocks);
 }

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -49,7 +49,7 @@ class FileResizeFixture : public MetadataBlockFixture {
   std::shared_ptr<Block> directory_block = *quota->AllocMetadataBlock();
   std::shared_ptr<DirectoryMap> directory_map = std::make_shared<DirectoryMap>(quota, directory_block);
 
-  FileResizeFixture() { directory_map->Init(); }
+  FileResizeFixture() : MetadataBlockFixture(20000) { directory_map->Init(); }
 
   TestFile CreateFile(std::string_view name, const FileLayout& layout) {
     std::vector<std::byte> metadata_storage(size_t{1} << layout.metadata_log2_size, std::byte{0});
@@ -123,12 +123,18 @@ class FileResizeFixture : public MetadataBlockFixture {
         return BlockType::Single;
       case FileLayoutCategory::LargeBlocks:
       case FileLayoutCategory::Clusters:
+      case FileLayoutCategory::ClusterMetadataBlocks:
         return BlockType::Large;
       case FileLayoutCategory::Inline:
-      case FileLayoutCategory::ClusterMetadataBlocks:
         break;
     }
     throw std::logic_error("Unexpected test file layout category");
+  }
+
+  static std::span<DataBlocksClusterMetadata> ClusterMetadataItems(const std::shared_ptr<Block>& metadata_block,
+                                                                   size_t clusters_per_metadata_block) {
+    return {metadata_block->get_mutable_object<DataBlocksClusterMetadata>(sizeof(MetadataBlockHeader)),
+            clusters_per_metadata_block};
   }
 
   template <typename T>
@@ -143,6 +149,12 @@ class FileResizeFixture : public MetadataBlockFixture {
     const auto category = Category(metadata);
     const auto metadata_items_count =
         FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), quota->block_size_log2());
+
+    if (category == FileLayoutCategory::ClusterMetadataBlocks) {
+      AssignClusterMetadataBlocks(metadata, metadata_items_count);
+      return;
+    }
+
     auto allocated_blocks = quota->AllocDataBlocks(metadata_items_count, AllocationBlockType(category));
     REQUIRE(allocated_blocks.has_value());
 
@@ -179,6 +191,11 @@ class FileResizeFixture : public MetadataBlockFixture {
       return;
     }
 
+    if (category == FileLayoutCategory::ClusterMetadataBlocks) {
+      StoreClusterMetadataBlockFileData(metadata, data, data_block_size);
+      return;
+    }
+
     constexpr size_t kLargeBlocksPerCluster = size_t{1} << log2_size(BlockType::Cluster) >> log2_size(BlockType::Large);
     auto cluster_refs = AlignedMetadataItems<DataBlocksClusterMetadata>(
         metadata, FileLayout::MetadataItemsCount(category, metadata->size_on_disk.value(), quota->block_size_log2()));
@@ -187,6 +204,54 @@ class FileResizeFixture : public MetadataBlockFixture {
       const auto large_block_index = i % kLargeBlocksPerCluster;
       const auto chunk_size = std::min(data_block_size, data.size() - offset);
       const auto cluster_block_number = cluster_refs[cluster_refs.size() - cluster_index - 1].block_number.value();
+      StoreDataBlock(cluster_block_number + static_cast<uint32_t>(large_block_index << log2_size(BlockType::Large)),
+                     data.subspan(offset, chunk_size));
+    }
+  }
+
+  void AssignClusterMetadataBlocks(EntryMetadata* metadata, size_t metadata_blocks_count) {
+    auto metadata_block_refs = AlignedMetadataItems<uint32_be_t>(metadata, metadata_blocks_count);
+    std::vector<std::shared_ptr<Block>> metadata_blocks;
+    metadata_blocks.reserve(metadata_blocks_count);
+    for (size_t i = 0; i < metadata_blocks_count; ++i) {
+      auto metadata_block = quota->AllocMetadataBlock();
+      REQUIRE(metadata_block.has_value());
+      metadata_block_refs[metadata_blocks_count - i - 1] =
+          quota->to_area_block_number((*metadata_block)->physical_block_number());
+      metadata_blocks.push_back(std::move(*metadata_block));
+    }
+
+    const auto clusters_count = FileLayout::DataUnitsCount(FileLayoutCategory::ClusterMetadataBlocks,
+                                                           metadata->size_on_disk.value(), quota->block_size_log2());
+    auto allocated_clusters = quota->AllocDataBlocks(clusters_count, BlockType::Cluster);
+    REQUIRE(allocated_clusters.has_value());
+
+    const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(quota->block_size_log2());
+    for (size_t i = 0; i < allocated_clusters->size(); ++i) {
+      auto cluster_refs =
+          ClusterMetadataItems(metadata_blocks[i / clusters_per_metadata_block], clusters_per_metadata_block);
+      cluster_refs[i % clusters_per_metadata_block].block_number = (*allocated_clusters)[i];
+    }
+  }
+
+  void StoreClusterMetadataBlockFileData(EntryMetadata* metadata,
+                                         std::span<const std::byte> data,
+                                         size_t data_block_size) {
+    constexpr size_t kLargeBlocksPerCluster = size_t{1} << log2_size(BlockType::Cluster) >> log2_size(BlockType::Large);
+    const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(quota->block_size_log2());
+    auto metadata_block_refs = AlignedMetadataItems<uint32_be_t>(
+        metadata, FileLayout::MetadataItemsCount(FileLayoutCategory::ClusterMetadataBlocks,
+                                                 metadata->size_on_disk.value(), quota->block_size_log2()));
+    for (size_t i = 0, offset = 0; offset < data.size(); ++i, offset += data_block_size) {
+      const auto cluster_index = i / kLargeBlocksPerCluster;
+      const auto metadata_block_index = cluster_index / clusters_per_metadata_block;
+      const auto cluster_index_in_metadata_block = cluster_index % clusters_per_metadata_block;
+      const auto large_block_index = i % kLargeBlocksPerCluster;
+      const auto metadata_block_number = metadata_block_refs[metadata_block_refs.size() - metadata_block_index - 1];
+      auto metadata_block = throw_if_error(quota->LoadMetadataBlock(metadata_block_number.value()));
+      auto cluster_refs = ClusterMetadataItems(metadata_block, clusters_per_metadata_block);
+      const auto cluster_block_number = cluster_refs[cluster_index_in_metadata_block].block_number.value();
+      const auto chunk_size = std::min(data_block_size, data.size() - offset);
       StoreDataBlock(cluster_block_number + static_cast<uint32_t>(large_block_index << log2_size(BlockType::Large)),
                      data.subspan(offset, chunk_size));
     }
@@ -580,6 +645,109 @@ TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 3 into categor
   CHECK(test_file.file->SizeOnDisk() == large_block_size);
   CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::LargeBlocks));
   CHECK(FreeBlocksCount() == free_blocks_before + cluster_blocks_count - large_block_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 3 into category 4", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto cluster_size = cluster_blocks_count * block_size;
+  const auto initial_size = 4 * cluster_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 5 * cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before + 4 * cluster_blocks_count - 5 * cluster_blocks_count - 1);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize shrinks category 4 into category 3", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto large_block_blocks_count = uint32_t{1} << log2_size(BlockType::Large);
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto large_block_size = large_block_blocks_count * block_size;
+  const auto cluster_size = cluster_blocks_count * block_size;
+  const auto initial_size = 4 * cluster_size + 1;
+  const auto target_size = large_block_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() ==
+          FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = std::vector<std::byte>{initial_data.begin(), initial_data.begin() + target_size};
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Clusters));
+  CHECK(FreeBlocksCount() == free_blocks_before + 5 * cluster_blocks_count + 1 - cluster_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture, "File resize grows category 4 within category", "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto cluster_size = cluster_blocks_count * block_size;
+  const auto initial_size = 5 * cluster_size + 4;
+  const auto target_size = 6 * cluster_size + 4;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() ==
+          FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == 7 * cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  CHECK(FreeBlocksCount() == free_blocks_before - cluster_blocks_count);
+  CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize grows category 4 into a second cluster metadata block",
+                 "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto cluster_size = cluster_blocks_count * block_size;
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(quota->block_size_log2());
+  const auto initial_size = clusters_per_metadata_block * cluster_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() ==
+          FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  REQUIRE(FileLayout::MetadataItemsCount(FileLayoutCategory::ClusterMetadataBlocks,
+                                         test_file.metadata->size_on_disk.value(), quota->block_size_log2()) == 1);
+  const auto free_blocks_before = FreeBlocksCount();
+
+  test_file.file->Resize(target_size);
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  auto expected = initial_data;
+  expected.resize(target_size, std::byte{0});
+  CHECK(test_file.file->Size() == target_size);
+  CHECK(test_file.file->SizeOnDisk() == (clusters_per_metadata_block + 1) * cluster_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  CHECK(FileLayout::MetadataItemsCount(FileLayoutCategory::ClusterMetadataBlocks, metadata->size_on_disk.value(),
+                                       quota->block_size_log2()) == 2);
+  CHECK(FreeBlocksCount() == free_blocks_before - cluster_blocks_count - 1);
   CHECK(ReadFile(test_file.file, target_size) == expected);
 }
 

--- a/tests/utils/test_fixtures.h
+++ b/tests/utils/test_fixtures.h
@@ -16,11 +16,14 @@
 
 class MetadataBlockFixture {
  public:
+  explicit MetadataBlockFixture(uint32_t blocks_count = 10000)
+      : test_device(std::make_shared<TestBlocksDevice>(blocks_count)) {}
+
   std::shared_ptr<TestBlock> LoadMetadataBlock(uint32_t physical_block_number, bool new_block = true) {
     return TestBlock::LoadMetadataBlock(test_device, physical_block_number, new_block);
   }
 
-  std::shared_ptr<TestBlocksDevice> test_device = std::make_shared<TestBlocksDevice>();
+  std::shared_ptr<TestBlocksDevice> test_device;
 };
 
 class FreeBlocksAllocatorFixture : public MetadataBlockFixture {


### PR DESCRIPTION
## Summary
- add category 4 resize support through the rebuild/copy commit path
- share category 4 data-block location resolution between layout accessors and resize
- allocate and populate category 4 metadata blocks and cluster references
- cover category 3 <-> category 4 transitions and same-category category 4 growth

## Tests
- cmake --build --preset debug-tests
- /tmp/wfslib-clang-format-venv/bin/clang-format --dry-run --Werror src/file_data_units.h src/file_layout_accessor.cpp src/file_layout_accessor.h src/file_resizer.cpp src/file_resizer_transitions.cpp tests/file_resize_tests.cpp tests/utils/test_fixtures.h
- ./build/tests/tests/Debug/wfslib_tests "[file-layout-accessor],[file-resize]"
- ctest --preset run-debug-tests --output-on-failure