### PR TITLE
Add entry metadata builders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(${PROJECT_NAME}
     src/directory_parent_tree.cpp
     src/directory.cpp
     src/entry.cpp
+    src/entry_metadata_builder.cpp
     src/eptree_iterator.cpp
     src/eptree.cpp
     src/errors.cpp

--- a/include/wfslib/errors.h
+++ b/include/wfslib/errors.h
@@ -24,6 +24,7 @@ enum WfsError {
   kInvalidWfsVersion,
   kNoSpace,
   kFileTooLarge,
+  kInvalidEntryName,
 };
 
 class WfsException : public std::exception {

--- a/src/entry_metadata_builder.cpp
+++ b/src/entry_metadata_builder.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include "entry_metadata_builder.h"
+
+#include <algorithm>
+#include <bit>
+#include <cassert>
+#include <cctype>
+#include <cstring>
+#include <limits>
+
+#include "file_layout.h"
+#include "utils.h"
+
+namespace {
+constexpr uint8_t kMinEntryMetadataLog2Size = 6;
+[[maybe_unused]] constexpr uint8_t kMaxEntryMetadataLog2Size = 10;
+
+void ApplyNameMetadata(EntryMetadataBuilder::Metadata& metadata, const EntryMetadataBuilder::NormalizedName& name) {
+  auto* entry_metadata = metadata.get();
+  assert(entry_metadata != nullptr);
+  assert(name.key.size() == name.filename_length);
+  entry_metadata->filename_length = name.filename_length;
+
+  auto bytes = metadata.mutable_bytes();
+  assert(offsetof(EntryMetadata, case_bitmap) + name.case_bitmap.size() <= bytes.size());
+  std::memcpy(bytes.data() + offsetof(EntryMetadata, case_bitmap), name.case_bitmap.data(), name.case_bitmap.size());
+}
+
+void ApplyCommonMetadata(EntryMetadataBuilder::Metadata& metadata,
+                         const EntryMetadataBuilder::NormalizedName& name,
+                         const EntryMetadataBuilder::Attributes& attributes) {
+  metadata.get()->permissions = attributes.permissions;
+  metadata.get()->ctime = attributes.ctime;
+  metadata.get()->mtime = attributes.mtime;
+  ApplyNameMetadata(metadata, name);
+}
+}  // namespace
+
+EntryMetadataBuilder::Metadata::Metadata(uint8_t metadata_log2_size)
+    : bytes_(size_t{1} << metadata_log2_size, std::byte{0}) {
+  assert(metadata_log2_size >= kMinEntryMetadataLog2Size);
+  assert(metadata_log2_size <= kMaxEntryMetadataLog2Size);
+  get()->metadata_log2_size = metadata_log2_size;
+}
+
+EntryMetadata* EntryMetadataBuilder::Metadata::get() {
+  return reinterpret_cast<EntryMetadata*>(bytes_.data());
+}
+
+const EntryMetadata* EntryMetadataBuilder::Metadata::get() const {
+  return reinterpret_cast<const EntryMetadata*>(bytes_.data());
+}
+
+size_t EntryMetadataBuilder::Metadata::size() const {
+  return bytes_.size();
+}
+
+std::span<std::byte> EntryMetadataBuilder::Metadata::mutable_bytes() {
+  return bytes_;
+}
+
+uint8_t EntryMetadataBuilder::Log2Size(size_t metadata_size) {
+  assert(metadata_size != 0);
+  const auto log2_size =
+      static_cast<uint8_t>(std::max<size_t>(kMinEntryMetadataLog2Size, std::bit_width(metadata_size - 1)));
+  assert(log2_size <= kMaxEntryMetadataLog2Size);
+  return log2_size;
+}
+
+uint8_t EntryMetadataBuilder::BaseLog2Size(uint8_t filename_length) {
+  return Log2Size(FileLayout::BaseMetadataSize(filename_length));
+}
+
+std::expected<EntryMetadataBuilder::NormalizedName, WfsError> EntryMetadataBuilder::NormalizeName(
+    std::string_view name) {
+  if (name.empty() || name.size() > std::numeric_limits<uint8_t>::max() || name.find('/') != std::string_view::npos)
+    return std::unexpected(WfsError::kInvalidEntryName);
+
+  NormalizedName normalized{
+      .key = {},
+      .case_bitmap = std::vector<uint8_t>(div_ceil(name.size(), 8), 0),
+      .filename_length = static_cast<uint8_t>(name.size()),
+  };
+  normalized.key.reserve(name.size());
+
+  for (size_t i = 0; i < name.size(); ++i) {
+    const auto ch = static_cast<unsigned char>(name[i]);
+    const auto lower = static_cast<char>(std::tolower(ch));
+    normalized.key.push_back(lower);
+    if (static_cast<char>(ch) != lower)
+      normalized.case_bitmap[i / 8] |= static_cast<uint8_t>(1u << (i % 8));
+  }
+
+  return normalized;
+}
+
+EntryMetadataBuilder::Metadata EntryMetadataBuilder::CreateEmptyFile(const NormalizedName& name,
+                                                                     const Attributes& attributes,
+                                                                     uint8_t block_size_log2) {
+  const auto layout = FileLayout::Calculate(0, 0, name.filename_length, block_size_log2, FileLayoutCategory::Inline);
+  Metadata metadata(layout.metadata_log2_size);
+  auto* entry_metadata = metadata.get();
+  entry_metadata->flags = EntryMetadata::UNENCRYPTED_FILE;
+  entry_metadata->file_size = layout.file_size;
+  entry_metadata->size_on_disk = layout.size_on_disk;
+  entry_metadata->size_category = FileLayout::CategoryValue(layout.category);
+  ApplyCommonMetadata(metadata, name, attributes);
+  return metadata;
+}
+
+EntryMetadataBuilder::Metadata EntryMetadataBuilder::CreateDirectory(const NormalizedName& name,
+                                                                     const Attributes& attributes,
+                                                                     uint32_t directory_block_number) {
+  Metadata metadata(BaseLog2Size(name.filename_length));
+  auto* entry_metadata = metadata.get();
+  entry_metadata->flags = EntryMetadata::DIRECTORY;
+  entry_metadata->file_size = 0;
+  entry_metadata->size_on_disk = 0;
+  entry_metadata->directory_block_number = directory_block_number;
+  ApplyCommonMetadata(metadata, name, attributes);
+  return metadata;
+}

--- a/src/entry_metadata_builder.h
+++ b/src/entry_metadata_builder.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "errors.h"
+#include "structs.h"
+
+class EntryMetadataBuilder {
+ public:
+  struct NormalizedName {
+    std::string key;
+    std::vector<uint8_t> case_bitmap;
+    uint8_t filename_length;
+  };
+
+  struct Attributes {
+    Permissions permissions;
+    uint32_t ctime;
+    uint32_t mtime;
+  };
+
+  class Metadata {
+   public:
+    explicit Metadata(uint8_t metadata_log2_size);
+
+    EntryMetadata* get();
+    const EntryMetadata* get() const;
+    size_t size() const;
+    std::span<std::byte> mutable_bytes();
+
+   private:
+    std::vector<std::byte> bytes_;
+  };
+
+  static uint8_t Log2Size(size_t metadata_size);
+  static uint8_t BaseLog2Size(uint8_t filename_length);
+
+  static std::expected<NormalizedName, WfsError> NormalizeName(std::string_view name);
+
+  static Metadata CreateEmptyFile(const NormalizedName& name, const Attributes& attributes, uint8_t block_size_log2);
+  static Metadata CreateDirectory(const NormalizedName& name,
+                                  const Attributes& attributes,
+                                  uint32_t directory_block_number);
+};

--- a/src/errors.cpp
+++ b/src/errors.cpp
@@ -35,6 +35,8 @@ char const* WfsException::what() const noexcept {
       return "Not enough free space";
     case WfsError::kFileTooLarge:
       return "File too large";
+    case WfsError::kInvalidEntryName:
+      return "Invalid entry name";
   }
   return "";
 }

--- a/src/structs.cpp
+++ b/src/structs.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <boost/dynamic_bitset.hpp>
+#include <cctype>
 #include <ranges>
 
 #include "structs.h"
@@ -18,9 +19,11 @@ std::string EntryMetadata::GetCaseSensitiveName(std::string_view name) const {
   }
   boost::dynamic_bitset<uint8_t> bits(name.size());
   boost::from_block_range(reinterpret_cast<const uint8_t*>(&case_bitmap),
-                          reinterpret_cast<const uint8_t*>(&case_bitmap) + (name.size() / 8), bits);
+                          reinterpret_cast<const uint8_t*>(&case_bitmap) + div_ceil(name.size(), 8), bits);
   std::string final_name;
