### PR TITLE
Rollback category 4 metadata allocation on no space

### DIFF
--- a/src/file_resizer_transitions.cpp
+++ b/src/file_resizer_transitions.cpp
@@ -149,21 +149,23 @@ class AllocatedTargetMetadataBlocks {
     blocks_.reserve(metadata_blocks_count);
     block_numbers_.reserve(metadata_blocks_count);
     for (uint32_t i = 0; i < metadata_blocks_count; ++i) {
-      auto block = throw_if_error(quota_->AllocMetadataBlock());
-      std::ranges::fill(block->mutable_data(), std::byte{0});
-      block_numbers_.push_back(quota_->to_area_block_number(block->physical_block_number()));
-      blocks_.push_back(std::move(block));
+      auto block = quota_->AllocMetadataBlock();
+      if (!block.has_value()) {
+        if (block.error() == WfsError::kNoSpace)
+          Rollback();
+        throw WfsException(block.error());
+      }
+
+      std::ranges::fill((*block)->mutable_data(), std::byte{0});
+      block_numbers_.push_back(quota_->to_area_block_number((*block)->physical_block_number()));
+      blocks_.push_back(std::move(*block));
     }
   }
 
   ~AllocatedTargetMetadataBlocks() {
     // Until metadata replacement succeeds, newly allocated metadata blocks are rollback state.
-    if (!released_) {
-      for (const auto& block : blocks_) {
-        quota_->DeleteBlocks(quota_->to_area_block_number(block->physical_block_number()), 1);
-        block->Detach();
-      }
-    }
+    if (!released_)
+      Rollback();
   }
 
   const std::vector<std::shared_ptr<Block>>& blocks() const { return blocks_; }