-  std::ranges::transform(std::ranges::iota_view(0ull, name.size()), std::back_inserter(final_name),
-                         [&](auto i) { return bits[i] ? std::toupper(name[i]) : std::tolower(name[i]); });
+  std::ranges::transform(std::ranges::iota_view(0ull, name.size()), std::back_inserter(final_name), [&](auto i) {
+    const auto ch = static_cast<unsigned char>(name[i]);
+    return static_cast<char>(bits[i] ? std::toupper(ch) : std::tolower(ch));
+  });
   return final_name;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ enable_testing()
 set(WFSLIB_BEHAVIOR_TEST_SOURCES
   block_tests.cpp
   eptree_tests.cpp
+  entry_metadata_builder_tests.cpp
   file_layout_accessor_tests.cpp
   file_layout_tests.cpp
   file_resize_tests.cpp

--- a/tests/entry_metadata_builder_tests.cpp
+++ b/tests/entry_metadata_builder_tests.cpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2026 koolkdev
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+#include <limits>
+#include <string>
+
+#include "block.h"
+#include "entry_metadata_builder.h"
+#include "file_layout.h"
+#include "utils.h"
+
+namespace {
+constexpr uint8_t kLogicalBlockSizeLog2 = static_cast<uint8_t>(log2_size(BlockSize::Logical));
+
+EntryMetadataBuilder::Attributes TestAttributes() {
+  EntryMetadataBuilder::Attributes attributes;
+  attributes.permissions.owner = 0x12345678;
+  attributes.permissions.group = 0x23456789;
+  attributes.permissions.mode = 0x3456789a;
+  attributes.ctime = 0x456789ab;
+  attributes.mtime = 0x56789abc;
+  return attributes;
+}
+
+void CheckTestAttributes(const EntryMetadata* metadata) {
+  CHECK(metadata->permissions.owner.value() == 0x12345678);
+  CHECK(metadata->permissions.group.value() == 0x23456789);
+  CHECK(metadata->permissions.mode.value() == 0x3456789a);
+  CHECK(metadata->ctime.value() == 0x456789ab);
+  CHECK(metadata->mtime.value() == 0x56789abc);
+}
+}  // namespace
+
+TEST_CASE("entry names are normalized and preserve caller casing", "[entry-metadata-builder][unit]") {
+  auto name = EntryMetadataBuilder::NormalizeName("AbCdEfGhIj");
+  REQUIRE(name.has_value());
+
+  CHECK(name->key == "abcdefghij");
+  CHECK(name->filename_length == uint8_t{10});
+  REQUIRE(name->case_bitmap.size() == 2);
+  CHECK(name->case_bitmap[0] == 0x55);
+  CHECK(name->case_bitmap[1] == 0x01);
+
+  auto metadata = EntryMetadataBuilder::CreateEmptyFile(*name, TestAttributes(), kLogicalBlockSizeLog2);
+  CHECK(metadata.get()->GetCaseSensitiveName(name->key) == "AbCdEfGhIj");
+}
+
+TEST_CASE("entry names reject invalid path components", "[entry-metadata-builder][unit]") {
+  CHECK(EntryMetadataBuilder::NormalizeName("").error() == WfsError::kInvalidEntryName);
+  CHECK(EntryMetadataBuilder::NormalizeName("with/slash").error() == WfsError::kInvalidEntryName);
+
+  const auto too_long_name = std::string(size_t{std::numeric_limits<uint8_t>::max()} + 1, 'a');
+  CHECK(EntryMetadataBuilder::NormalizeName(too_long_name).error() == WfsError::kInvalidEntryName);
+}
+
+TEST_CASE("entry names accept the maximum stored filename length", "[entry-metadata-builder][unit]") {
+  const auto max_name = std::string(std::numeric_limits<uint8_t>::max(), 'A');
+  auto name = EntryMetadataBuilder::NormalizeName(max_name);
+  REQUIRE(name.has_value());
+
+  CHECK(name->filename_length == std::numeric_limits<uint8_t>::max());
+  CHECK(name->key == std::string(std::numeric_limits<uint8_t>::max(), 'a'));
+  CHECK(name->case_bitmap.size() == div_ceil(std::numeric_limits<uint8_t>::max(), 8));
+}
+
+TEST_CASE("entry metadata log2 size rounds base metadata allocations", "[entry-metadata-builder][unit]") {
+  CHECK(EntryMetadataBuilder::BaseLog2Size(uint8_t{1}) == 6);
+  CHECK(EntryMetadataBuilder::BaseLog2Size(uint8_t{161}) == 6);
+  CHECK(EntryMetadataBuilder::BaseLog2Size(uint8_t{169}) == 7);
+}
+
+TEST_CASE("empty file entry metadata uses inline file layout", "[entry-metadata-builder][unit]") {
+  auto name = EntryMetadataBuilder::NormalizeName("ReadMe.TXT");
+  REQUIRE(name.has_value());
+
+  auto metadata = EntryMetadataBuilder::CreateEmptyFile(*name, TestAttributes(), kLogicalBlockSizeLog2);
+  const auto expected_layout =
+      FileLayout::Calculate(0, 0, name->filename_length, kLogicalBlockSizeLog2, FileLayoutCategory::Inline);
+
+  CHECK(metadata.size() == (size_t{1} << expected_layout.metadata_log2_size));
+  CHECK(metadata.get()->is_file());
+  CHECK(!metadata.get()->is_directory());
+  CHECK((metadata.get()->flags.value() & EntryMetadata::UNENCRYPTED_FILE) != 0);
+  CHECK(metadata.get()->file_size.value() == 0);
+  CHECK(metadata.get()->size_on_disk.value() == 0);
+  CHECK(metadata.get()->metadata_log2_size.value() == expected_layout.metadata_log2_size);
+  CHECK(metadata.get()->size_category.value() == FileLayout::CategoryValue(FileLayoutCategory::Inline));
+  CheckTestAttributes(metadata.get());
+  CHECK(metadata.get()->filename_length.value() == name->filename_length);
+  CHECK(metadata.get()->GetCaseSensitiveName(name->key) == "ReadMe.TXT");
+}
+
+TEST_CASE("directory entry metadata stores directory target block", "[entry-metadata-builder][unit]") {
+  auto name = EntryMetadataBuilder::NormalizeName("ChildDir");
+  REQUIRE(name.has_value());
+
+  auto metadata = EntryMetadataBuilder::CreateDirectory(*name, TestAttributes(), 0x12345);
+
+  CHECK(metadata.size() == (size_t{1} << EntryMetadataBuilder::BaseLog2Size(name->filename_length)));
+  CHECK(metadata.get()->is_directory());
+  CHECK(!metadata.get()->is_quota());
+  CHECK(metadata.get()->flags.value() == EntryMetadata::DIRECTORY);
+  CHECK(metadata.get()->file_size.value() == 0);
+  CHECK(metadata.get()->size_on_disk.value() == 0);
+  CHECK(metadata.get()->directory_block_number.value() == 0x12345);
+  CHECK(metadata.get()->metadata_log2_size.value() == EntryMetadataBuilder::BaseLog2Size(name->filename_length));
+  CheckTestAttributes(metadata.get());
+  CHECK(metadata.get()->filename_length.value() == name->filename_length);
+  CHECK(metadata.get()->GetCaseSensitiveName(name->key) == "ChildDir");
+}


### PR DESCRIPTION
## Summary

- Add an internal helper for preparing WFS directory-entry names, including lowercase keys and case bitmap generation.
- Add metadata builders for empty file entries and directory entries.
- Add an invalid entry-name error for rejected path components.
- Fix case-sensitive name restoration to read the rounded-up case-bitmap byte count.

## Validation

- `/tmp/clang-format-18/usr/lib/llvm-18/bin/clang-format -style=file --dry-run --Werror src/entry_metadata_builder.h src/entry_metadata_builder.cpp src/structs.cpp tests/entry_metadata_builder_tests.cpp include/wfslib/errors.h src/errors.cpp`
- `build/gcc14-tests/tests/Debug/wfslib_tests "[entry-metadata-builder]"`
- `ctest --test-dir build/gcc14-tests -C Debug --output-on-failure`