@@ -177,6 +179,15 @@ class AllocatedTargetMetadataBlocks {
   void release() { released_ = true; }
 
  private:
+  void Rollback() {
+    for (const auto& block : blocks_) {
+      quota_->DeleteBlocks(quota_->to_area_block_number(block->physical_block_number()), 1);
+      block->Detach();
+    }
+    blocks_.clear();
+    block_numbers_.clear();
+  }
+
   std::shared_ptr<QuotaArea> quota_;
   std::vector<std::shared_ptr<Block>> blocks_;
   std::vector<uint32_t> block_numbers_;

--- a/tests/file_resize_tests.cpp
+++ b/tests/file_resize_tests.cpp
@@ -24,6 +24,7 @@
 
 #include "block.h"
 #include "directory_map.h"
+#include "errors.h"
 #include "file_layout.h"
 #include "free_blocks_allocator.h"
 #include "quota_area.h"
@@ -96,6 +97,43 @@ class FileResizeFixture : public MetadataBlockFixture {
   }
 
   uint32_t FreeBlocksCount() { return (*quota->GetFreeBlocksAllocator())->free_blocks_count(); }
+
+  std::vector<uint32_t> ExhaustFreeBlocks() {
+    std::vector<uint32_t> blocks;
+    while (true) {
+      auto block = quota->AllocMetadataBlock();
+      if (!block.has_value()) {
+        REQUIRE(block.error() == WfsError::kNoSpace);
+        return blocks;
+      }
+
+      blocks.push_back(quota->to_area_block_number((*block)->physical_block_number()));
+      (*block)->Detach();
+    }
+  }
+
+  void RestoreAlignedFreeRange(std::vector<uint32_t>& blocks, uint32_t blocks_count, uint32_t alignment) {
+    std::ranges::sort(blocks);
+
+    size_t range_begin = 0;
+    while (range_begin < blocks.size()) {
+      size_t range_end = range_begin + 1;
+      while (range_end < blocks.size() && blocks[range_end] == blocks[range_end - 1] + 1)
+        ++range_end;
+
+      const auto aligned_start = static_cast<uint32_t>((blocks[range_begin] + alignment - 1) & ~(alignment - 1));
+      if (aligned_start >= blocks[range_begin] && aligned_start + blocks_count <= blocks[range_end - 1] + 1) {
+        REQUIRE(quota->DeleteBlocks(aligned_start, blocks_count));
+        auto erase_begin = std::ranges::lower_bound(blocks, aligned_start);
+        blocks.erase(erase_begin, erase_begin + blocks_count);
+        return;
+      }
+
+      range_begin = range_end;
+    }
+
+    FAIL("Could not find an aligned drained free-block range");
+  }
 
  private:
   static FileLayoutCategory Category(const EntryMetadata* metadata) {
@@ -749,6 +787,50 @@ TEST_CASE_METHOD(FileResizeFixture,
                                        quota->block_size_log2()) == 2);
   CHECK(FreeBlocksCount() == free_blocks_before - cluster_blocks_count - 1);
   CHECK(ReadFile(test_file.file, target_size) == expected);
+}
+
+TEST_CASE_METHOD(FileResizeFixture,
+                 "File resize rolls back partial category 4 metadata block allocation on no space",
+                 "[file-resize][unit]") {
+  const auto block_size = static_cast<uint32_t>(quota->block_size());
+  const auto cluster_blocks_count = uint32_t{1} << log2_size(BlockType::Cluster);
+  const auto cluster_size = cluster_blocks_count * block_size;
+  const auto clusters_per_metadata_block = FileLayout::ClustersPerClusterMetadataBlock(quota->block_size_log2());
+  const auto initial_size = clusters_per_metadata_block * cluster_size;
+  const auto target_size = initial_size + 1;
+  auto initial_data = DataPattern(initial_size);
+  auto test_file = CreateDataUnitFile(kTestFilename, initial_size, initial_data);
+  REQUIRE(test_file.metadata->size_category.value() ==
+          FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+
+  auto drained_blocks = ExhaustFreeBlocks();
+  const auto target_layout =
+      FileLayout::Calculate(initial_size, target_size, test_file.metadata->filename_length.value(),
+                            quota->block_size_log2(), FileLayoutCategory::ClusterMetadataBlocks);
+  REQUIRE(FileLayout::MetadataItemsCount(FileLayoutCategory::ClusterMetadataBlocks, target_layout.size_on_disk,
+                                         quota->block_size_log2()) == 2);
+
+  // Leave enough space for the rebuilt data clusters and exactly one of the two target metadata blocks. This forces
+  // partial metadata-block allocation rollback.
+  const auto restored_blocks = target_layout.data_units_count * cluster_blocks_count + 1;
+  for (uint32_t i = 0; i < target_layout.data_units_count; ++i)
+    RestoreAlignedFreeRange(drained_blocks, cluster_blocks_count, cluster_blocks_count);
+  RestoreAlignedFreeRange(drained_blocks, 1, 1);
+  REQUIRE(FreeBlocksCount() == restored_blocks);
+
+  try {
+    test_file.file->Resize(target_size);
+    FAIL("Resize should fail after the first target metadata block allocation");
+  } catch (const WfsException& error) {
+    CHECK(error.error() == WfsError::kNoSpace);
+  }
+
+  auto* metadata = StoredMetadata(kTestFilename);
+  CHECK(FreeBlocksCount() == restored_blocks);
+  CHECK(test_file.file->Size() == initial_size);
+  CHECK(test_file.file->SizeOnDisk() == initial_size);
+  CHECK(metadata->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::ClusterMetadataBlocks));
+  CHECK(ReadFile(test_file.file, initial_size) == initial_data);
 }
 
 TEST_CASE_METHOD(FileResizeFixture, "File resize can grow across more than one category", "[file-resize][unit]") {


### PR DESCRIPTION
## Summary
- roll back category 4 target metadata blocks when a later metadata-block allocation runs out of space
- keep the rollback scoped to `WfsError::kNoSpace` instead of catching arbitrary exceptions
- add a regression test that forces partial category 4 metadata allocation and verifies free-block accounting and file state

## Tests
- CC=gcc-14 CXX=g++-14 cmake --preset tests
- cmake --build --preset debug-tests
- /tmp/wfslib-clang-format-venv/bin/clang-format --dry-run --Werror src/file_resizer_transitions.cpp tests/file_resize_tests.cpp
- ./build/tests/tests/Debug/wfslib_tests "[file-resize]"
- ctest --preset run-debug-tests --output-on-failure
- cmake --build --preset release-tests
- ctest --preset run-release-tests --output-on-failure

## CI
- All checks pass. The first ubuntu/gcc/release run failed during vcpkg dependency download with a GitHub 502 before project compilation; the failed job passed on rerun.